### PR TITLE
Refactor scrolling 

### DIFF
--- a/minimap.js
+++ b/minimap.js
@@ -140,6 +140,7 @@ class Minimap extends Array {
         if (column.length === 0)
             this.splice(index, 1);
         this.container.remove_child(clone);
+        this.layout();
     }
 
     swapped(space, index, targetIndex, row, targetRow) {

--- a/navigator.js
+++ b/navigator.js
@@ -101,10 +101,7 @@ var PreviewedWindowNavigator = new Lang.Class({
         this.monitor = this.space.monitor;
         this.minimaps = new Map();
 
-        this.space.visible.forEach(w => {
-            w.get_compositor_private().hide();
-            w.clone.show();
-        });
+        this.space.startAnimate();
 
         let paperActions = Extension.imports.extension.paperActions;
         let actionId = paperActions.idOf(actionName);
@@ -518,10 +515,7 @@ function switchWorkspace(to, from, callback) {
         Tiling.ensureViewport(selected, toSpace, true);
 
     if (from) {
-        Tiling.spaces.spaceOf(from).getWindows().forEach(w => {
-            w.get_compositor_private().hide();
-            w.clone.show();
-        });
+        Tiling.spaces.spaceOf(from).startAnimate();
     }
 
     Tweener.addTween(toSpace.actor,

--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -218,8 +218,9 @@ var StackOverlay = new Lang.Class({
                 return bail(); // Should normally have a neighbour. Bail!
 
             let frame = neighbour.get_frame_rect();
+            frame.x = neighbour.clone.targetX + space.targetX;
             let max = 75;
-            let width = frame.x - this.monitor.x;
+            let width = frame.x;
             if (space.visible.includes(metaWindow))
                 width = Math.min(width, 75);
             if (width > 75)
@@ -233,7 +234,8 @@ var StackOverlay = new Lang.Class({
                 return bail(); // Should normally have a neighbour. Bail!
 
             let frame = neighbour.get_frame_rect();
-            let width = (this.monitor.x + this.monitor.width) - (frame.x + frame.width);
+            frame.x = neighbour.clone.targetX + space.targetX;
+            let width = this.monitor.width - (frame.x + frame.width);
             if (space.visible.includes(metaWindow))
                 width = Math.min(width, 75);
             if (width > 75)

--- a/tiling.js
+++ b/tiling.js
@@ -454,7 +454,6 @@ class Space extends Array {
             }
             if(this.indexOf(meta_window) < 0 && add_filter(meta_window)) {
                 this.addWindow(meta_window, this.length);
-                this.cloneContainer.add_actor(meta_window.clone);
             }
         })
 

--- a/tiling.js
+++ b/tiling.js
@@ -188,6 +188,13 @@ class Space extends Array {
             }
             x += width + gap;
         }
+        if (x < this.width) {
+            this.targetX = Math.round((this.width - x)/2);
+            Tweener.addTween(this.cloneContainer,
+                             { x: this.targetX,
+                               time: 0.25,
+                               transition: 'easeInOutQuad'});
+        }
     }
 
     getWindows() {
@@ -1136,10 +1143,7 @@ function ensureViewport(meta_window, space, force) {
     let x = Math.round(clone.targetX) + space.targetX;
     let y = panelBox.height + prefs.vertical_margin;
     let gap = prefs.window_gap;
-    if (space.cloneContainer.width < monitor.width) {
-        x = Math.round((monitor.width - space.cloneContainer.width)/2);
-        meta_window  = space[0][0];
-    } else if (index == 0 && x <= 0) {
+    if (index == 0 && x <= 0) {
         // Always align the first window to the display's left edge
         x = 0;
     } else if (index == space.length-1 && x + frame.width >= space.width) {

--- a/tiling.js
+++ b/tiling.js
@@ -1104,6 +1104,10 @@ function ensureViewport(meta_window, space, force) {
         animateDown(space.selectedWindow);
     }
 
+    if (space.selectedWindow !== meta_window) {
+        updateSelection(space, meta_window, true);
+    }
+
     space.selectedWindow = meta_window;
 
     let monitor = space.monitor;
@@ -1111,8 +1115,6 @@ function ensureViewport(meta_window, space, force) {
     let buffer = meta_window.get_buffer_rect();
     let clone = meta_window.clone;
     let dX = frame.x - buffer.x;
-
-    updateSelection(space, true);
 
     let x = Math.round(clone.targetX) + space.targetX;
     let y = panelBox.height + prefs.vertical_margin;
@@ -1160,24 +1162,23 @@ function ensureViewport(meta_window, space, force) {
         x, y, force
     });
 
+    updateSelection(space);
     space.emit('select');
-    updateSelection(space, noAnimate);
 }
 
-function updateSelection(space, noAnimate) {
-    if (!space.selectedWindow)
+function updateSelection(space, metaWindow, noAnimate){
+    metaWindow = metaWindow || space.selectedWindow;
+    if (!metaWindow)
         return;
 
-    let metaWindow = space.selectedWindow;
     let clone = metaWindow.clone;
-    const frame = space.selectedWindow.get_frame_rect();
-    const buffer = space.selectedWindow.get_buffer_rect();
-    const dX = frame.x - buffer.x, dY = frame.x - buffer.y;
+    const frame = metaWindow.get_frame_rect();
+    const buffer = metaWindow.get_buffer_rect();
+    const dX = frame.x - buffer.x, dY = frame.y - buffer.y;
     let protrusion = Math.round(prefs.window_gap/2);
     Tweener.addTween(space.selection,
                      {x: clone.targetX - protrusion,
-                      y: Math.max(frame.y - space.monitor.y,
-                                  panelBox.height + prefs.vertical_margin) - protrusion,
+                      y: clone.targetY - protrusion,
                       width: frame.width + prefs.window_gap,
                       height: frame.height + prefs.window_gap,
                       time: noAnimate ? 0 : 0.25,

--- a/tiling.js
+++ b/tiling.js
@@ -826,6 +826,12 @@ function registerWindow(metaWindow) {
     signals.connect(metaWindow, 'notify::fullscreen', fullscreenWrapper);
     signals.connect(metaWindow, 'size-changed', resizeHandler);
     signals.connect(actor, 'show', showWrapper);
+
+    signals.connect(actor, 'destroy', destroyHandler);
+}
+
+function destroyHandler(actor) {
+    signals.disconnect(actor);
 }
 
 function cloneSizeHandler(metaWindow) {
@@ -978,6 +984,9 @@ function remove_handler(workspace, meta_window) {
     if (!space.removeWindow(meta_window))
         return;
     space.layout();
+
+    if (!meta_window.get_compositor_private())
+        signals.disconnect(meta_window);
 
     // (could be an empty workspace)
     if (space.selectedWindow) {

--- a/tiling.js
+++ b/tiling.js
@@ -845,8 +845,16 @@ function resizeHandler(metaWindow) {
     if (metaWindow !== space.selectedWindow)
         return;
 
-    space.layout(!noAnimate);
-    !noAnimate && ensureViewport(space.selectedWindow, space, true);
+    if (noAnimate) {
+        space.layout(false);
+    } else {
+        // Restore window position when eg. exiting fullscreen
+        !Navigator.navigating
+            && move_to(space, metaWindow, {x: metaWindow.get_frame_rect().x});
+
+        space.layout(true);
+        ensureViewport(space.selectedWindow, space, true);
+    }
 }
 
 function enable() {

--- a/tiling.js
+++ b/tiling.js
@@ -82,6 +82,7 @@ class Space extends Array {
 
         // The windows that should be represented by their WindowActor
         this.visible = [];
+        this._populated = false;
 
 
         let clip = new Clutter.Actor();
@@ -141,6 +142,7 @@ class Space extends Array {
         this.rightStack = 0; // not implemented
 
         this.addAll(oldSpace);
+        this._populated = true;
         oldSpaces.delete(workspace);
     }
 
@@ -214,7 +216,7 @@ class Space extends Array {
             this.splice(index, 0, [metaWindow]);
         }
         metaWindow.clone.reparent(this.cloneContainer);
-        this.layout();
+        this._populated && this.layout();
         this.emit('window-added', metaWindow, index, row);
         return true;
     }

--- a/tiling.js
+++ b/tiling.js
@@ -865,6 +865,7 @@ function resizeHandler(metaWindow) {
 
     if (noAnimate) {
         space.layout(false);
+        space.selection.width = metaWindow.get_frame_rect().width + prefs.window_gap;
     } else {
         // Restore window position when eg. exiting fullscreen
         !Navigator.navigating

--- a/utils.js
+++ b/utils.js
@@ -169,6 +169,14 @@ class Signals extends Map {
         signals.push(object.connect(signal, handler));
     }
 
+    disconnect(object) {
+        let ids = this.get(object);
+        if (ids) {
+            ids.forEach(id => object.disconnect(id));
+            this.delete(object);
+        }
+    }
+
     destroy() {
         for (let [object, signals] of this) {
             signals.forEach(id => object.disconnect(id));


### PR DESCRIPTION
This is somewhat large rewrite of the scroll and layout functionality.

Instead of laying out all the clones and windows when on eg. running `ensureVievport` we now move the `scrollContainer`, syncing the MetaWindow positions when animations are done.

This makes scrolling consistently smooth and easier to deal with, though it does require some simple math doing coordinate transforms. 