### PR TITLE
Restore monitor setup on disable/enable

### DIFF
--- a/navigator.js
+++ b/navigator.js
@@ -181,8 +181,8 @@ var PreviewedWindowNavigator = new Lang.Class({
 
         let visible = Main.layoutManager.monitors
             .map(m => Tiling.spaces.monitors.get(m));
-        Main.layoutManager.monitors
-            .forEach(m => m.clickOverlay.deactivate());
+        Tiling.spaces.clickOverlays
+            .forEach(overlay => overlay.deactivate());
 
         let mru = [this.space].concat(
             Tiling.spaces.mru().filter(space => !visible.includes(space)));
@@ -500,7 +500,7 @@ var PreviewedWindowNavigator = new Lang.Class({
             this.space.emit('move-done');
 
         for (let monitor of Main.layoutManager.monitors) {
-            if (monitor === this.monitor)
+            if (monitor === this.monitor || !monitor.clickOverlay)
                 continue;
             monitor.clickOverlay.activate();
         }

--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -71,6 +71,7 @@ class ClickOverlay {
         enterMonitor.set_position(monitor.x, monitor.y);
 
         Main.uiGroup.add_actor(enterMonitor);
+        Main.layoutManager.trackChrome(enterMonitor);
 
         this.enterSignal = enterMonitor.connect(
             'enter-event', () => {

--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -76,7 +76,13 @@ class ClickOverlay {
             'enter-event', () => {
                 this.deactivate();
                 let space = Tiling.spaces.monitors.get(this.monitor);
-                space.workspace.activate(global.get_current_time());
+                if (space.selectedWindow) {
+                    space.workspace.activate_with_focus(
+                        space.selectedWindow,
+                        global.get_current_time());
+                } else {
+                    space.workspace.activate(global.get_current_time());
+                }
                 return Clutter.EVENT_STOP;
             }
         );

--- a/tiling.js
+++ b/tiling.js
@@ -919,11 +919,7 @@ function add_handler(ws, metaWindow) {
 function insertWindow(metaWindow, {existing}) {
 
     let space = spaces.spaceOfWindow(metaWindow);
-    let monitor = Main.layoutManager.monitors[metaWindow.get_monitor()];
-
-    if (monitor !== space.monitor) {
-        return;
-    }
+    let monitor = space.monitor;
 
     if (!add_filter(metaWindow)) {
         return;

--- a/tiling.js
+++ b/tiling.js
@@ -451,6 +451,10 @@ class Spaces extends Map {
             for (let [monitor, space] of this.monitors) {
                 space.clip.raise_top();
             }
+            let selected = activeSpace.selectedWindow;
+            if (selected) {
+                ensureViewport(selected, activeSpace, true);
+            }
             this.spaceContainer.show();
         };
 

--- a/tiling.js
+++ b/tiling.js
@@ -687,8 +687,8 @@ class Spaces extends Map {
         metaWindow.change_workspace(space.workspace);
 
         // This doesn't play nice with the clickoverlay, disable for now
-        // if (focus)
-        //     Main.activateWindow(metaWindow);
+        if (focus)
+            Main.activateWindow(metaWindow);
     }
 }
 
@@ -984,11 +984,12 @@ function insertWindow(metaWindow, {existing}) {
         });
     }
 
-    if (space.workspace === global.screen.get_active_workspace()) {
+    if (metaWindow === global.display.focus_window ||
+        space.workspace === global.screen.get_active_workspace()) {
         ensureViewport(metaWindow, space, true);
         Main.activateWindow(metaWindow);
     } else {
-        ensureViewport(space.selectedWindow, space);
+        ensureViewport(space.selectedWindow, space, true);
     }
 }
 
@@ -1284,11 +1285,15 @@ function moveSizeHandler(metaWindow) {
 
     let frame = metaWindow.get_frame_rect();
     let monitor = space.monitor;
+    if (frame.x + frame.width <= monitor.x ||
+        frame.y + frame.height <= monitor.y ||
+        frame.x >= monitor.x + monitor.width ||
+        frame.y >= monitor.y + monitor.height)
+        return;
     const x = frame.x - monitor.x;
     let onComplete = !noAnimate && (() => space.emit('move-done'));
     move_to(space, metaWindow, {x: x,
                                 onComplete});
-
     updateSelection(space, noAnimate);
 }
 var moveSizeHandlerWrapper = utils.dynamic_function_ref("moveSizeHandler", Me);

--- a/tiling.js
+++ b/tiling.js
@@ -676,6 +676,8 @@ class Spaces extends Map {
     windowEnteredMonitor(screen, index, metaWindow) {
         debug('window-entered-monitor', index, metaWindow.title);
         if (!metaWindow.get_compositor_private()
+            || Scratch.isScratchWindow(metaWindow)
+            || metaWindow.is_on_all_workspaces()
             || !metaWindow.clone
             || metaWindow.clone.visible)
             return;


### PR DESCRIPTION
Better multi monitor support. In particular persist the monitor layout when eg. locking and unlocking gnome-shell.

fixes #58 

Also add basic support for `workspaces-only-on-primary` by putting all the spaces on the primary monitor leaving the rest of the monitors with a regular layout.

closes #57 
