### PR TITLE
Use clones for all animations, fixing a bunch of underlying issues

### DIFF
--- a/navigator.js
+++ b/navigator.js
@@ -36,6 +36,7 @@ var PreviewedWindowNavigator = new Lang.Class({
 
         let heights = [0, 0.10, 0.05];
 
+        let cloneParent = this.space.cloneContainer.get_parent();
         multimap.minimaps.forEach((m, i) => {
             let h = heights[i];
             if (h === undefined)
@@ -47,7 +48,7 @@ var PreviewedWindowNavigator = new Lang.Class({
 
             if (multimap.minimaps[i - 1] === undefined)
                 return;
-            Main.uiGroup.set_child_below_sibling(
+            cloneParent.set_child_below_sibling(
                 m.space.cloneContainer,
                 multimap.minimaps[i - 1].space.cloneContainer
             );
@@ -249,13 +250,15 @@ var PreviewedWindowNavigator = new Lang.Class({
 
         let multimap = this.multimap;
         let last = multimap.minimaps[multimap.selectedIndex - 1];
-        Main.wm._previewWorkspace(last && last.space.workspace,
-                                  this.space.workspace,
-                                  () => {
-                                      Main.uiGroup.set_child_above_sibling(
-                                          this.space.cloneContainer,
-                                          multimap.minimaps[0].space.cloneContainer);
-                                  });
+        Main.wm._previewWorkspace(
+            last && last.space.workspace,
+            this.space.workspace,
+            () => {
+                let cloneParent = this.space.cloneContainer.get_parent();
+                cloneParent.set_child_above_sibling(
+                    this.space.cloneContainer,
+                    multimap.minimaps[0].space.cloneContainer);
+            });
 
         if (this.space.length === 0) {
             this.space.workspace.activate(global.get_current_time());
@@ -337,7 +340,8 @@ WindowManager.WindowManager.prototype._previewWorkspace = function(from, to, cal
     let fromSpace = Tiling.spaces.spaceOf(from) || [];
     this._fromSpace = fromSpace;
 
-    Main.uiGroup.set_child_below_sibling(
+    let cloneParent = fromSpace.cloneContainer.get_parent();
+    cloneParent.set_child_below_sibling(
         toSpace.cloneContainer,
         fromSpace.cloneContainer);
 

--- a/navigator.js
+++ b/navigator.js
@@ -256,6 +256,9 @@ WindowManager.WindowManager.prototype._previewWorkspace = function(from, to, cal
         w.clone.show();
     });
 
+    toSpace.cloneContainer.set_pivot_point(0.5, 0);
+    fromSpace.cloneContainer.set_pivot_point(0.5, 0);
+
     toSpace.cloneContainer.set_position(0, 0);
     toSpace.cloneContainer.show();
     Main.uiGroup.set_child_below_sibling(
@@ -265,12 +268,16 @@ WindowManager.WindowManager.prototype._previewWorkspace = function(from, to, cal
     Tweener.addTween(fromSpace.cloneContainer,
                      { x: xDest,
                        y: yDest,
+                       scale_x: 0.9,
+                       scale_y: 0.9,
                        time: 0.25,
                        transition: 'easeInOutQuad',
                      });
     Tweener.addTween(toSpace.cloneContainer,
                      { x: 0,
                        y: 0,
+                       scale_x: 1,
+                       scale_y: 1,
                        time: 0.25,
                        transition: 'easeInOutQuad',
                        onComplete: callback,

--- a/navigator.js
+++ b/navigator.js
@@ -250,7 +250,7 @@ var PreviewedWindowNavigator = new Lang.Class({
 
         let multimap = this.multimap;
         let last = multimap.minimaps[multimap.selectedIndex - 1];
-        Main.wm._previewWorkspace(
+        switchWorkspace(
             last && last.space.workspace,
             this.space.workspace,
             () => {
@@ -290,8 +290,8 @@ var PreviewedWindowNavigator = new Lang.Class({
             let multimap = this.multimap;
             let last = multimap.minimaps[multimap.selectedIndex - 1];
             if (focus.get_workspace() !== this.space.workspace) {
-                Main.wm._previewWorkspace(last && last.space.workspace,
-                                          focus.get_workspace());
+                switchWorkspace(last && last.space.workspace,
+                                focus.get_workspace());
             }
             Tiling.ensure_viewport(Tiling.spaces.spaceOfWindow(focus), focus);
         }
@@ -306,16 +306,12 @@ function preview_navigate(display, screen, meta_window, binding) {
     tabPopup.show(binding.is_reversed(), binding.get_name(), binding.get_mask())
 }
 
-
-WindowManager.WindowManager.prototype._previewWorkspace = function(from, to, callback) {
-
+function switchWorkspace(from, to, callback) {
     TopBar.updateWorkspaceIndicator(to.index());
 
     let xDest = 0, yDest = global.screen_height;
 
     let toSpace = Tiling.spaces.spaceOf(to);
-
-    this._toSpace = toSpace;
 
     toSpace.forEach(w => {
         w.get_compositor_private().hide();
@@ -336,7 +332,6 @@ WindowManager.WindowManager.prototype._previewWorkspace = function(from, to, cal
         return;
 
     let fromSpace = Tiling.spaces.spaceOf(from) || [];
-    this._fromSpace = fromSpace;
 
     let cloneParent = fromSpace.cloneContainer.get_parent();
     cloneParent.set_child_below_sibling(

--- a/navigator.js
+++ b/navigator.js
@@ -256,8 +256,11 @@ WindowManager.WindowManager.prototype._previewWorkspace = function(from, to, cal
         w.clone.show();
     });
 
-    toSpace.cloneContainer.set_position(-xDest, global.screen_height);
+    toSpace.cloneContainer.set_position(0, 0);
     toSpace.cloneContainer.show();
+    Main.uiGroup.set_child_below_sibling(
+        toSpace.cloneContainer,
+        fromSpace.cloneContainer);
 
     Tweener.addTween(fromSpace.cloneContainer,
                      { x: xDest,
@@ -265,9 +268,16 @@ WindowManager.WindowManager.prototype._previewWorkspace = function(from, to, cal
                        time: 0.25,
                        transition: 'easeInOutQuad',
                        onComplete: () => {
-                           fromSpace.cloneContainer.hide();
-                           fromSpace.cloneContainer.set_position(0, 0);
+                           Main.uiGroup.set_child_above_sibling(
+                               toSpace.cloneContainer,
+                               fromSpace.cloneContainer);
+                       },
+                       onOverwrite: () => {
+                           Main.uiGroup.set_child_above_sibling(
+                               toSpace.cloneContainer,
+                               fromSpace.cloneContainer);
                        }
+
                      });
     Tweener.addTween(toSpace.cloneContainer,
                      { x: 0,

--- a/navigator.js
+++ b/navigator.js
@@ -11,12 +11,14 @@ const Main = imports.ui.main;
 const Clutter = imports.gi.Clutter;
 const Tweener = imports.ui.tweener;
 
+var TopBar = Extension.imports.topbar;
 const Minimap = Extension.imports.minimap;
 const Tiling = Extension.imports.tiling;
 const utils = Extension.imports.utils;
 const debug = utils.debug;
 
 const scale = 0.90;
+var navigating = false;
 
 var PreviewedWindowNavigator = new Lang.Class({
     Name: 'PreviewedWindowNavigator',
@@ -24,6 +26,8 @@ var PreviewedWindowNavigator = new Lang.Class({
 
     _init: function() {
         this.parent();
+
+        navigating = true;
 
         let multimap = new Minimap.MultiMap(true);
         this.multimap = multimap;
@@ -290,6 +294,8 @@ var PreviewedWindowNavigator = new Lang.Class({
             }
             Tiling.ensure_viewport(Tiling.spaces.spaceOfWindow(focus), focus);
         }
+
+        navigating = false;
         this.parent();
     }
 });

--- a/navigator.js
+++ b/navigator.js
@@ -23,8 +23,21 @@ var PreviewedWindowNavigator = new Lang.Class({
     _init: function() {
         this.parent();
 
-        this._switcherList = new Minimap.MultiMap(true);
+        let multimap = new Minimap.MultiMap(true);
+        this.multimap = multimap;
+        this._switcherList = multimap;
         this.space = this._switcherList.getSelected().space;
+
+        multimap.minimaps.forEach((m, i) => {
+            m.space.cloneContainer.set_position(0, 0);
+            if (multimap.minimaps[i + 1] === undefined)
+                return;
+            Main.uiGroup.set_child_above_sibling(
+                m.space.cloneContainer,
+                multimap.minimaps[i + 1].space.cloneContainer
+            )
+        })
+
 
         this._switcherList.onlyShowSelected();
 

--- a/navigator.js
+++ b/navigator.js
@@ -17,7 +17,7 @@ const Tiling = Extension.imports.tiling;
 const utils = Extension.imports.utils;
 const debug = utils.debug;
 
-const scale = 0.90;
+var scale = 0.9;
 var navigating = false;
 
 var PreviewedWindowNavigator = new Lang.Class({

--- a/navigator.js
+++ b/navigator.js
@@ -43,9 +43,8 @@ var PreviewedWindowNavigator = new Lang.Class({
                 h = 0;
             m.space.cloneContainer.set_position(0, global.screen_height*h);
 
-            m.space.cloneContainer.scale_y = scale;
-            m.space.cloneContainer.scale_x = scale;
-
+            m.space.cloneContainer.scale_y = scale + (1 - i)*0.01;
+            m.space.cloneContainer.scale_x = scale + (1 - i)*0.01;
             if (multimap.minimaps[i - 1] === undefined)
                 return;
             cloneParent.set_child_below_sibling(
@@ -163,8 +162,8 @@ var PreviewedWindowNavigator = new Lang.Class({
             Tweener.addTween(actor,
                              {y: h*global.screen_height,
                               time: 0.25,
-                              scale_x: scale,
-                              scale_y: scale,
+                              scale_x: scale + (to - i)*0.01,
+                              scale_y: scale + (to - i)*0.01,
                               transition: 'easeInOutQuad',
                              });
 

--- a/navigator.js
+++ b/navigator.js
@@ -267,17 +267,6 @@ WindowManager.WindowManager.prototype._previewWorkspace = function(from, to, cal
                        y: yDest,
                        time: 0.25,
                        transition: 'easeInOutQuad',
-                       onComplete: () => {
-                           Main.uiGroup.set_child_above_sibling(
-                               toSpace.cloneContainer,
-                               fromSpace.cloneContainer);
-                       },
-                       onOverwrite: () => {
-                           Main.uiGroup.set_child_above_sibling(
-                               toSpace.cloneContainer,
-                               fromSpace.cloneContainer);
-                       }
-
                      });
     Tweener.addTween(toSpace.cloneContainer,
                      { x: 0,

--- a/navigator.js
+++ b/navigator.js
@@ -4,7 +4,6 @@
 
 const Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.org'];
 const SwitcherPopup = imports.ui.switcherPopup;
-const WindowManager = imports.ui.windowManager;
 const Lang = imports.lang;
 const Meta = imports.gi.Meta;
 const Main = imports.ui.main;

--- a/navigator.js
+++ b/navigator.js
@@ -268,7 +268,6 @@ var PreviewedWindowNavigator = new Lang.Class({
         }
         // Finish workspace preview _after_ activate, that way the new animation
         // triggered by activate gets killed immediately
-        Main.wm._previewWorkspaceDone();
         this.parent(timestamp);
     },
 
@@ -285,7 +284,6 @@ var PreviewedWindowNavigator = new Lang.Class({
         if (Main.panel.statusArea.appMenu)
             Main.panel.statusArea.appMenu.container.show();
         debug('#preview', 'onDestroy', this.was_accepted);
-        Main.wm._previewWorkspaceDone();
         if(!this.was_accepted) {
             debug('#preview', 'Abort', global.display.focus_window.title);
             let focus = global.display.focus_window;
@@ -358,43 +356,4 @@ WindowManager.WindowManager.prototype._previewWorkspace = function(from, to, cal
                        time: 0.25,
                        transition: 'easeInOutQuad',
                      });
-}
-
-WindowManager.WindowManager.prototype._previewWorkspaceDone = function() {
-    let switchData = this._switchData;
-    if (!switchData)
-        return;
-    this._switchData = null;
-
-    for (let i = 0; i < switchData.windows.length; i++) {
-        let w = switchData.windows[i];
-        if (w.window.is_destroyed()) // Window gone
-            continue;
-        if (w.window.get_parent() == switchData.outGroup) {
-            w.window.reparent(w.parent);
-            w.window.hide();
-        } else
-            w.window.reparent(w.parent);
-    }
-    Tweener.removeTweens(switchData.inGroup);
-    Tweener.removeTweens(switchData.outGroup);
-    switchData.inGroup.destroy();
-    switchData.outGroup.destroy();
-    switchData.movingWindowBin.destroy();
-
-    if (this._movingWindow)
-        this._movingWindow = null;
-
-    let fromSpace = this.fromSpace, toSpace = this._toSpace;
-    if (fromSpace && toSpace) {
-        fromSpace.forEach(w => {
-            w.get_compositor_private().hide();
-            w.clone.show();
-        });
-        toSpace.forEach(w => {
-            w.get_compositor_private().hide();
-            w.clone.show();
-        });
-    }
-
 }

--- a/scratch.js
+++ b/scratch.js
@@ -67,7 +67,6 @@ function hide() {
     let windows = getScratchWindows();
     windows.map(function(meta_window) {
         meta_window.minimize();
-        meta_window.get_compositor_private().hide();
     });
 }
 

--- a/scratch.js
+++ b/scratch.js
@@ -56,6 +56,7 @@ function show() {
         . map(function(meta_window) {
             meta_window.unminimize();
             meta_window.make_above();
+            meta_window.get_compositor_private().show();
     });
     windows[0].activate(global.get_current_time());
 }
@@ -64,6 +65,7 @@ function hide() {
     let windows = getScratchWindows();
     windows.map(function(meta_window) {
         meta_window.minimize();
+        meta_window.get_compositor_private().hide();
     });
 }
 

--- a/scratch.js
+++ b/scratch.js
@@ -10,6 +10,8 @@ function makeScratch(metaWindow) {
     metaWindow[float] = true;
     metaWindow.make_above();
     metaWindow.stick();
+    metaWindow.clone.hide();
+    metaWindow.get_compositor_private().show();
 }
 
 function unmakeScratch(metaWindow) {

--- a/tiling.js
+++ b/tiling.js
@@ -165,6 +165,9 @@ function disable () {
     }
 }
 
+let colors = [ 'grey', 'cyan', 'red', 'blue', 'green', 'yellow', 'orange'];
+let color = 0;
+let containers = [];
 class Space extends Array {
     constructor (workspace) {
         super(0);
@@ -178,7 +181,11 @@ class Space extends Array {
 
         let cloneContainer = new Clutter.Actor();
         this.cloneContainer = cloneContainer;
+
+
         cloneContainer.set_size(global.screen_width, global.screen_height);
+        cloneContainer.background_color = Clutter.color_from_string(colors[color])[1];
+        color = (color + 1) % colors.length;
         Main.uiGroup.add_actor(cloneContainer);
         Main.uiGroup.set_child_above_sibling(
             cloneContainer,

--- a/tiling.js
+++ b/tiling.js
@@ -680,18 +680,10 @@ let showWrapper = utils.dynamic_function_ref('showHandler', Me);
   stack, not the mru, when auto choosing focus after closing a window.
  */
 function fixStack(space, around) {
-    let topLeft = space.topOfLeftStack();
-    let topRight = space.topOfRightStack();
-
-    let left = topLeft !== null ? space.indexOf(topLeft) : 0;
-    let right = topRight !== null ? space.indexOf(topRight) : space.length - 1;
-
-    let max = Math.max(Math.abs(around - left), Math.abs(around - right));
-
     let mru = global.display.get_tab_list(Meta.TabList.NORMAL,
                                           space.workspace);
 
-    for (let i=max; i >= 0; i--) {
+    for (let i=1; i >= 0; i--) {
         let leftWindow = space[around - i];
         let rightWindow = space[around + i];
         mru.filter(w => w === leftWindow || w === rightWindow)

--- a/tiling.js
+++ b/tiling.js
@@ -491,8 +491,6 @@ function setInitialPosition(actor, existing) {
 
         let space = spaces.spaceOfWindow(metaWindow);
         space.cloneContainer.add_actor(metaWindow.clone);
-        metaWindow.clone.hide();
-
     } else {
         signalId && metaWindow.disconnect(signalId);
     }

--- a/tiling.js
+++ b/tiling.js
@@ -20,6 +20,7 @@ let preferences = Extension.imports.convenience.getSettings();
 var window_gap = preferences.get_int('window-gap');
 // Top/bottom margin
 var margin_tb = preferences.get_int('vertical-margin');
+margin_tb = 6
 // left/right margin
 var margin_lr = preferences.get_int('horizontal-margin');
 margin_lr = 30
@@ -194,6 +195,10 @@ class Space extends Array {
 
         cloneContainer.set_size(global.screen_width, global.screen_height);
         cloneContainer.background_color = Clutter.color_from_string(colors[color])[1];
+        cloneContainer.set_clip(0, 0, global.screen_width, global.screen_height)
+        cloneContainer.set_pivot_point(0.5, 0);
+        cloneContainer.background_color =
+            Clutter.color_from_string(colors[color])[1];
         color = (color + 1) % colors.length;
         Main.uiGroup.add_actor(cloneContainer);
         Main.uiGroup.set_child_above_sibling(

--- a/tiling.js
+++ b/tiling.js
@@ -4,6 +4,7 @@ const Tweener = imports.ui.tweener;
 const Lang = imports.lang;
 const Meta = imports.gi.Meta;
 const Clutter = imports.gi.Clutter;
+const St = imports.gi.St;
 const Main = imports.ui.main;
 const Shell = imports.gi.Shell;
 const Gio = imports.gi.Gio;
@@ -179,23 +180,24 @@ class Space extends Array {
             workspace.connect("window-removed",
                               utils.dynamic_function_ref("remove_handler", Me));
 
-        let cloneContainer = new Clutter.Actor();
+        let cloneContainer = new St.Widget();
         this.cloneContainer = cloneContainer;
 
-
         cloneContainer.set_size(global.screen_width, global.screen_height);
-        cloneContainer.background_color = Clutter.color_from_string(colors[color])[1];
-        cloneContainer.set_clip(0, 0, global.screen_width, global.screen_height)
+        cloneContainer.set_clip(0, 0, global.screen_width, global.screen_height);
         cloneContainer.set_pivot_point(0.5, 0);
-        cloneContainer.background_color =
-            Clutter.color_from_string(colors[color])[1];
-        color = (color + 1) % colors.length;
 
         let cloneParent = backgroundGroup;
         cloneParent.add_actor(cloneContainer);
         cloneParent.set_child_above_sibling(
             cloneContainer,
             cloneParent.first_child);
+
+        cloneContainer.set_style(
+            `background: ${colors[color]};
+             box-shadow: 0px -10px 10px 10px black;
+             border-radius: 2px 2px 0 0;`);
+        color = (color + 1) % colors.length;
 
         this.selectedWindow = null;
         this.moving = false;

--- a/tiling.js
+++ b/tiling.js
@@ -3,6 +3,7 @@ const GLib = imports.gi.GLib;
 const Tweener = imports.ui.tweener;
 const Lang = imports.lang;
 const Meta = imports.gi.Meta;
+const Clutter = imports.gi.Clutter;
 const Main = imports.ui.main;
 const Shell = imports.gi.Shell;
 const Gio = imports.gi.Gio;
@@ -21,10 +22,11 @@ var window_gap = preferences.get_int('window-gap');
 var margin_tb = preferences.get_int('vertical-margin');
 // left/right margin
 var margin_lr = preferences.get_int('horizontal-margin');
+margin_lr = 30
 // How much the stack should protrude from the side
 var stack_margin = 75;
 // Minimum margin
-var minimumMargin = 15;
+var minimumMargin = 30;
 
 // FIXME: stackoverlay have to be imported after certain global variables have been
 //        defined atm. Preferences should be accessed as preferences and globals
@@ -37,16 +39,24 @@ var primary = Main.layoutManager.primaryMonitor;
 var panelBox = Main.layoutManager.panelBox;
 
 // Symbol to retrieve the focus handler id
-var signals, oldSpaces;
+var signals, oldSpaces, backgroundGroup;
 function init() {
     signals = Symbol();
     oldSpaces = new Map();
+
+    backgroundGroup = global.window_group.first_child;
 
     global.screen[signals] = [];
     global.display[signals] = [];
 }
 
 function enable() {
+
+    backgroundGroup.reparent(Main.uiGroup);
+    Main.uiGroup.set_child_below_sibling(
+        backgroundGroup,
+        Main.uiGroup.first_child);
+
     global.screen[signals].push(
         global.screen.connect(
             'notify::n-workspaces',
@@ -74,6 +84,14 @@ function enable() {
     let isDuringGnomeShellStartup = Main.actionMode === Shell.ActionMode.NONE;
 
     function initWorkspaces() {
+
+        global.display.get_tab_list(Meta.TabList.NORMAL_ALL, null)
+            .forEach(metaWindow => {
+                let actor = metaWindow.get_compositor_private();
+                let clone = new Clutter.Clone({source: actor});
+                metaWindow.clone = clone;
+            });
+
         // Hook up existing workspaces
         for (let i=0; i < global.screen.n_workspaces; i++) {
             let workspace = global.screen.get_workspace_by_index(i)
@@ -107,11 +125,18 @@ function enable() {
 }
 
 function disable () {
+    backgroundGroup.reparent(global.window_group);
+    global.window_group.set_child_below_sibling(
+        backgroundGroup,
+        global.window_group.first_child);
+
     global.display.get_tab_list(Meta.TabList.NORMAL_ALL, null)
         .forEach(metaWindow => {
             let actor = metaWindow.get_compositor_private();
             actor.set_scale(1, 1);
             actor.set_pivot_point(0, 0);
+
+            metaWindow.clone.destroy();
 
             if (metaWindow[signals]) {
                 metaWindow[signals].forEach(id => metaWindow.disconnect(id));
@@ -142,6 +167,15 @@ class Space extends Array {
         this.removeSignal =
             workspace.connect("window-removed",
                               utils.dynamic_function_ref("remove_handler", Me));
+
+        let cloneContainer = new Clutter.Actor();
+        this.cloneContainer = cloneContainer;
+        cloneContainer.set_size(global.screen_width, global.screen_height);
+        Main.uiGroup.add_actor(cloneContainer);
+        Main.uiGroup.set_child_above_sibling(
+            cloneContainer,
+            Main.uiGroup.first_child);
+
         this.selectedWindow = null;
         this.moving = false;
         this.leftStack = 0; // not implemented
@@ -236,6 +270,7 @@ var spaces = (function () {
         let workspace = space.workspace;
         workspace.disconnect(space.addSignal);
         workspace.disconnect(space.removeSignal);
+        space.cloneContainer.destroy();
         this.delete(workspace);
     };
 
@@ -254,12 +289,16 @@ var spaces = (function () {
                 metaWindow.connect('notify::minimized', minimizeWrapper)
             ];
         }
+
+        let actor = metaWindow.get_compositor_private();
+        let clone = new Clutter.Clone({source: actor});
+        metaWindow.clone = clone;
+
         // Only run setInitialPosition on inserted windows
         if (!metaWindow[isInserted])
             return;
         delete metaWindow[isInserted];
         debug('window-created', metaWindow.title);
-        let actor = metaWindow.get_compositor_private();
         let signal = Symbol();
         metaWindow[signal] = actor.connect('show',
                                            Lang.bind({metaWindow, signal}, setInitialPosition));
@@ -295,7 +334,9 @@ function move(meta_window, {x, y,
                             onComplete,
                             onStart,
                             delay,
-                            transition}) {
+                            transition,
+                            stack
+                           }) {
 
     onComplete = onComplete || (() => {});
     onStart = onStart || (() => {});
@@ -305,13 +346,18 @@ function move(meta_window, {x, y,
     let actor = meta_window.get_compositor_private();
     let buffer = meta_window.get_buffer_rect();
     let frame = meta_window.get_frame_rect();
+    let clone = meta_window.clone;
+
+    clone.show();
+    actor.hide();
+
     // Set monitor offset
     y += primary.y;
     x += primary.x;
     let x_offset = frame.x - buffer.x;
     let y_offset = frame.y - buffer.y;
     meta_window.destinationX = x;
-    Tweener.addTween(actor, {x: x - x_offset
+    Tweener.addTween(clone, {x: x - x_offset
                              , y: y - y_offset
                              , time: 0.25 - delay
                              , delay: delay
@@ -323,6 +369,11 @@ function move(meta_window, {x, y,
                                  meta_window.destinationX = undefined;
                                  if(meta_window.get_compositor_private()) {
                                      // If the actor is gone, the window is in process of closing
+                                     if (!stack) {
+                                         actor.set_position(clone.x, clone.y);
+                                         clone.hide();
+                                         actor.show();
+                                     }
                                      meta_window.move_frame(true, x, y);
                                      onComplete();
                                  }
@@ -409,6 +460,11 @@ function setInitialPosition(actor, existing) {
         signalId && metaWindow.get_compositor_private().disconnect(signalId);
         metaWindow[signals].push(
             metaWindow.connect('size-changed', sizeHandler));
+
+        let space = spaces.spaceOfWindow(metaWindow);
+        space.cloneContainer.add_actor(metaWindow.clone);
+        metaWindow.clone.hide();
+
     } else {
         signalId && metaWindow.disconnect(signalId);
     }
@@ -417,7 +473,6 @@ function setInitialPosition(actor, existing) {
 // Move @meta_window to x, y and propagate the change in @space
 function move_to(space, meta_window, { x, y, delay, transition,
                                          onComplete, onStart }) {
-    // Register @meta_window as moving on @space
     move(meta_window, { x, y
                         , onComplete
                         , onStart
@@ -436,64 +491,20 @@ const DIRECTION = {
     Right: 1
 }
 
-/**
-   Put @space[@index] on the stack in @direction.
- */
-function stackWindow(space, index, direction) {
-    let metaWindow = space[index];
-    metaWindow._isStacked = true; // use isStacked function to check
-
-    let x, y = primary.y + panelBox.height + margin_tb;
-
-    let actor = metaWindow.get_compositor_private();
-    let buffer = metaWindow.get_buffer_rect();
-    let frame = metaWindow.get_frame_rect();
-
-
-    let x_offset = frame.x - buffer.x;
-    let y_offset = frame.y - buffer.y;
-
-    var max_height = primary.height - panelBox.height - margin_tb*2;
-    // Height to use when scaled down at the sides
-    var scaled_height = max_height*0.95;
-    var scaled_y_offset = (max_height - scaled_height)/2;
-
-    let scale = scaled_height/frame.height;
-    // Center the actor properly
-    y += scaled_y_offset;
-
-    if (direction === DIRECTION.Right) {
-        x = primary.x + primary.width - stack_margin;
-        actor.set_pivot_point(0, y_offset/buffer.height);
-    } else { // Left
-        x = primary.x + stack_margin - frame.width;
-        actor.set_pivot_point(1, y_offset/buffer.height);
-    }
-
-    metaWindow.destinationX = x;
-    Tweener.addTween(actor, {x: x - x_offset
-                             , y: y - y_offset
-                             , time: 0.25
-                             , scale_x: scale
-                             , scale_y: scale
-                             , transition: 'easeInOutQuad'
-                             , onComplete: () => {
-                                 metaWindow.destinationX = undefined;
-                                 if(metaWindow.get_compositor_private()) {
-                                     // If the actor is gone, the window is in
-                                     // process of closing
-                                     metaWindow.move_frame(true, x, y);
-                                 }
-                             }
-                            });
-}
-
 function ensure_viewport(space, meta_window, force) {
     if (space.moving == meta_window && !force) {
         debug('already moving', meta_window.title);
         return;
     }
     debug('Moving', meta_window.title);
+
+
+    if (isStacked(meta_window)) {
+        let actor = meta_window.get_compositor_private();
+        let clone = meta_window.clone;
+        actor.set_position(clone.x, clone.y);
+        actor.show();
+    }
 
     meta_window._isStacked = false;
 
@@ -649,22 +660,28 @@ function propogate_forward(space, n, x, gap) {
         return;
     }
     let meta_window = space[n];
+    let frame = meta_window.get_frame_rect();
+    gap = gap || window_gap;
 
+    let stack = false;
     // Check if we should start stacking windows
     if (x > primary.width - stack_margin) {
-        for (let i=n; i<space.length; i++) {
-            stackWindow(space, i, DIRECTION.Right);
-        }
-        StackOverlay.rightOverlay.setTarget(meta_window);
-        return;
+        stack = true;
+        meta_window._isStacked = true;
+    } else {
+        meta_window._isStacked = false;
     }
-    meta_window._isStacked = false;
 
-    gap = gap || window_gap;
     let actor = meta_window.get_compositor_private();
     if (actor) {
         // Anchor scaling/animation on the left edge for windows positioned to the right,
-        move(meta_window, { x, y: panelBox.height + margin_tb });
+
+        move(meta_window, { x,
+                            y: meta_window.fullscreen ?
+                            0 :
+                            panelBox.height + margin_tb,
+                            stack
+                          });
         propogate_forward(space, n+1, x+meta_window.get_frame_rect().width + gap, gap);
     } else {
         // If the window doesn't have an actor we should just skip it
@@ -679,23 +696,27 @@ function propogate_backward(space, n, x, gap) {
         return;
     }
     let meta_window = space[n];
+    let frame = meta_window.get_frame_rect();
+    gap = gap || window_gap;
 
     // Check if we should start stacking windows
+    let stack = false;
     if (x < stack_margin) {
-        for (let i=n; i>=0; i--) {
-            stackWindow(space, i, DIRECTION.Left);
-        }
-        StackOverlay.leftOverlay.setTarget(meta_window);
-        return;
+        stack = true;
+        meta_window._isStacked = true;
+    } else {
+        meta_window._isStacked = false;
     }
-    meta_window._isStacked = false;
 
-    gap = gap || window_gap;
     let actor = meta_window.get_compositor_private();
     if (actor) {
         x = x - meta_window.get_frame_rect().width
         // Anchor on the right edge for windows positioned to the left.
-        move(meta_window, { x, y: panelBox.height + margin_tb });
+        move(meta_window, { x, y: meta_window.fullscreen ?
+                            0 :
+                            panelBox.height + margin_tb,
+                            stack
+                          });
         propogate_backward(space, n-1, x - gap, gap);
     } else {
         // If the window doesn't have an actor we should just skip it
@@ -838,6 +859,8 @@ function remove_handler(workspace, meta_window) {
         return
     space.splice(removed_i, 1)
 
+    space.cloneContainer.remove_actor(meta_window.clone);
+
     if (space.selectedWindow === meta_window) {
         // Window closed or moved when other workspace is active so no new focus
         // has been assigned in this workspace.
@@ -925,6 +948,7 @@ function add_all_from_workspace(workspace, windows = []) {
         if(space.indexOf(meta_window) < 0 && add_filter(meta_window, true)) {
             // Using add_handler is unreliable since it interacts with focus.
             space.push(meta_window);
+            space.cloneContainer.add_actor(meta_window.clone);
         }
     })
 

--- a/tiling.js
+++ b/tiling.js
@@ -53,12 +53,6 @@ function init() {
 }
 
 function enable() {
-
-    backgroundGroup.reparent(Main.uiGroup);
-    Main.uiGroup.set_child_below_sibling(
-        backgroundGroup,
-        Main.uiGroup.first_child);
-
     global.screen[signals].push(
         global.screen.connect(
             'notify::n-workspaces',
@@ -140,11 +134,6 @@ function enable() {
 }
 
 function disable () {
-    backgroundGroup.reparent(global.window_group);
-    global.window_group.set_child_below_sibling(
-        backgroundGroup,
-        global.window_group.first_child);
-
     global.display.get_tab_list(Meta.TabList.NORMAL_ALL, null)
         .forEach(metaWindow => {
             let actor = metaWindow.get_compositor_private();
@@ -201,10 +190,12 @@ class Space extends Array {
         cloneContainer.background_color =
             Clutter.color_from_string(colors[color])[1];
         color = (color + 1) % colors.length;
-        Main.uiGroup.add_actor(cloneContainer);
-        Main.uiGroup.set_child_above_sibling(
+
+        let cloneParent = backgroundGroup;
+        cloneParent.add_actor(cloneContainer);
+        cloneParent.set_child_above_sibling(
             cloneContainer,
-            Main.uiGroup.first_child);
+            cloneParent.first_child);
 
         this.selectedWindow = null;
         this.moving = false;
@@ -656,7 +647,6 @@ function minimizeHandler(metaWindow) {
     debug('minimized', metaWindow.title);
     if (metaWindow.minimized) {
         Scratch.makeScratch(metaWindow);
-        metaWindow.get_compositor_private().hide();
     }
 }
 let minimizeWrapper = utils.dynamic_function_ref('minimizeHandler', Me);

--- a/tiling.js
+++ b/tiling.js
@@ -166,8 +166,15 @@ function disable () {
     }
 }
 
-let colors = [ 'grey', 'green', 'yellow', 'orange', 'cyan', 'blue', 'red'];
-let color = 0;
+// From https://developer.gnome.org/hig-book/unstable/design-color.html.en
+let colors = [
+    '#EAE8E3', '#BAB5AB', '#807D74', '#565248', '#C5D2C8', '#83A67F', '#5D7555',
+    '#445632', '#E0B6AF', '#C1665A', '#884631', '#663822', '#ADA7C8', '#887FA3',
+    '#625B81', '#494066', '#9DB8D2', '#7590AE', '#4B6983', '#314E6C', '#EFE0CD',
+    '#E0C39E', '#B39169', '#826647', '#DF421E', '#990000', '#EED680', '#D1940C',
+    '#46A046', '#267726', '#ffffff', '#000000'
+];
+let color = 1;
 let containers = [];
 class Space extends Array {
     constructor (workspace) {
@@ -197,7 +204,7 @@ class Space extends Array {
             `background: ${colors[color]};
              box-shadow: 0px -10px 10px 10px black;
              border-radius: 2px 2px 0 0;`);
-        color = (color + 1) % colors.length;
+        color = (color + 9) % colors.length;
 
         this.selectedWindow = null;
         this.moving = false;

--- a/tiling.js
+++ b/tiling.js
@@ -665,6 +665,9 @@ function showHandler(actor) {
     let metaWindow = actor.meta_window;
     let onActive = metaWindow.get_workspace() === global.screen.get_active_workspace();
 
+    if (Scratch.isScratchWindow(metaWindow))
+        return;
+
     if (metaWindow.clone.visible || ! onActive || Navigator.navigating) {
         actor.hide();
         metaWindow.clone.show();

--- a/tiling.js
+++ b/tiling.js
@@ -13,6 +13,7 @@ const debug = utils.debug;
 var Minimap = Extension.imports.minimap;
 var Scratch = Extension.imports.scratch;
 var TopBar = Extension.imports.topbar;
+var Navigator = Extension.imports.navigator;
 var Me = Extension.imports.tiling;
 
 let preferences = Extension.imports.convenience.getSettings();
@@ -175,7 +176,7 @@ function disable () {
     }
 }
 
-let colors = [ 'grey', 'cyan', 'red', 'blue', 'green', 'yellow', 'orange'];
+let colors = [ 'grey', 'green', 'yellow', 'orange', 'cyan', 'blue', 'red'];
 let color = 0;
 let containers = [];
 class Space extends Array {
@@ -663,7 +664,8 @@ let minimizeWrapper = utils.dynamic_function_ref('minimizeHandler', Me);
 function showHandler(actor) {
     let metaWindow = actor.meta_window;
     let onActive = metaWindow.get_workspace() === global.screen.get_active_workspace();
-    if (metaWindow.clone.visible || ! onActive) {
+
+    if (metaWindow.clone.visible || ! onActive || Navigator.navigating) {
         actor.hide();
         metaWindow.clone.show();
     }

--- a/tiling.js
+++ b/tiling.js
@@ -66,7 +66,7 @@ function enable() {
         global.screen.connect(
             'workspace-switched',
             (screen, from, to) => {
-                Main.wm._previewWorkspace(
+                Navigator.switchWorkspace(
                     global.screen.get_workspace_by_index(from),
                     global.screen.get_workspace_by_index(to)
                 );

--- a/tiling.js
+++ b/tiling.js
@@ -67,6 +67,15 @@ function enable() {
             'workspace-removed',
             utils.dynamic_function_ref('workspaceRemoved', spaces)),
 
+        global.screen.connect(
+            'workspace-switched',
+            (screen, from, to) => {
+                let f = spaces.get(global.screen.get_workspace_by_index(from));
+                let t = spaces.get(global.screen.get_workspace_by_index(to));
+                Main.uiGroup.set_child_above_sibling(t.cloneContainer,
+                                                     f.cloneContainer);
+            }),
+
         // Reset primary when monitors change
         global.screen.connect("monitors-changed",
             function(screen) {

--- a/tiling.js
+++ b/tiling.js
@@ -650,8 +650,10 @@ let minimizeWrapper = utils.dynamic_function_ref('minimizeHandler', Me);
 
 function showHandler(actor) {
     let metaWindow = actor.meta_window;
-    if (metaWindow.clone.visible) {
+    let onActive = metaWindow.get_workspace() === global.screen.get_active_workspace();
+    if (metaWindow.clone.visible || ! onActive) {
         actor.hide();
+        metaWindow.clone.show();
     }
 }
 let showWrapper = utils.dynamic_function_ref('showHandler', Me);

--- a/tiling.js
+++ b/tiling.js
@@ -70,10 +70,10 @@ function enable() {
         global.screen.connect(
             'workspace-switched',
             (screen, from, to) => {
-                let f = spaces.get(global.screen.get_workspace_by_index(from));
-                let t = spaces.get(global.screen.get_workspace_by_index(to));
-                Main.uiGroup.set_child_above_sibling(t.cloneContainer,
-                                                     f.cloneContainer);
+                Main.wm._previewWorkspace(
+                    global.screen.get_workspace_by_index(from),
+                    global.screen.get_workspace_by_index(to)
+                );
             }),
 
         // Reset primary when monitors change


### PR DESCRIPTION

Let every window have a clone (made on `window-created`). The clone lives in a workspace specific container. When doing animations we hide the WindowActors and animate the clones instead. When animations are done we hide the clone and show the WindowActor if the window position is placed in a _possible_ position.

The most obvious benefit is getting rid of the weird stack on the sides. Windows can instead be cleanly placed one after each other.

Another benefit is making workspace animations override-able by simply hiding all `WindowActors` and moving the clone containers around instead. This means we can do stuff like making an android style workspace mru.