### PR TITLE
Multimonitor support

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,8 +2,8 @@
   Application functionality, like global new window actions etc.
  */
 
-const Shell = imports.gi.Shell;
-const Tracker = Shell.WindowTracker.get_default();
+var Shell = imports.gi.Shell;
+var Tracker = Shell.WindowTracker.get_default();
 
 function newWindow(metaWindow) {
     metaWindow = metaWindow || global.display.focus_window;

--- a/extension.js
+++ b/extension.js
@@ -1,27 +1,27 @@
-const Extension = imports.misc.extensionUtils.getCurrentExtension();
-const convenience = Extension.imports.convenience;
+var Extension = imports.misc.extensionUtils.getCurrentExtension();
+var convenience = Extension.imports.convenience;
 
-const modules = [
+var modules = [
     Extension.imports.tiling, Extension.imports.scratch,
     Extension.imports.liveAltTab, Extension.imports.utils,
     Extension.imports.stackoverlay, Extension.imports.app,
     Extension.imports.kludges, Extension.imports.topbar,
     Extension.imports.navigator
 ];
-const [ Tiling, Scratch, LiveAltTab,
+var [ Tiling, Scratch, LiveAltTab,
         utils, StackOverlay,
         App, Kludges, TopBar,
         Navigator
       ] = modules;
 
-const debug = utils.debug;
+var debug = utils.debug;
 
-const Gio = imports.gi.Gio;
-const GLib = imports.gi.GLib;
-const Meta = imports.gi.Meta;
-const Main = imports.ui.main;
-const Shell = imports.gi.Shell;
-const Lang = imports.lang;
+var Gio = imports.gi.Gio;
+var GLib = imports.gi.GLib;
+var Meta = imports.gi.Meta;
+var Main = imports.ui.main;
+var Shell = imports.gi.Shell;
+var Lang = imports.lang;
 
 let SESSIONID = ""+(new Date().getTime());
 // The extension sometimes go through multiple init -> enable -> disable cycles..

--- a/kludges.js
+++ b/kludges.js
@@ -4,9 +4,9 @@
   around these problems.
  */
 
-const Meta = imports.gi.Meta;
+var Meta = imports.gi.Meta;
 
-let orgUpdateState;
+var orgUpdateState;
 function init() {
     orgUpdateState = imports.ui.messageTray.MessageTray.prototype._updateState;
 }

--- a/liveAltTab.js
+++ b/liveAltTab.js
@@ -1,14 +1,14 @@
-const Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.org']
-const Clutter = imports.gi.Clutter;
-const Lang = imports.lang;
-const Meta = imports.gi.Meta;
-const AltTab = imports.ui.altTab;
-const Main = imports.ui.main;
+var Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.org'];
+var Clutter = imports.gi.Clutter;
+var Lang = imports.lang;
+var Meta = imports.gi.Meta;
+var AltTab = imports.ui.altTab;
+var Main = imports.ui.main;
 
-const Scratch = Extension.imports.scratch;
-const Tiling = Extension.imports.tiling;
-const utils = Extension.imports.utils;
-const debug = utils.debug;
+var Scratch = Extension.imports.scratch;
+var Tiling = Extension.imports.tiling;
+var utils = Extension.imports.utils;
+var debug = utils.debug;
 
 var LiveAltTab = Lang.Class({
     Name: 'LiveAltTab',

--- a/minimap.js
+++ b/minimap.js
@@ -1,16 +1,16 @@
-const Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.org']
-const Clutter = imports.gi.Clutter;
-const Tweener = imports.ui.tweener;
-const Lang = imports.lang;
-const St = imports.gi.St;
-const Workspace = imports.ui.workspace;
-const Background = imports.ui.background;
-const Meta = imports.gi.Meta;
-const Pango = imports.gi.Pango;
+var Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.org']
+var Clutter = imports.gi.Clutter;
+var Tweener = imports.ui.tweener;
+var Lang = imports.lang;
+var St = imports.gi.St;
+var Workspace = imports.ui.workspace;
+var Background = imports.ui.background;
+var Meta = imports.gi.Meta;
+var Pango = imports.gi.Pango;
 
-const Tiling = Extension.imports.tiling;
-const utils = Extension.imports.utils;
-const debug = utils.debug;
+var Tiling = Extension.imports.tiling;
+var utils = Extension.imports.utils;
+var debug = utils.debug;
 
 var MINIMAP_SCALE = 0.15;
 
@@ -497,5 +497,5 @@ var MultiMap = new Lang.Class({
     }
 })
 
-const Signals = imports.signals;
+var Signals = imports.signals;
 Signals.addSignalMethods(MultiMap.prototype);

--- a/minimap.js
+++ b/minimap.js
@@ -86,8 +86,8 @@ var Minimap = new Lang.Class({
 
         this.clones = [];
         this.actor.set_scale(MINIMAP_SCALE, MINIMAP_SCALE);
-        this.actor.height = Tiling.primary.height;
-        this.actor.width = Tiling.primary.width;
+        this.actor.height = space.height;
+        this.actor.width = space.width;
         this.actor.add_actor(this.minimapActor);
 
     },
@@ -157,10 +157,10 @@ var Minimap = new Lang.Class({
         for (let i=clones.length-1; i>around; i--) {
             let clone = clones[i];
             clone.set_pivot_point(1, 0.5);
-            if (clone.x + clone.width + this.minimapActor.x >= Tiling.primary.width + maxProtrusion) {
+            if (clone.x + clone.width + this.minimapActor.x >= this.space.width + maxProtrusion) {
                 let scale = 1 - 0.02*(i - around);
                 Tweener.addTween(clone, {x: -this.minimapActor.x
-                                         + Tiling.primary.width
+                                         + this.space.width
                                          + (maxProtrusion - (clones.length-1 - i)*rightStackGap) - clone.width
                                          , scale_x: scale
                                          , scale_y: scale

--- a/navigator.js
+++ b/navigator.js
@@ -103,6 +103,8 @@ var PreviewedWindowNavigator = new Lang.Class({
 
         let visible = Main.layoutManager.monitors
             .map(m => Tiling.spaces.monitors.get(m));
+        Main.layoutManager.monitors
+            .forEach(m => m.clickOverlay.deactivate());
 
         let top = multimap.minimaps[0];
         multimap.minimaps = [top].concat(multimap.minimaps
@@ -341,8 +343,15 @@ var PreviewedWindowNavigator = new Lang.Class({
             this.space.selectedWindow = from[this._startIndex];
         }
 
-        if (this.monitor !== this.space.monitor)
+        if (this.monitor !== this.space.monitor) {
             this.space.setMonitor(this.monitor, true);
+        }
+
+        for (let monitor of Main.layoutManager.monitors) {
+            if (monitor === this.monitor)
+                continue;
+            monitor.clickOverlay.activate();
+        }
 
         if (this.space === from && force) {
             // We can't activate an already active workspace

--- a/navigator.js
+++ b/navigator.js
@@ -341,7 +341,8 @@ var PreviewedWindowNavigator = new Lang.Class({
             this.space.selectedWindow = from[this._startIndex];
         }
 
-        this.space.setMonitor(this.monitor, true);
+        if (this.monitor !== this.space.monitor)
+            this.space.setMonitor(this.monitor, true);
 
         if (this.space === from && force) {
             // We can't activate an already active workspace

--- a/navigator.js
+++ b/navigator.js
@@ -112,7 +112,7 @@ var PreviewedWindowNavigator = new Lang.Class({
             let h = heights[i];
             if (h === undefined)
                 h = heights[heights.length-1];
-            space.cloneContainer.set_position(0, global.screen_height*h);
+            space.cloneContainer.set_position(0, space.height*h);
 
             space.cloneContainer.scale_y = scale + (1 - i)*0.01;
             space.cloneContainer.scale_x = scale + (1 - i)*0.01;
@@ -198,7 +198,7 @@ var PreviewedWindowNavigator = new Lang.Class({
                 h = 1;
 
             Tweener.addTween(actor,
-                             {y: h*global.screen_height,
+                             {y: h*m.space.height,
                               time: 0.25,
                               scale_x: scale + (to - i)*0.01,
                               scale_y: scale + (to - i)*0.01,

--- a/navigator.js
+++ b/navigator.js
@@ -2,20 +2,20 @@
   Navigation and previewing functionality.
  */
 
-const Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.org'];
-const SwitcherPopup = imports.ui.switcherPopup;
-const Lang = imports.lang;
-const Meta = imports.gi.Meta;
-const Main = imports.ui.main;
-const Clutter = imports.gi.Clutter;
-const Tweener = imports.ui.tweener;
+var Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.org'];
+var SwitcherPopup = imports.ui.switcherPopup;
+var Lang = imports.lang;
+var Meta = imports.gi.Meta;
+var Main = imports.ui.main;
+var Clutter = imports.gi.Clutter;
+var Tweener = imports.ui.tweener;
 
 var TopBar = Extension.imports.topbar;
 var Scratch = Extension.imports.scratch;
-const Minimap = Extension.imports.minimap;
-const Tiling = Extension.imports.tiling;
-const utils = Extension.imports.utils;
-const debug = utils.debug;
+var Minimap = Extension.imports.minimap;
+var Tiling = Extension.imports.tiling;
+var utils = Extension.imports.utils;
+var debug = utils.debug;
 
 var scale = 0.9;
 var navigating = false;

--- a/navigator.js
+++ b/navigator.js
@@ -11,7 +11,6 @@ const Clutter = imports.gi.Clutter;
 const Tweener = imports.ui.tweener;
 
 var TopBar = Extension.imports.topbar;
-var StackOverlay = Extension.imports.stackoverlay;
 var Scratch = Extension.imports.scratch;
 const Minimap = Extension.imports.minimap;
 const Tiling = Extension.imports.tiling;

--- a/navigator.js
+++ b/navigator.js
@@ -330,7 +330,7 @@ var PreviewedWindowNavigator = new Lang.Class({
         if (Main.panel.statusArea.appMenu)
             Main.panel.statusArea.appMenu.container.show();
         if (workspaceMru)
-            StackOverlay.reset();
+            this.space.monitor.clickOverlay.reset();
 
         let force = workspaceMru;
         navigating = false; workspaceMru = false;

--- a/navigator.js
+++ b/navigator.js
@@ -106,7 +106,7 @@ var PreviewedWindowNavigator = new Lang.Class({
             Scratch.makeScratch(this._moving);
         }
 
-        let cloneParent = this.space.cloneContainer.get_parent();
+        let cloneParent = this.space.clip.get_parent();
         multimap.minimaps.forEach((m, i) => {
             let space = m.space;
             let h = heights[i];
@@ -119,8 +119,8 @@ var PreviewedWindowNavigator = new Lang.Class({
             if (multimap.minimaps[i - 1] === undefined)
                 return;
             cloneParent.set_child_below_sibling(
-                space.cloneContainer,
-                multimap.minimaps[i - 1].space.cloneContainer
+                space.clip,
+                multimap.minimaps[i - 1].space.clip
             );
             space.cloneContainer.show();
 
@@ -385,15 +385,16 @@ function switchWorkspace(to, from, callback) {
                        onComplete: () => {
                            Meta.enable_unredirect_for_screen(global.screen);
 
-                           toSpace.cloneContainer.raise_top();
+                           toSpace.clip.raise_top();
                            callback && callback();
                        }
                      });
 
-    let next = toSpace.cloneContainer.get_next_sibling();
+    let next = toSpace.clip.get_next_sibling();
 
     while (next !== null) {
-        Tweener.addTween(next,
+        if (next.space.monitor === toSpace.monitor)
+        Tweener.addTween(next.first_child,
                          { x: xDest,
                            y: yDest,
                            scale_x: scale,
@@ -403,7 +404,7 @@ function switchWorkspace(to, from, callback) {
                            onComplete() {
                                this.set_position(0, global.screen_height*0.1);
                            },
-                           onCompleteScope: next
+                           onCompleteScope: next.first_child
                          });
 
         next = next.get_next_sibling();

--- a/navigator.js
+++ b/navigator.js
@@ -127,25 +127,25 @@ var PreviewedWindowNavigator = new Lang.Class({
             let h = heights[i];
             if (h === undefined)
                 h = heights[heights.length-1];
-            space.cloneContainer.set_position(0, space.height*h);
+            space.actor.set_position(0, space.height*h);
 
-            space.cloneContainer.scale_y = scale + (1 - i)*0.01;
-            space.cloneContainer.scale_x = scale + (1 - i)*0.01;
+            space.actor.scale_y = scale + (1 - i)*0.01;
+            space.actor.scale_x = scale + (1 - i)*0.01;
             if (multimap.minimaps[i - 1] === undefined)
                 return;
             cloneParent.set_child_below_sibling(
                 space.clip,
                 multimap.minimaps[i - 1].space.clip
             );
-            space.cloneContainer.show();
+            space.actor.show();
 
             let selected = space.selectedWindow;
             if (selected && selected.fullscreen) {
                 selected.clone.y = Main.panel.actor.height + Tiling.margin_tb;
             }
         });
-        this.space.cloneContainer.scale_y = 1;
-        this.space.cloneContainer.scale_x = 1;
+        this.space.actor.scale_y = 1;
+        this.space.actor.scale_x = 1;
     },
 
     selectSpace: function(direction, move) {
@@ -199,7 +199,7 @@ var PreviewedWindowNavigator = new Lang.Class({
         let heights = this._yPositions;
 
         multimap.minimaps.forEach((m, i) => {
-            let actor = m.space.cloneContainer;
+            let actor = m.space.actor;
             let h;
             if (to === i)
                 h = heights[1];
@@ -392,7 +392,7 @@ function switchWorkspace(to, from, callback) {
         });
     }
 
-    Tweener.addTween(toSpace.cloneContainer,
+    Tweener.addTween(toSpace.actor,
                      { x: 0,
                        y: 0,
                        scale_x: 1,

--- a/navigator.js
+++ b/navigator.js
@@ -342,7 +342,7 @@ var PreviewedWindowNavigator = new Lang.Class({
             this.space.selectedWindow = from[this._startIndex];
         }
 
-        this.space.setMonitor(this.monitor);
+        this.space.setMonitor(this.monitor, true);
 
         if (this.space === from && force) {
             // We can't activate an already active workspace

--- a/navigator.js
+++ b/navigator.js
@@ -409,20 +409,25 @@ function switchWorkspace(to, from, callback) {
 
     let next = toSpace.clip.get_next_sibling();
 
+    let visible = new Map();
+    for (let [monitor, space] of Tiling.spaces.monitors) {
+        visible.set(space, true);
+    }
     while (next !== null) {
-        if (next.space.monitor === toSpace.monitor)
-        Tweener.addTween(next.first_child,
-                         { x: xDest,
-                           y: yDest,
-                           scale_x: scale,
-                           scale_y: scale,
-                           time: 0.25,
-                           transition: 'easeInOutQuad',
-                           onComplete() {
-                               this.set_position(0, global.screen_height*0.1);
-                           },
-                           onCompleteScope: next.first_child
-                         });
+        if (!visible.get(next.space))
+            Tweener.addTween(
+                next.first_child,
+                { x: xDest,
+                  y: yDest,
+                  scale_x: scale,
+                  scale_y: scale,
+                  time: 0.25,
+                  transition: 'easeInOutQuad',
+                  onComplete() {
+                      this.set_position(0, global.screen_height*0.1);
+                  },
+                  onCompleteScope: next.first_child
+                });
 
         next = next.get_next_sibling();
     }

--- a/notes.org
+++ b/notes.org
@@ -2,10 +2,12 @@
 ** When window A is closed
 1. The next window, B, receives 'focus' (but the actor of A seems to be gone?)
 2. Workspace receives 'window-removed'. ('A' seems to have been stripped of signal handlers)
+3. on screen 'window-left-monitor', actor isn't available
 ** When window A is created
 1. on workspace "window-added" is run, actor isn't available
-2. on display "window-created is run, actor is available
-3. focus is run if the new window should be focused
+2. on screen "window-entered-monitor", actor isn't available
+3. on display "window-created" is run, actor is available
+4. focus is run if the new window should be focused
 * Keybinding system
 `Main.wm.addKeybinding` is used to register a named keybindable /action/ and it's handler. An numeric id is returned. (this is a thin wrapper around `[[https://developer.gnome.org/meta/stable/MetaDisplay.html#meta-display-add-keybinding][MetaDisplay.add_keybinding]]`)
 

--- a/scratch.js
+++ b/scratch.js
@@ -14,7 +14,7 @@ function makeScratch(metaWindow) {
     metaWindow.clone.hide();
     metaWindow.get_compositor_private().show();
 
-    StackOverlay.reset();
+    // StackOverlay.reset();
 }
 
 function unmakeScratch(metaWindow) {
@@ -63,7 +63,7 @@ function show() {
             meta_window.get_compositor_private().show();
     });
     windows[0].activate(global.get_current_time());
-    StackOverlay.reset();
+    // StackOverlay.reset();
 }
 
 function hide() {

--- a/scratch.js
+++ b/scratch.js
@@ -1,10 +1,10 @@
-const Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.org']
-const Meta = imports.gi.Meta;
+var Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.org'];
+var Meta = imports.gi.Meta;
 
-const TopBar = Extension.imports.topbar;
-const utils = Extension.imports.utils;
-const debug = utils.debug;
-let float;
+var TopBar = Extension.imports.topbar;
+var utils = Extension.imports.utils;
+var debug = utils.debug;
+var float;
 
 function makeScratch(metaWindow) {
     metaWindow[float] = true;
@@ -70,10 +70,10 @@ function hide() {
 }
 
 // Monkey patch the alt-space menu
-const Lang = imports.lang;
-const PopupMenu = imports.ui.popupMenu;
-const WindowMenu = imports.ui.windowMenu;
-const originalBuildMenu = WindowMenu.WindowMenu.prototype._buildMenu;
+var Lang = imports.lang;
+var PopupMenu = imports.ui.popupMenu;
+var WindowMenu = imports.ui.windowMenu;
+var originalBuildMenu = WindowMenu.WindowMenu.prototype._buildMenu;
 
 function init() {
     float = Symbol();

--- a/scratch.js
+++ b/scratch.js
@@ -2,7 +2,6 @@ const Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix
 const Meta = imports.gi.Meta;
 
 const TopBar = Extension.imports.topbar;
-const StackOverlay = Extension.imports.stackoverlay;
 const utils = Extension.imports.utils;
 const debug = utils.debug;
 let float;
@@ -13,8 +12,6 @@ function makeScratch(metaWindow) {
     metaWindow.stick();
     metaWindow.clone.hide();
     metaWindow.get_compositor_private().show();
-
-    // StackOverlay.reset();
 }
 
 function unmakeScratch(metaWindow) {
@@ -63,7 +60,6 @@ function show() {
             meta_window.get_compositor_private().show();
     });
     windows[0].activate(global.get_current_time());
-    // StackOverlay.reset();
 }
 
 function hide() {

--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -1,14 +1,14 @@
-const Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.org']
-const Tiling = Extension.imports.tiling;
-const Clutter = imports.gi.Clutter;
-const Tweener = imports.ui.tweener;
-const Lang = imports.lang;
-const Main = imports.ui.main;
-const Shell = imports.gi.Shell;
-const Meta = imports.gi.Meta;
-const utils = Extension.imports.utils;
-const debug = utils.debug;
-const Minimap = Extension.imports.minimap;
+var Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.org'];
+var Tiling = Extension.imports.tiling;
+var Clutter = imports.gi.Clutter;
+var Tweener = imports.ui.tweener;
+var Lang = imports.lang;
+var Main = imports.ui.main;
+var Shell = imports.gi.Shell;
+var Meta = imports.gi.Meta;
+var utils = Extension.imports.utils;
+var debug = utils.debug;
+var Minimap = Extension.imports.minimap;
 
 /*
   The stack overlay decorates the top stacked window with its icon and

--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -59,7 +59,7 @@ function createAppIcon(metaWindow, size) {
 var StackOverlay = new Lang.Class({
     Name: 'Stackoverlay',
 
-    _init: function(direction, showIcon) {
+    _init: function(direction, monitor, showIcon) {
         this.showIcon = showIcon;
 
         this._direction = direction;
@@ -67,11 +67,11 @@ var StackOverlay = new Lang.Class({
         let overlay = new Clutter.Actor({ reactive: true
                                           , name: "stack-overlay" });
 
-        this.monitor = Main.layoutManager.primaryMonitor;
+        this.monitor = monitor;
 
         let panelBox = Main.layoutManager.panelBox;
 
-        overlay.y = panelBox.height + Tiling.margin_tb;
+        overlay.y = monitor.y + panelBox.height + Tiling.margin_tb;
         overlay.height = this.monitor.height - panelBox.height - Tiling.margin_tb;
         overlay.width = Tiling.stack_margin;
 
@@ -134,6 +134,8 @@ var StackOverlay = new Lang.Class({
         let frame = metaWindow.get_frame_rect();
         let space = Tiling.spaces.spaceOfWindow(metaWindow);
 
+        overlay.y = this.monitor.y + Main.layoutManager.panelBox.height + Tiling.margin_tb;
+
         // Note: Atm. this can be called when the windows are moving. Therefore
         //       we must use destinationX and we might occationally get wrong y
         //       positions (icon) (since we don't track the y destination)
@@ -147,7 +149,7 @@ var StackOverlay = new Lang.Class({
             if (neighbourX === undefined)
                 neighbourX = neighbour.get_frame_rect().x;
 
-            overlay.x = 0;
+            overlay.x = this.monitor.x;
             overlay.width = Math.max(0, neighbourX - Tiling.window_gap);
         } else {
             let neighbour = space[space.indexOf(metaWindow) - 1]
@@ -186,8 +188,9 @@ function reset() {
 var leftOverlay;
 var rightOverlay;
 function enable() {
-    leftOverlay  = new StackOverlay(Meta.MotionDirection.LEFT);
-    rightOverlay = new StackOverlay(Meta.MotionDirection.RIGHT);
+    let monitor = Main.layoutManager.primaryMonitor;
+    leftOverlay  = new StackOverlay(Meta.MotionDirection.LEFT, monitor);
+    rightOverlay = new StackOverlay(Meta.MotionDirection.RIGHT, monitor);
 }
 
 function disable() {

--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -72,7 +72,7 @@ class ClickOverlay {
 
         this.enterSignal = enterMonitor.connect(
             'enter-event', () => {
-                this.reset();
+                this.deactivate();
                 let space = Tiling.spaces.monitors.get(this.monitor);
                 space.workspace.activate(global.get_current_time());
                 return Clutter.EVENT_STOP;
@@ -86,10 +86,13 @@ class ClickOverlay {
         this.enterMonitor.set_size(monitor.width, monitor.height);
     }
 
+    deactivate() {
+        this.enterMonitor.set_size(0, 0);
+    }
+
     reset() {
         this.left.setTarget(null);
         this.right.setTarget(null);
-        this.enterMonitor.set_size(0, 0);
     }
 
     destroy() {

--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -227,26 +227,3 @@ var StackOverlay = new Lang.Class({
         Tweener.addTween(this.overlay, { opacity: 0, time: 0.25 });
     }
 });
-
-function reset() {
-    leftOverlay.setTarget(null);
-    rightOverlay.setTarget(null);
-}
-
-var leftOverlay;
-var rightOverlay;
-function enable() {
-    let monitor = Main.layoutManager.primaryMonitor;
-    leftOverlay  = new StackOverlay(Meta.MotionDirection.LEFT, monitor);
-    rightOverlay = new StackOverlay(Meta.MotionDirection.RIGHT, monitor);
-}
-
-function disable() {
-    // Disconnect the overlay
-    for (let overlay of [leftOverlay, rightOverlay]) {
-        let actor = overlay.overlay;
-        actor.disconnect(overlay.pressId);
-        actor.disconnect(overlay.releaseId);
-        actor.destroy();
-    }
-}

--- a/tiling.js
+++ b/tiling.js
@@ -118,6 +118,7 @@ class Space extends Array {
         this.height = monitor.height;
 
         cloneContainer.set_scale(1, 1);
+        clip.set_scale(1, 1);
 
         clip.set_position(monitor.x, monitor.y);
         clip.set_size(monitor.width, monitor.height);

--- a/tiling.js
+++ b/tiling.js
@@ -549,8 +549,9 @@ class Spaces extends Map {
 
         metaWindow.change_workspace(space.workspace);
 
-        if (focus)
-            Main.activateWindow(metaWindow);
+        // This doesn't play nice with the clickoverlay, disable for now
+        // if (focus)
+        //     Main.activateWindow(metaWindow);
     }
 }
 

--- a/tiling.js
+++ b/tiling.js
@@ -960,6 +960,11 @@ function move(meta_window, space,
     let buffer = meta_window.get_buffer_rect();
     let frame = meta_window.get_frame_rect();
     let clone = meta_window.clone;
+    let monitor = space.monitor;
+
+    if (actor.visible) {
+        clone.set_position(actor.x - monitor.x, actor.y - monitor.y);
+    }
 
     clone.show();
     actor.hide();

--- a/tiling.js
+++ b/tiling.js
@@ -593,6 +593,7 @@ function enable() {
                 if (toSpace.monitor === fromSpace.monitor)
                     return;
 
+                TopBar.setMonitor(toSpace.monitor);
                 toSpace.monitor.clickOverlay.deactivate();
 
                 let display = Gdk.Display.get_default();

--- a/tiling.js
+++ b/tiling.js
@@ -872,7 +872,7 @@ function ensureViewport(meta_window, space, force) {
     let frame = meta_window.get_frame_rect();
     let width = Math.min(space.monitor.width - 2*minimumMargin, frame.width);
     meta_window.move_resize_frame(true, frame.x, frame.y, width,
-                                  space.height - panelBox.height - margin_tb*2);
+                                  space.height - panelBox.height - margin_tb);
 
     // Use monitor relative coordinates.
     frame.x -= monitor.x;

--- a/tiling.js
+++ b/tiling.js
@@ -378,15 +378,20 @@ class Spaces extends Map {
                 this.monitors.set(primary, space);
             }
         });
+
+        // Populate all monitors with existing worspaces
+        mru.slice(1).forEach((space, i) => {
+            let monitor = monitors[i];
+            if (!monitor)
+                return;
+            space.setMonitor(monitor);
+            this.monitors.set(monitor, space);
         });
-        this.monitors.set(primary, mru[0]);
-        let i = 1;
-        for (let monitor of others) {
-            // debug('monitor', monitor.index)
-            mru[i].setMonitor(monitor);
-            this.monitors.set(monitor, mru[i]);
-            i++;
-        }
+
+        // Let the active workspace follow the primary monitor
+        let active = mru[0];
+        active.setMonitor(primary);
+        this.monitors.set(primary, active);
     }
 
     destroy() {

--- a/tiling.js
+++ b/tiling.js
@@ -563,6 +563,12 @@ function enable() {
                 Navigator.switchWorkspace(to, from);
                 let toSpace = spaces.spaceOf(to);
                 spaces.monitors.set(toSpace.monitor, toSpace);
+
+                for (let monitor of Main.layoutManager.monitors) {
+                    if (monitor === toSpace.monitor)
+                        continue;
+                    monitor.clickOverlay.activate();
+                }
             }));
 
     // HACK: couldn't find an other way within a reasonable time budget

--- a/tiling.js
+++ b/tiling.js
@@ -1,15 +1,15 @@
-const Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.org']
-const GLib = imports.gi.GLib;
-const Tweener = imports.ui.tweener;
-const Lang = imports.lang;
-const Meta = imports.gi.Meta;
-const Clutter = imports.gi.Clutter;
-const St = imports.gi.St;
-const Main = imports.ui.main;
-const Shell = imports.gi.Shell;
-const Gio = imports.gi.Gio;
-const utils = Extension.imports.utils;
-const debug = utils.debug;
+var Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.org'];
+var GLib = imports.gi.GLib;
+var Tweener = imports.ui.tweener;
+var Lang = imports.lang;
+var Meta = imports.gi.Meta;
+var Clutter = imports.gi.Clutter;
+var St = imports.gi.St;
+var Main = imports.ui.main;
+var Shell = imports.gi.Shell;
+var Gio = imports.gi.Gio;
+var utils = Extension.imports.utils;
+var debug = utils.debug;
 
 var Gdk = imports.gi.Gdk;
 
@@ -24,7 +24,7 @@ var Navigator = Extension.imports.navigator;
 var ClickOverlay = Extension.imports.stackoverlay.ClickOverlay;
 var Me = Extension.imports.tiling;
 
-let preferences = Extension.imports.convenience.getSettings();
+var preferences = Extension.imports.convenience.getSettings();
 // Gap between windows
 var window_gap = preferences.get_int('window-gap');
 // Top/bottom margin
@@ -39,7 +39,7 @@ var minimumMargin = 15;
 var panelBox = Main.layoutManager.panelBox;
 
 // From https://developer.gnome.org/hig-book/unstable/design-color.html.en
-let colors = [
+var colors = [
     '#9DB8D2', '#7590AE', '#4B6983', '#314E6C',
     '#EAE8E3', '#BAB5AB', '#807D74', '#565248',
     '#C5D2C8', '#83A67F', '#5D7555', '#445632',
@@ -49,7 +49,7 @@ let colors = [
     '#DF421E', '#990000', '#EED680', '#D1940C',
     '#46A046', '#267726', '#ffffff', '#000000'
 ];
-let color;
+var color;
 
 /**
    Scrolled and tiled per monitor workspace.

--- a/tiling.js
+++ b/tiling.js
@@ -367,8 +367,6 @@ class Spaces extends Map {
     }
 
     destroy() {
-        this.spaceContainer.destroy();
-
         for (let overlay of this.clickOverlays) {
             overlay.destroy();
         }
@@ -386,9 +384,6 @@ class Spaces extends Map {
                     actor[signals].forEach(id => actor.disconnect(id));
                 }
 
-                if (metaWindow.clone)
-                    metaWindow.clone.destroy();
-
                 if (metaWindow[signals]) {
                     metaWindow[signals].forEach(id => metaWindow.disconnect(id));
                     delete metaWindow[signals];
@@ -405,6 +400,8 @@ class Spaces extends Map {
         for (let [workspace, space] of this) {
             this.removeSpace(space);
         }
+
+        this.spaceContainer.destroy();
     }
 
     workspacesChanged() {

--- a/tiling.js
+++ b/tiling.js
@@ -368,11 +368,17 @@ class Spaces extends Map {
 
         let mru = this.mru();
         let primary = Main.layoutManager.primaryMonitor;
-        let others = Main.layoutManager.monitors
-            .filter(m => m !== primary);
+        let monitors = Main.layoutManager.monitors;
+        let others = monitors.filter(m => m !== primary);
 
-        // Reset all monitors
-        this.forEach(s => s.setMonitor(primary));
+        // Reset all removed monitors
+        this.forEach(space => {
+            if (monitors.indexOf(space.monitor) === -1) {
+                space.setMonitor(primary);
+                this.monitors.set(primary, space);
+            }
+        });
+        });
         this.monitors.set(primary, mru[0]);
         let i = 1;
         for (let monitor of others) {

--- a/tiling.js
+++ b/tiling.js
@@ -584,9 +584,14 @@ function enable() {
             (screen, fromIndex, toIndex) => {
                 let to = screen.get_workspace_by_index(toIndex);
                 let from = screen.get_workspace_by_index(fromIndex);
-                Navigator.switchWorkspace(to, from);
                 let toSpace = spaces.spaceOf(to);
                 spaces.monitors.set(toSpace.monitor, toSpace);
+
+                Navigator.switchWorkspace(to, from);
+
+                let fromSpace = spaces.spaceOf(from);
+                if (toSpace.monitor === fromSpace.monitor)
+                    return;
 
                 toSpace.monitor.clickOverlay.deactivate();
 

--- a/tiling.js
+++ b/tiling.js
@@ -340,6 +340,7 @@ class Spaces extends Map {
         for (let monitor of Main.layoutManager.monitors) {
             let overlay = new ClickOverlay(monitor);
             monitor.clickOverlay = overlay;
+            overlay.activate();
             this.clickOverlays.push(overlay);
         }
 
@@ -567,6 +568,8 @@ function enable() {
                 Navigator.switchWorkspace(to, from);
                 let toSpace = spaces.spaceOf(to);
                 spaces.monitors.set(toSpace.monitor, toSpace);
+
+                toSpace.monitor.clickOverlay.deactivate();
 
                 let display = Gdk.Display.get_default();
                 let deviceManager = display.get_device_manager();

--- a/tiling.js
+++ b/tiling.js
@@ -111,7 +111,7 @@ class Space extends Array {
         this.addAll(oldSpaces.get(workspace));
     }
 
-    setMonitor(monitor) {
+    setMonitor(monitor, animate) {
         let cloneContainer = this.cloneContainer;
         let clip = this.clip;
 
@@ -119,8 +119,14 @@ class Space extends Array {
         this.width = monitor.width;
         this.height = monitor.height;
 
-        cloneContainer.set_scale(1, 1);
-        clip.set_scale(1, 1);
+        let time = animate ? 0.25 : 0;
+
+        let transition = 'easeInOutQuad';
+        Tweener.addTween(cloneContainer,
+                        {x: 0, y: 0, scale_x: 1, scale_y: 1,
+                         time, transition});
+        Tweener.addTween(clip,
+                         {scale_x: 1, scale_y: 1, time});
 
         clip.set_position(monitor.x, monitor.y);
         clip.set_size(monitor.width, monitor.height);
@@ -128,7 +134,6 @@ class Space extends Array {
                       monitor.width,
                       monitor.height);
 
-        cloneContainer.set_position(0, 0);
         cloneContainer.set_size(monitor.width, monitor.height);
         cloneContainer.set_size(monitor.width, monitor.height);
         cloneContainer.set_clip(-(window_gap - 2), -10,

--- a/tiling.js
+++ b/tiling.js
@@ -999,11 +999,13 @@ function propagateForward(space, n, x, gap) {
         return;
     }
     let meta_window = space[n];
+    let frame = meta_window.get_frame_rect();
     gap = gap || window_gap;
 
     let stack = false;
     // Check if we should start stacking windows
-    if (x > space.width - stack_margin || meta_window.fullscreen
+    if (x + frame.width > space.width
+        || meta_window.fullscreen
         || meta_window.get_maximized() === Meta.MaximizeFlags.BOTH) {
         if (x < space.width) {
             space.monitor.clickOverlay.right.setTarget(meta_window);
@@ -1020,7 +1022,7 @@ function propagateForward(space, n, x, gap) {
 
         move(meta_window, space,
              { x, y: panelBox.height + margin_tb, stack });
-        propagateForward(space, n+1, x+meta_window.get_frame_rect().width + gap, gap);
+        propagateForward(space, n+1, x+frame.width + gap, gap);
     } else {
         // If the window doesn't have an actor we should just skip it
         propagateForward(space, n+1, x, gap);
@@ -1033,11 +1035,12 @@ function propagateBackward(space, n, x, gap) {
         return;
     }
     let meta_window = space[n];
+    let frame = meta_window.get_frame_rect();
     gap = gap || window_gap;
 
     // Check if we should start stacking windows
     let stack = false;
-    if (x < stack_margin || meta_window.fullscreen
+    if (x - frame.width < 0 || meta_window.fullscreen
         || meta_window.get_maximized() === Meta.MaximizeFlags.BOTH) {
         if (x > 0) {
             space.monitor.clickOverlay.left.setTarget(meta_window);
@@ -1050,7 +1053,7 @@ function propagateBackward(space, n, x, gap) {
 
     let actor = meta_window.get_compositor_private();
     if (actor) {
-        x = x - meta_window.get_frame_rect().width
+        x = x - frame.width;
         // Anchor on the right edge for windows positioned to the left.
         move(meta_window, space,
              { x, y: panelBox.height + margin_tb, stack });

--- a/tiling.js
+++ b/tiling.js
@@ -687,14 +687,13 @@ function ensureViewport(meta_window, space, force) {
         debug('already moving', meta_window.title);
         return;
     }
-    debug('Moving', meta_window.title);
-
-    meta_window._isStacked = false;
 
     let index = space.indexOf(meta_window)
     if (index === -1)
         return;
 
+    debug('Moving', meta_window.title);
+    meta_window._isStacked = false;
     space.selectedWindow = meta_window;
     let frame = meta_window.get_frame_rect();
     meta_window.move_resize_frame(true, frame.x, frame.y,

--- a/tiling.js
+++ b/tiling.js
@@ -1091,8 +1091,16 @@ function propagateBackward(space, n, x, gap) {
 function sizeHandler(metaWindow) {
     debug('size-changed', metaWindow.title);
     let space = spaces.spaceOfWindow(metaWindow);
-    if (space.selectedWindow === metaWindow)
-        ensureViewport(metaWindow, space, true);
+    if (space.selectedWindow === metaWindow) {
+        let index = space.indexOf(metaWindow);
+        let frame = metaWindow.get_frame_rect();
+        let monitor = space.monitor;
+        frame.x -= monitor.x; frame.y -= monitor.y;
+
+        space.monitor.clickOverlay.reset();
+        propagateForward(space, index + 1, frame.x + frame.width + window_gap);
+        propagateBackward(space, index - 1, frame.x - window_gap);
+    }
 }
 
 // `MetaWindow::focus` handling

--- a/tiling.js
+++ b/tiling.js
@@ -11,6 +11,8 @@ const Gio = imports.gi.Gio;
 const utils = Extension.imports.utils;
 const debug = utils.debug;
 
+var Gdk = imports.gi.Gdk;
+
 var screen = global.screen;
 
 var spaces;
@@ -563,6 +565,22 @@ function enable() {
                 Navigator.switchWorkspace(to, from);
                 let toSpace = spaces.spaceOf(to);
                 spaces.monitors.set(toSpace.monitor, toSpace);
+
+                let display = Gdk.Display.get_default();
+                let deviceManager = display.get_device_manager();
+                let pointer = deviceManager.get_client_pointer();
+                let [gdkscreen, pointerX, pointerY] = pointer.get_position();
+
+                let monitor = toSpace.monitor;
+                pointerX -= monitor.x;
+                pointerY -= monitor.y;
+                if (pointerX < 0 ||
+                    pointerX > monitor.width ||
+                    pointerY < 0 ||
+                    pointerY > monitor.height)
+                    pointer.warp(gdkscreen,
+                                 monitor.x + Math.floor(monitor.width/2),
+                                 monitor.y + Math.floor(monitor.height/2));
 
                 for (let monitor of Main.layoutManager.monitors) {
                     if (monitor === toSpace.monitor)

--- a/tiling.js
+++ b/tiling.js
@@ -853,8 +853,8 @@ function ensureViewport(meta_window, space, force) {
 
     let monitor = space.monitor;
     let frame = meta_window.get_frame_rect();
-    meta_window.move_resize_frame(true, frame.x, frame.y,
-                                  frame.width,
+    let width = Math.min(space.monitor.width - 2*minimumMargin, frame.width);
+    meta_window.move_resize_frame(true, frame.x, frame.y, width,
                                   space.height - panelBox.height - margin_tb*2);
 
     // Use monitor relative coordinates.

--- a/tiling.js
+++ b/tiling.js
@@ -21,7 +21,7 @@ var Minimap = Extension.imports.minimap;
 var Scratch = Extension.imports.scratch;
 var TopBar = Extension.imports.topbar;
 var Navigator = Extension.imports.navigator;
-var StackOverlay = Extension.imports.stackoverlay;
+var ClickOverlay = Extension.imports.stackoverlay.ClickOverlay;
 var Me = Extension.imports.tiling;
 
 let preferences = Extension.imports.convenience.getSettings();
@@ -333,12 +333,14 @@ class Spaces extends Map {
 
         this.spaceContainer.set_size(global.screen_width, global.screen_height);
 
+        for (let overlay of this.clickOverlays) {
+            overlay.destroy();
+        }
+        this.clickOverlays = [];
         for (let monitor of Main.layoutManager.monitors) {
-            if (!monitor.clickOverlay) {
-                let overlay = new StackOverlay.ClickOverlay(monitor);
-                monitor.clickOverlay = overlay;
-                this.clickOverlays.push(overlay);
-            }
+            let overlay = new ClickOverlay(monitor);
+            monitor.clickOverlay = overlay;
+            this.clickOverlays.push(overlay);
         }
 
         let mru = this.mru();

--- a/topbar.js
+++ b/topbar.js
@@ -25,7 +25,7 @@ function enable () {
     // Force transparency
     Main.panel.actor.set_style('background-color: rgba(0, 0, 0, 0.35);');
     [Main.panel._rightCorner, Main.panel._leftCorner]
-        .forEach(c => c.actor.hide());
+        .forEach(c => c.actor.opacity = 0);
 
     screenSignals.push(
         global.screen.connect_after('workspace-switched',
@@ -48,7 +48,7 @@ function enable () {
 function disable() {
     Main.panel.actor.set_style('');
     [Main.panel._rightCorner, Main.panel._leftCorner]
-        .forEach(c => c.actor.show());
+        .forEach(c => c.actor.opacity = 255);
 
     screenSignals.forEach(id => global.screen.disconnect(id));
     screenSignals = [];

--- a/topbar.js
+++ b/topbar.js
@@ -97,3 +97,9 @@ function setWorkspaceName (name) {
     let label = Main.panel.statusArea.activities.actor.first_child;
     label.text = name;
 }
+
+function setMonitor(monitor) {
+    let panelBox = Main.layoutManager.panelBox;
+    panelBox.set_position(monitor.x, monitor.y);
+    panelBox.width = monitor.width;
+}

--- a/topbar.js
+++ b/topbar.js
@@ -2,12 +2,12 @@
   Functionality related to the top bar, often called the statusbar.
  */
 
-const Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.org'];
-const Meta = imports.gi.Meta;
-const Main = imports.ui.main;
-const Tweener = imports.ui.tweener;
+var Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.org'];
+var Meta = imports.gi.Meta;
+var Main = imports.ui.main;
+var Tweener = imports.ui.tweener;
 
-const Tiling = Extension.imports.tiling;
+var Tiling = Extension.imports.tiling;
 
 var panelBox = Main.layoutManager.panelBox;
 


### PR DESCRIPTION
## Features

- When changing monitors the active workspace will follow the primary monitor, the remaining monitors will be populated with the top of the workspace mru.

- The workspace mru stack is shared between all monitors, scaled to fit the monitor accessing the stack.

- Non active monitors are covered in a overlay which will activate the corresponding workspace when detecting the mouse pointer. It seems like there's no `pointer-entered-monitor`.

- When changing to another visible workspace the pointer will warp to the center of its monitor.

## Some implementation notes

We create an actor spanning the whole screen, `Spaces.spaceContainer` which holds all spaces. A `Space` is now first contained in a `Space.clip` container clipping away anything that protrudes from the monitor. The `cloneContainer` is then moved within the `clip` when doing previews.

There's now an associated `monitor` per `Space` (`space.monitor`), which can be set by `Space.setMonitor(monitor, animate)`. When doing previews the `space.clip` actor is moved and scaled without setting the associated monitor.

We also keep visible workspaces through a  `monitor` -> `Space` mapping. Currently implemented with  a `Map` accessed through `spaces.monitors`. So used like this `spaces.monitors.get(monitor)`. It might be better to just keep a reference on the monitor objects instead though.

## Some remaining issues:

- [x] The top bar shows the name of the active workspace, not the workspace that's on the primary monitor.
- [ ] The minimap is always placed on the primary monitor.
- [x] When moving windows to another monitor the pointer will warp back to the original monitor for some reason. Disabled moving the focus for now.
- [x] Move and resize the top bar to the focused monitor.
- [ ] The activities overview won't show windows on other monitors. Will delay this.
- [ ] Windows not in the tiling or the scratch layer gets hidden when focusing another monitor.


Fixes #47, #46, #48, #17 