### PR TITLE
Hide window previews after workspace was selected

### DIFF
--- a/navigator.js
+++ b/navigator.js
@@ -438,6 +438,7 @@ function switchWorkspace(to, from, callback) {
     let xDest = 0, yDest = global.screen_height;
 
     let toSpace = Tiling.spaces.spaceOf(to);
+    toSpace.actor.show();
     let selected = toSpace.selectedWindow;
     if (selected)
         Tiling.ensureViewport(selected, toSpace, true);
@@ -482,6 +483,7 @@ function switchWorkspace(to, from, callback) {
                   transition: 'easeInOutQuad',
                   onComplete() {
                       this.set_position(0, global.screen_height*0.1);
+                      this.hide();                     
                   },
                   onCompleteScope: next.first_child
                 });


### PR DESCRIPTION
I'm using paperwm without coloring each workspace (actually I'm using other extension which changes wallpaper on workspace change). In that case I can see workspace previews in background (especially if target workspace is empty).

This change hides previews when workspace change was done