### PR TITLE
Refactor interal keybinding API and support schemaless/user-defined keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,26 @@ Available application actions can be listed like this:
 app.action_group.list_actions();
 ```
 
+### User-defined keybindings
+
+`Extension.imports.keybindings.bindkey(keystr, name, handler, options)`
+
+Option              | Values              | Meaning
+--------------------|---------------------|------------------------------------
+`activeInNavigator` | `true`, **`false`** | The keybinding is active when the minimap/navigator is open
+`opensNavigator`    | `true`, **`false`** | The minimap will open when the keybinding is invoked
+
+```javascript
+let Keybindings = Extension.imports.keybindings;
+Keybindings.bindkey("<Super>j", "my-favorite-width", 
+                    (metaWindow) => {
+                        let f = metaWindow.get_frame_rect();
+                        metaWindow.move_resize_frame(true, f.x, f.y, 500, f.h);
+                    },
+                    { activeInNavigator: true });
+```
+
+See 'examples/keybindings.js' for more examples.
 
 ## Prior work ##
 

--- a/examples/keybindings.js
+++ b/examples/keybindings.js
@@ -60,7 +60,7 @@ function swapNeighbours() {
     var Tiling = Extension.imports.tiling;
     var Meta = imports.gi.Meta;
 
-    Keybindings.bindkey("<Super>y", (mw) => {
+    Keybindings.bindkey("<Super>y", "swap-neighbours", (mw) => {
         let space = Tiling.spaces.spaceOfWindow(mw)
         let i = space.indexOf(mw);
         if (space[i+1]) {
@@ -71,7 +71,7 @@ function swapNeighbours() {
 
 
 function showNavigator() {
-    Keybindings.bindkey("<Super>j", () => null, { opensNavigator: true })
+    Keybindings.bindkey("<Super>j", "show-minimap", () => null, { opensNavigator: true })
 }
 
 // listFreeBindings("<super>").join("\n")

--- a/examples/keybindings.js
+++ b/examples/keybindings.js
@@ -39,3 +39,13 @@ function swapNeighbours() {
 function showNavigator() {
     Keybindings.bindkey("<Super>j", () => null, { opensNavigator: true })
 }
+
+// listFreeBindings("<super>").join("\n")
+function listFreeBindings(modifierString) {
+    let free = [];
+    const chars = "abcdefghijklmnopqrstuvxyz1234567890".split("")
+    const symbols = ["minus", "comma", "period", "plus"]
+    return [].concat(chars, symbols).filter(
+        key => Keybindings.getBoundActionId(modifierString+key) === 0
+    ).map(key => modifierString+key)
+}

--- a/examples/keybindings.js
+++ b/examples/keybindings.js
@@ -1,6 +1,7 @@
 var Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.org'];
 var Keybindings = Extension.imports.keybindings;
 var Main = imports.ui.main;
+var Tiling = Extension.imports.tiling;
 
 
 function windowMarks() {
@@ -11,11 +12,22 @@ function windowMarks() {
     }
 
     function gotoMark(k) {
-        return () => marks[k] && Main.activateWindow(marks[k])
+        return () => {
+            let metaWindow = marks[k];
+            if (!metaWindow)
+                return;
+
+            if (metaWindow.has_focus()) {
+                // Can happen when navigator is open
+                Tiling.ensureViewport(metaWindow);
+            } else {
+                Main.activateWindow(metaWindow);
+            }
+        }
     }
 
     for(let k = 0; k < 9; k++) {
-        Keybindings.bindkey(`<Super>${k}`, gotoMark(k))
+        Keybindings.bindkey(`<Super>${k}`, gotoMark(k), {activeInNavigator: true})
         Keybindings.bindkey(`<Super><Shift>${k}`, setMark(k),
                             {activeInNavigator: true})
     }

--- a/examples/keybindings.js
+++ b/examples/keybindings.js
@@ -1,0 +1,41 @@
+var Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.org'];
+var Keybindings = Extension.imports.keybindings;
+var Main = imports.ui.main;
+
+
+function windowMarks() {
+    var marks = {}
+
+    function setMark(k) {
+        return (mw) => marks[k] = mw
+    }
+
+    function gotoMark(k) {
+        return () => marks[k] && Main.activateWindow(marks[k])
+    }
+
+    for(let k = 0; k < 9; k++) {
+        Keybindings.bindkey(`<Super>${k}`, gotoMark(k))
+        Keybindings.bindkey(`<Super><Shift>${k}`, setMark(k),
+                            {activeInNavigator: true})
+    }
+}
+
+
+function swapNeighbours() {
+    var Tiling = Extension.imports.tiling;
+    var Meta = imports.gi.Meta;
+
+    Keybindings.bindkey("<Super>y", (mw) => {
+        let space = Tiling.spaces.spaceOfWindow(mw)
+        let i = space.indexOf(mw);
+        if (space[i+1]) {
+            space.swap(Meta.MotionDirection.RIGHT, space[i+1][0])
+        }
+    }, {activeInNavigator: true})
+}
+
+
+function showNavigator() {
+    Keybindings.bindkey("<Super>j", () => null, { opensNavigator: true })
+}

--- a/examples/keybindings.js
+++ b/examples/keybindings.js
@@ -3,6 +3,27 @@ var Keybindings = Extension.imports.keybindings;
 var Main = imports.ui.main;
 var Tiling = Extension.imports.tiling;
 
+function gotoByIndex() {
+    function goto(k) {
+        return () => {
+            let space = Tiling.spaces.get(global.screen.get_active_workspace());
+            let metaWindow = space.getWindow(k, 0)
+            if (!metaWindow)
+                return;
+
+            if (metaWindow.has_focus()) {
+                // Can happen when navigator is open
+                Tiling.ensureViewport(metaWindow);
+            } else {
+                Main.activateWindow(metaWindow);
+            }
+        }
+    }
+    for(let k = 1; k <= 9; k++) {
+        Keybindings.bindkey(`<Super>${k}`, `goto-coloumn-${i}`,
+                            goto(k-1), {activeInNavigator: true})
+    }
+}
 
 function windowMarks() {
     var marks = {}
@@ -26,10 +47,11 @@ function windowMarks() {
         }
     }
 
-    for(let k = 0; k < 9; k++) {
-        Keybindings.bindkey(`<Super>${k}`, gotoMark(k), {activeInNavigator: true})
-        Keybindings.bindkey(`<Super><Shift>${k}`, setMark(k),
-                            {activeInNavigator: true})
+    for(let k = 0; k <= 9; k++) {
+        Keybindings.bindkey(`<Super>${k}`, `goto-mark-${k}`,
+                            gotoMark(k), {activeInNavigator: true})
+        Keybindings.bindkey(`<Super><Shift>${k}`, `set-mark-${k}`,
+                            setMark(k), {activeInNavigator: true})
     }
 }
 

--- a/extension.js
+++ b/extension.js
@@ -6,7 +6,8 @@ var modules = [
     Extension.imports.liveAltTab, Extension.imports.utils,
     Extension.imports.stackoverlay, Extension.imports.app,
     Extension.imports.kludges, Extension.imports.topbar,
-    Extension.imports.navigator, Extension.imports.settings
+    Extension.imports.navigator, Extension.imports.settings,
+    Extension.imports.keybindings,
 ];
 var [ Tiling, Scratch, LiveAltTab,
         utils, StackOverlay,
@@ -36,7 +37,9 @@ window.PaperWM = Extension;
 var wmSettings;
 var shellSettings;
 var paperSettings;
-var paperActions;
+
+var paperActions = Extension.imports.keybindings.paperActions;
+
 function init() {
     SESSIONID += "#";
     log(`init: ${SESSIONID}`);
@@ -54,63 +57,6 @@ function init() {
 
     shellSettings = new Gio.Settings({ schema_id: "org.gnome.shell.keybindings"});
     paperSettings = convenience.getSettings();
-
-    /*
-      Keep track of some mappings mutter doesn't do/expose
-      - action-name -> action-id mapping
-      - action-id   -> action mapping
-      - action      -> handler
-    */
-    paperActions = {
-        actions: [],
-        nameMap: {},
-        unregisterSchemaless(actionId) {
-            const i = this.actions.findIndex(a => a.id === actionId);
-            if (i < 0) {
-                log("Tried to remove un registered action", actionId);
-                return;
-            }
-            delete this.nameMap[this.actions[i].name];
-            this.actions.splice(i, 1);
-        },
-        registerSchemaless(actionId, actionName, handler) {
-            let action = {
-                id: actionId, name: actionName, handler
-            }
-            this.actions.push(action);
-            this.nameMap[actionName] = action;
-        },
-        register: function(actionName, handler, metaKeyBindingFlags) {
-            let id = registerMutterAction(actionName,
-                                          handler,
-                                          metaKeyBindingFlags);
-            // If the id is NONE the action is already registered
-            if (id === Meta.KeyBindingAction.NONE)
-                return null;
-
-            let action = { id: id
-                           , name: actionName
-                           , handler: handler
-                         };
-            this.actions.push(action);
-            this.nameMap[actionName] = action;
-            return action;
-        },
-        idOf: function(name) {
-            let action = this.byName(name);
-            if (action) {
-                return action.id;
-            } else {
-                return Meta.KeyBindingAction.NONE;
-            }
-        },
-        byName: function(name) {
-            return this.nameMap[name];
-        },
-        byId: function(mutterId) {
-            return this.actions.find(action => action.id == mutterId);
-        }
-    };
 
     let dynamic_function_ref = utils.dynamic_function_ref;
     let as_key_handler = utils.as_key_handler;
@@ -309,43 +255,6 @@ function disable() {
     modules.forEach(m => m.disable && m.disable());
 
     enabled = false;
-}
-
-/**
- * Register a key-bindable action (from our own schema) in mutter.
- *
- * Return the assigned numeric id.
- *
- * NB: use `Meta.keybindings_set_custom_handler` to re-assign the handler.
- */
-function registerMutterAction(action_name, handler, flags) {
-    // Ripped from https://github.com/negesti/gnome-shell-extensions-negesti 
-    // Handles multiple gnome-shell versions
-    flags = flags || Meta.KeyBindingFlags.NONE;
-
-    let settings = convenience.getSettings('org.gnome.Shell.Extensions.PaperWM.Keybindings')
-
-    if (Main.wm.addKeybinding && Shell.ActionMode){ // introduced in 3.16
-        return Main.wm.addKeybinding(action_name,
-                                     settings, flags,
-                                     Shell.ActionMode.NORMAL,
-                                     handler
-                                    );
-    } else if (Main.wm.addKeybinding && Shell.KeyBindingMode) { // introduced in 3.7.5
-        // Shell.KeyBindingMode.NORMAL | Shell.KeyBindingMode.MESSAGE_TRAY,
-        return Main.wm.addKeybinding(action_name,
-                                     settings, flags,
-                                     Shell.KeyBindingMode.NORMAL,
-                                     handler
-                                    );
-    } else {
-        return global.display.add_keybinding(
-            action_name,
-            settings,
-            flags,
-            handler
-        );
-    }
 }
 
 

--- a/extension.js
+++ b/extension.js
@@ -38,7 +38,15 @@ var wmSettings;
 var shellSettings;
 var paperSettings;
 
-var paperActions = Extension.imports.keybindings.paperActions;
+var Keybindings = Extension.imports.keybindings;
+
+function registerPaperAction(actionName, handler, flags) {
+    let settings = convenience.getSettings('org.gnome.Shell.Extensions.PaperWM.Keybindings');
+    Keybindings.registerAction(
+        actionName,
+        handler,
+        {settings: settings, mutterFlags: flags, activeInNavigator: true})
+}
 
 function init() {
     SESSIONID += "#";
@@ -64,96 +72,96 @@ function init() {
     let liveAltTab = dynamic_function_ref('liveAltTab', LiveAltTab);
     let previewNavigate = dynamic_function_ref("preview_navigate", Navigator);
 
-    paperActions.register('live-alt-tab',
+    registerPaperAction('live-alt-tab',
                           liveAltTab);
-    paperActions.register('live-alt-tab-backward',
+    registerPaperAction('live-alt-tab-backward',
                           liveAltTab,
                           Meta.KeyBindingFlags.IS_REVERSED);
 
-    paperActions.register('previous-workspace', previewNavigate);
-    paperActions.register('previous-workspace-backward', previewNavigate);
+    registerPaperAction('previous-workspace', previewNavigate);
+    registerPaperAction('previous-workspace-backward', previewNavigate);
 
-    paperActions.register('move-previous-workspace', previewNavigate);
-    paperActions.register('move-previous-workspace-backward', previewNavigate);
+    registerPaperAction('move-previous-workspace', previewNavigate);
+    registerPaperAction('move-previous-workspace-backward', previewNavigate);
 
-    paperActions.register("switch-next", previewNavigate);
-    paperActions.register("switch-previous", previewNavigate);
+    registerPaperAction("switch-next", previewNavigate);
+    registerPaperAction("switch-previous", previewNavigate);
 
-    paperActions.register("switch-first", Tiling.activateFirstWindow);
-    paperActions.register("switch-last", Tiling.activateLastWindow);
+    registerPaperAction("switch-first", Tiling.activateFirstWindow);
+    registerPaperAction("switch-last", Tiling.activateLastWindow);
 
-    paperActions.register("switch-right", previewNavigate);
-    paperActions.register("switch-left", previewNavigate);
-    paperActions.register("switch-up", previewNavigate);
-    paperActions.register("switch-down", previewNavigate);
+    registerPaperAction("switch-right", previewNavigate);
+    registerPaperAction("switch-left", previewNavigate);
+    registerPaperAction("switch-up", previewNavigate);
+    registerPaperAction("switch-down", previewNavigate);
 
-    paperActions.register("move-left", previewNavigate);
-    paperActions.register("move-right", previewNavigate);
-    paperActions.register("move-up", previewNavigate);
-    paperActions.register("move-down", previewNavigate);
+    registerPaperAction("move-left", previewNavigate);
+    registerPaperAction("move-right", previewNavigate);
+    registerPaperAction("move-up", previewNavigate);
+    registerPaperAction("move-down", previewNavigate);
 
-    paperActions.register("toggle-scratch-layer",
-                          dynamic_function_ref("toggleScratch",
-                                               Scratch));
+    registerPaperAction("toggle-scratch-layer",
+                        dynamic_function_ref("toggleScratch",
+                                             Scratch));
 
-    paperActions.register("toggle-scratch",
-                          utils.as_key_handler("toggle",
-                                               Scratch),
-                          Meta.KeyBindingFlags.PER_WINDOW);
+    registerPaperAction("toggle-scratch",
+                        utils.as_key_handler("toggle",
+                                             Scratch),
+                        Meta.KeyBindingFlags.PER_WINDOW);
 
-    paperActions.register("develop-set-globals",
-                          dynamic_function_ref("setDevGlobals",
-                                               utils));
+    registerPaperAction("develop-set-globals",
+                        dynamic_function_ref("setDevGlobals",
+                                             utils));
 
-    paperActions.register("cycle-width",
-                          as_key_handler("cycleWindowWidth",
-                                         Tiling),
-                          Meta.KeyBindingFlags.PER_WINDOW);
+    registerPaperAction("cycle-width",
+                        as_key_handler("cycleWindowWidth",
+                                       Tiling),
+                        Meta.KeyBindingFlags.PER_WINDOW);
 
-    paperActions.register("center-horizontally",
-                          as_key_handler("centerWindowHorizontally",
-                                         Tiling),
-                          Meta.KeyBindingFlags.PER_WINDOW);
+    registerPaperAction("center-horizontally",
+                        as_key_handler("centerWindowHorizontally",
+                                       Tiling),
+                        Meta.KeyBindingFlags.PER_WINDOW);
 
-    paperActions.register("tile-visible",
-                          as_key_handler("tileVisible",
-                                         Tiling),
-                          Meta.KeyBindingFlags.PER_WINDOW);
+    registerPaperAction("tile-visible",
+                        as_key_handler("tileVisible",
+                                       Tiling),
+                        Meta.KeyBindingFlags.PER_WINDOW);
 
-    paperActions.register('new-window',
-                          as_key_handler('newWindow',
-                                         App),
-                          Meta.KeyBindingFlags.PER_WINDOW);
+    registerPaperAction('new-window',
+                        as_key_handler('newWindow',
+                                       App),
+                        Meta.KeyBindingFlags.PER_WINDOW);
 
-    paperActions.register('close-window',
-                          as_key_handler(
-                              (metaWindow) =>
-                                  metaWindow.delete(global.get_current_time())),
-                          Meta.KeyBindingFlags.PER_WINDOW);
+    registerPaperAction('close-window',
+                        as_key_handler(
+                            (metaWindow) =>
+                                metaWindow.delete(global.get_current_time())),
+                        Meta.KeyBindingFlags.PER_WINDOW);
 
-    paperActions.register('slurp-in',
-                          as_key_handler('slurp',
-                                         Tiling),
-                          Meta.KeyBindingFlags.PER_WINDOW);
+    registerPaperAction('slurp-in',
+                        as_key_handler('slurp',
+                                       Tiling),
+                        Meta.KeyBindingFlags.PER_WINDOW);
 
-    paperActions.register('barf-out',
-                          as_key_handler('barf',
-                                         Tiling),
-                          Meta.KeyBindingFlags.PER_WINDOW);
+    registerPaperAction('barf-out',
+                        as_key_handler('barf',
+                                       Tiling),
+                        Meta.KeyBindingFlags.PER_WINDOW);
 
-    paperActions.register('toggle-maximize-width',
-                          as_key_handler("toggleMaximizeHorizontally",
-                                         Tiling),
-                          Meta.KeyBindingFlags.PER_WINDOW);
+    registerPaperAction('toggle-maximize-width',
+                        as_key_handler("toggleMaximizeHorizontally",
+                                       Tiling),
+                        Meta.KeyBindingFlags.PER_WINDOW);
 
-    paperActions.register('paper-toggle-fullscreen',
-                          as_key_handler(
-                              (metaWindow) => {
-                                  if (metaWindow.fullscreen)
-                                      metaWindow.unmake_fullscreen();
-                                  else
-                                      metaWindow.make_fullscreen();
-                              }), Meta.KeyBindingFlags.PER_WINDOW);
+    registerPaperAction('paper-toggle-fullscreen',
+                        as_key_handler(
+                            (metaWindow) => {
+                                if (metaWindow.fullscreen)
+                                    metaWindow.unmake_fullscreen();
+                                else
+                                    metaWindow.make_fullscreen();
+                            }), Meta.KeyBindingFlags.PER_WINDOW);
 
     initUserConfig();
 }
@@ -166,44 +174,44 @@ function enable() {
     let settings = new Gio.Settings({ schema_id: "org.gnome.desktop.wm.keybindings"});
 
     setKeybinding('switch-applications', // <Super>Tab
-                  paperActions.byName('live-alt-tab').handler);
+                  Keybindings.byMutterName('live-alt-tab').handler);
     setKeybinding('switch-applications-backward',
-                  paperActions.byName('live-alt-tab-backward').handler);
+                  Keybindings.byMutterName('live-alt-tab-backward').handler);
 
     setKeybinding('switch-group', // <Super>Above_tab
-                  paperActions.byName('previous-workspace').handler);
+                  Keybindings.byMutterName('previous-workspace').handler);
     setKeybinding('switch-group-backward',
-                  paperActions.byName('previous-workspace-backward').handler);
+                  Keybindings.byMutterName('previous-workspace-backward').handler);
     setKeybinding('switch-to-workspace-down', // <Super>Page_Down
-                  paperActions.byName('previous-workspace').handler);
+                  Keybindings.byMutterName('previous-workspace').handler);
 
     setKeybinding('switch-to-workspace-up', // <Super>Page_Up
-                  paperActions.byName('previous-workspace-backward').handler);
+                  Keybindings.byMutterName('previous-workspace-backward').handler);
 
     setKeybinding('maximize', // <Super>Up
-                  paperActions.byName('switch-up').handler);
+                  Keybindings.byMutterName('switch-up').handler);
     setKeybinding('unmaximize', // <Super>Down
-                  paperActions.byName('switch-down').handler);
+                  Keybindings.byMutterName('switch-down').handler);
 
     setKeybinding('focus-active-notification', // `<Super>N`
-                  paperActions.byName('new-window').handler);
+                  Keybindings.byMutterName('new-window').handler);
 
     setKeybinding('restore-shortcuts', // `<Super>Escape`
-                  paperActions.byName('toggle-scratch-layer').handler);
+                  Keybindings.byMutterName('toggle-scratch-layer').handler);
 
     setKeybinding('toggle-tiled-right', // <Super>Right
-                  paperActions.byName('switch-right').handler);
+                  Keybindings.byMutterName('switch-right').handler);
 
     setKeybinding('toggle-tiled-left', // <Super>Left
-                  paperActions.byName('switch-left').handler);
+                  Keybindings.byMutterName('switch-left').handler);
 
 
     setKeybinding('switch-to-workspace-1', // <Super>Home
-                  paperActions.byName('switch-first').handler);
+                  Keybindings.byMutterName('switch-first').handler);
     setKeybinding('switch-to-workspace-last', // <Super>End
-                  paperActions.byName('switch-last').handler);
+                  Keybindings.byMutterName('switch-last').handler);
 
-    paperActions.actions.forEach(a => {
+    Keybindings.actions.forEach(a => {
         setKeybinding(a.name, a.handler);
     });
 
@@ -244,7 +252,7 @@ function disable() {
     Meta.keybindings_set_custom_handler('switch-to-workspace-down', null);
     Meta.keybindings_set_custom_handler('switch-to-workspace-up', null);
 
-    paperActions.actions.forEach(a => {
+    Keybindings.actions.forEach(a => {
         setKeybinding(a.name, () => {});
     });
 

--- a/extension.js
+++ b/extension.js
@@ -211,10 +211,6 @@ function enable() {
     setKeybinding('switch-to-workspace-last', // <Super>End
                   Keybindings.byMutterName('switch-last').handler);
 
-    Keybindings.actions.forEach(a => {
-        setKeybinding(a.name, a.handler);
-    });
-
     // Only enable modules after disable have been run
     if (enabled) {
         log('enable called without calling disable');
@@ -251,10 +247,6 @@ function disable() {
     Meta.keybindings_set_custom_handler('switch-to-workspace-last', null);
     Meta.keybindings_set_custom_handler('switch-to-workspace-down', null);
     Meta.keybindings_set_custom_handler('switch-to-workspace-up', null);
-
-    Keybindings.actions.forEach(a => {
-        setKeybinding(a.name, () => {});
-    });
 
     if (!enabled)
         return;

--- a/extension.js
+++ b/extension.js
@@ -64,6 +64,22 @@ function init() {
     paperActions = {
         actions: [],
         nameMap: {},
+        unregisterSchemaless(actionId) {
+            const i = this.actions.findIndex(a => a.id === actionId);
+            if (i < 0) {
+                log("Tried to remove un registered action", actionId);
+                return;
+            }
+            delete this.nameMap[this.actions[i].name];
+            this.actions.splice(i, 1);
+        },
+        registerSchemaless(actionId, actionName, handler) {
+            let action = {
+                id: actionId, name: actionName, handler
+            }
+            this.actions.push(action);
+            this.nameMap[actionName] = action;
+        },
         register: function(actionName, handler, metaKeyBindingFlags) {
             let id = registerMutterAction(actionName,
                                           handler,
@@ -362,6 +378,7 @@ function installConfig() {
         settings.set_boolean("has-installed-config-template", true);
 
     } catch(e) {
+        errorNotification("PaperWM", "Failed to install user config", e.stack);
         utils.debug("#rc", "Install failed", e.message);
     }
 }

--- a/keybindings.js
+++ b/keybindings.js
@@ -120,6 +120,15 @@ function openNavigatorHandler(actionName, keystr) {
     }
 }
 
+function getBoundActionId(keystr) {
+    let [dontcare, keycodes, mask] =
+        Gtk.accelerator_parse_with_keycode(keystr);
+    if(keycodes.length > 1) {
+        throw new Error("Multiple keycodes " + keycodes + " " + keystr);
+    }
+    const rawMask = devirtualizeMask(mask);
+    return global.display.get_keybinding_action(keycodes[0], rawMask);
+}
 
 function handleAccelerator(display, actionId, deviceId, timestamp) {
     const action = actionIdMap[actionId];

--- a/keybindings.js
+++ b/keybindings.js
@@ -78,33 +78,14 @@ var paperActions = {
  * NB: use `Meta.keybindings_set_custom_handler` to re-assign the handler.
  */
 function registerMutterAction(action_name, handler, flags) {
-    // Ripped from https://github.com/negesti/gnome-shell-extensions-negesti 
-    // Handles multiple gnome-shell versions
     flags = flags || Meta.KeyBindingFlags.NONE;
 
     let settings = convenience.getSettings('org.gnome.Shell.Extensions.PaperWM.Keybindings')
 
-    if (Main.wm.addKeybinding && Shell.ActionMode){ // introduced in 3.16
-        return Main.wm.addKeybinding(action_name,
-                                     settings, flags,
-                                     Shell.ActionMode.NORMAL,
-                                     handler
-                                    );
-    } else if (Main.wm.addKeybinding && Shell.KeyBindingMode) { // introduced in 3.7.5
-        // Shell.KeyBindingMode.NORMAL | Shell.KeyBindingMode.MESSAGE_TRAY,
-        return Main.wm.addKeybinding(action_name,
-                                     settings, flags,
-                                     Shell.KeyBindingMode.NORMAL,
-                                     handler
-                                    );
-    } else {
-        return global.display.add_keybinding(
-            action_name,
-            settings,
-            flags,
-            handler
-        );
-    }
+    return Main.wm.addKeybinding(action_name,
+                                 settings, flags,
+                                 Shell.ActionMode.NORMAL,
+                                 handler);
 }
 
 

--- a/keybindings.js
+++ b/keybindings.js
@@ -1,0 +1,142 @@
+var Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.org'];
+var Me = Extension.imports.keybindings;
+var Gdk = imports.gi.Gdk;
+var Gtk = imports.gi.Gtk;
+var Meta = imports.gi.Meta;
+
+var Utils = Extension.imports.utils;
+var Main = imports.ui.main;
+var Shell = imports.gi.Shell;
+
+var signals = new Utils.Signals();
+
+var Navigator = Extension.imports.navigator;
+var paperActions = Extension.imports.extension.paperActions;
+
+var actionIdMap = {}; // actionID -> handler
+var keycomboMap = {}
+var actions = [];
+
+function devirtualizeMask(gdkVirtualMask) {
+    const keymap = Gdk.Keymap.get_default();
+    let [success, rawMask] = keymap.map_virtual_modifiers(gdkVirtualMask);
+    if (!success)
+        throw new Error("Couldn't devirtualize mask " + gdkVirtualMask);
+    return rawMask;
+}
+
+function rawMaskOfKeystr(keystr) {
+    let [dontcare, keycodes, mask] =
+        Gtk.accelerator_parse_with_keycode(keystr);
+    return devirtualizeMask(mask);
+}
+
+/**
+ * Two keystrings can represent the same key combination
+ */
+function keystrToKeycombo(keystr) {
+    // ASSUMPTION: Gtk parses accelerators mostly the same as mutter
+    let [key, mask] = Gtk.accelerator_parse(keystr);
+    return `${key}|${mask}`; // Since js doesn't have a mapable tuple type
+}
+
+function bindkey(keystr, handler, options={}) {
+    let { opensNavigator, activeInNavigator, name } = options;
+    if (opensNavigator)
+        activeInNavigator = true;
+
+    let keycombo = keystrToKeycombo(keystr);
+    let boundAction = keycomboMap[keycombo]
+    if (boundAction) {
+        log("Rebinding", keystr);
+        unbindkey(boundAction.id)
+    }
+    handler = Utils.as_key_handler(handler)
+
+    let actionId = global.display.grab_accelerator(keystr);
+    if (actionId === Meta.KeyBindingAction.NONE) {
+        // Failed to grab. Binding probably already taken.
+        log("Failed to grab")
+        return null;
+    }
+    let actionName = Meta.external_binding_name_for_action(actionId);
+
+    let action = {
+        id: actionId,
+        combo: keycombo,
+        name: actionName,
+        handler: opensNavigator
+            ? openNavigatorHandler(actionName, keystr)
+            : handler,
+        options: options,
+    };
+
+    Main.wm.allowKeybinding(actionName, Shell.ActionMode.ALL);
+    actionIdMap[actionId] = action;
+    keycomboMap[keycombo] = action;
+
+    if (activeInNavigator) {
+        paperActions.registerSchemaless(actionId, actionName, handler);
+    }
+
+    return actionId;
+}
+
+function unbindkey(actionIdOrKeystr) {
+    let actionId;
+    if (typeof(actionId) === "string") {
+        const action = keycomboMap[keystrToKeycombo(actionIdOrKeystr)];
+        actionId = action && action.id
+    } else {
+        actionId = actionIdOrKeystr;
+    }
+
+    const action = actionIdMap[actionId];
+    if (!action) {
+        log("Attempted to unbind unbound keystr/action", actionIdOrKeystr);
+        return null;
+    }
+
+    delete keycomboMap[action.combo];
+    delete actionIdMap[action.id];
+    if (action.options.navigator) {
+        paperActions.unregisterSchemaless(action.id);
+    }
+    
+    return global.display.ungrab_accelerator(actionId);
+}
+
+function openNavigatorHandler(actionName, keystr) {
+    const mask = rawMaskOfKeystr(keystr) & 0xff;
+
+    const dummyEvent = {
+        get_name: () => actionName,
+        get_mask: () => mask,
+        is_reversed: () => false,
+    }
+    return function(display, screen, metaWindow) {
+        return Navigator.preview_navigate(
+            display, screen, metaWindow, dummyEvent);
+    }
+}
+
+
+function handleAccelerator(display, actionId, deviceId, timestamp) {
+    const action = actionIdMap[actionId];
+    if (action) {
+        log("user.js keybinding activated", actionId, action.handler);
+        action.handler(display, null, global.display.focus_window);
+    }
+}
+
+function enable() {
+    signals.connect(
+        global.display,
+        'accelerator-activated',
+        Utils.dynamic_function_ref(handleAccelerator.name, Me)
+    );
+}
+
+function disable() {
+    signals.destroy();
+}

--- a/liveAltTab.js
+++ b/liveAltTab.js
@@ -7,6 +7,7 @@ var Main = imports.ui.main;
 
 var Scratch = Extension.imports.scratch;
 var Tiling = Extension.imports.tiling;
+var Keybindings = Extension.imports.keybindings;
 var utils = Extension.imports.utils;
 var debug = utils.debug;
 
@@ -35,7 +36,6 @@ var LiveAltTab = Lang.Class({
     _keyPressHandler: function(keysym, action) {
         // After the first super-tab the action we get is apparently
         // SWITCH_APPLICATIONS so we need to case on those too.
-        let paperActions = Extension.imports.extension.paperActions;
         switch(action) {
         case Meta.KeyBindingAction.SWITCH_APPLICATIONS:
             action = Meta.KeyBindingAction.SWITCH_WINDOWS;
@@ -43,11 +43,11 @@ var LiveAltTab = Lang.Class({
         case Meta.KeyBindingAction.SWITCH_APPLICATIONS_BACKWARD:
             action = Meta.KeyBindingAction.SWITCH_WINDOWS_BACKWARD;
             break;
-        case paperActions.idOf('live-alt-tab'):
+        case Keybindings.idOf('live-alt-tab'):
             action = Meta.KeyBindingAction.SWITCH_WINDOWS;
             break;
             ;;
-        case paperActions.idOf('live-alt-tab-backward'):
+        case Keybindings.idOf('live-alt-tab-backward'):
             action = Meta.KeyBindingAction.SWITCH_WINDOWS_BACKWARD;
             break;
             ;;

--- a/navigator.js
+++ b/navigator.js
@@ -18,6 +18,7 @@ var TopBar = Extension.imports.topbar;
 var Scratch = Extension.imports.scratch;
 var Minimap = Extension.imports.minimap;
 var Tiling = Extension.imports.tiling;
+var Keybindings = Extension.imports.keybindings;
 var utils = Extension.imports.utils;
 var debug = utils.debug;
 
@@ -103,8 +104,7 @@ var PreviewedWindowNavigator = new Lang.Class({
 
         this.space.startAnimate();
 
-        let paperActions = Extension.imports.extension.paperActions;
-        let actionId = paperActions.idOf(actionName);
+        let actionId = Keybindings.idOf(actionName);
         if(actionId === Meta.KeyBindingAction.NONE) {
             try {
                 // Check for built-in actions
@@ -247,90 +247,88 @@ var PreviewedWindowNavigator = new Lang.Class({
     },
 
     _doAction: function(mutterActionId) {
-        let paperActions = Extension.imports.extension.paperActions;
-
         switch (mutterActionId) {
         case Meta.KeyBindingAction.SWITCH_GROUP:
-            mutterActionId = paperActions.idOf('previous-workspace');
+            mutterActionId = Keybindings.idOf('previous-workspace');
             break;
         case Meta.KeyBindingAction.SWITCH_GROUP_BACKWARD:
-            mutterActionId = paperActions.idOf('previous-workspace-backward');
+            mutterActionId = Keybindings.idOf('previous-workspace-backward');
             break;
         case Meta.KeyBindingAction.WORKSPACE_UP: // PageUp
-            mutterActionId = paperActions.idOf('previous-workspace-backward');
+            mutterActionId = Keybindings.idOf('previous-workspace-backward');
             break;
         case Meta.KeyBindingAction.WORKSPACE_DOWN: // PageDown
-            mutterActionId = paperActions.idOf('previous-workspace');
+            mutterActionId = Keybindings.idOf('previous-workspace');
             break;
         case Meta.KeyBindingAction.TOGGLE_TILED_RIGHT: // Right
-            mutterActionId = paperActions.idOf('switch-right');
+            mutterActionId = Keybindings.idOf('switch-right');
             break;
         case Meta.KeyBindingAction.TOGGLE_TILED_LEFT: // Left
-            mutterActionId = paperActions.idOf('switch-left');
+            mutterActionId = Keybindings.idOf('switch-left');
             break;
         case Meta.KeyBindingAction.MAXIMIZE: // Up
-            mutterActionId = paperActions.idOf('switch-up');
+            mutterActionId = Keybindings.idOf('switch-up');
             break;
         case Meta.KeyBindingAction.UNMAXIMIZE: // Down
-            mutterActionId = paperActions.idOf('switch-down');
+            mutterActionId = Keybindings.idOf('switch-down');
             break;
         case Meta.KeyBindingAction.CLOSE:
-            mutterActionId = paperActions.idOf('close-window');
+            mutterActionId = Keybindings.idOf('close-window');
             break;
         }
 
-        if (mutterActionId === paperActions.idOf("switch-next")) {
+        if (mutterActionId === Keybindings.idOf("switch-next")) {
             this._select(this._next());
             return true;
-        } else if (mutterActionId === paperActions.idOf("switch-previous")) {
+        } else if (mutterActionId === Keybindings.idOf("switch-previous")) {
             this._select(this._previous());
             return true;
-        } else if (mutterActionId === paperActions.idOf("switch-right")) {
+        } else if (mutterActionId === Keybindings.idOf("switch-right")) {
             this._switch(Meta.MotionDirection.RIGHT);
             return true;
-        } else if (mutterActionId === paperActions.idOf("switch-left")) {
+        } else if (mutterActionId === Keybindings.idOf("switch-left")) {
             this._switch(Meta.MotionDirection.LEFT);
             return true;
-        } else if (mutterActionId === paperActions.idOf("switch-up")) {
+        } else if (mutterActionId === Keybindings.idOf("switch-up")) {
             this._switch(Meta.MotionDirection.UP);
             return true;
-        } else if (mutterActionId === paperActions.idOf("switch-down")) {
+        } else if (mutterActionId === Keybindings.idOf("switch-down")) {
             this._switch(Meta.MotionDirection.DOWN);
             return true;
-        } else if (mutterActionId === paperActions.idOf("move-left")) {
+        } else if (mutterActionId === Keybindings.idOf("move-left")) {
             this._showMinimap();
             this.space.swap(Meta.MotionDirection.LEFT);
             return true;
-        } else if (mutterActionId === paperActions.idOf("move-right")) {
+        } else if (mutterActionId === Keybindings.idOf("move-right")) {
             this._showMinimap();
             this.space.swap(Meta.MotionDirection.RIGHT);
             return true;
-        } else if (mutterActionId === paperActions.idOf("move-up")) {
+        } else if (mutterActionId === Keybindings.idOf("move-up")) {
             this._showMinimap();
             this.space.swap(Meta.MotionDirection.UP);
             return true;
-        } else if (mutterActionId === paperActions.idOf("move-down")) {
+        } else if (mutterActionId === Keybindings.idOf("move-down")) {
             this._showMinimap();
             this.space.swap(Meta.MotionDirection.DOWN);
             return true;
         } else if (mutterActionId
-                   === paperActions.idOf('previous-workspace-backward')) {
+                   === Keybindings.idOf('previous-workspace-backward')) {
             this.selectSpace(Meta.MotionDirection.UP);
             return true;
-        } else if (mutterActionId === paperActions.idOf('previous-workspace')) {
+        } else if (mutterActionId === Keybindings.idOf('previous-workspace')) {
             this.selectSpace(Meta.MotionDirection.DOWN);
             return true;
         } else if (mutterActionId
-                   === paperActions.idOf('move-previous-workspace')) {
+                   === Keybindings.idOf('move-previous-workspace')) {
             this.selectSpace(Meta.MotionDirection.DOWN, true);
             return true;
         } else if (mutterActionId
-                   === paperActions.idOf('move-previous-workspace-backward')) {
+                   === Keybindings.idOf('move-previous-workspace-backward')) {
             this.selectSpace(Meta.MotionDirection.UP, true);
             return true;
         } else {
-            let action = paperActions.byId(mutterActionId);
-            if (action) {
+            let action = Keybindings.byId(mutterActionId);
+            if (action && action.options.activeInNavigator) {
                 log("Show minimap and do action..")
                 this._showMinimap();
                 let metaWindow = this.space.selectedWindow;

--- a/navigator.js
+++ b/navigator.js
@@ -331,6 +331,8 @@ var PreviewedWindowNavigator = new Lang.Class({
         } else {
             let action = paperActions.byId(mutterActionId);
             if (action) {
+                log("Show minimap and do action..")
+                this._showMinimap();
                 let metaWindow = this.space.selectedWindow;
                 action.handler(null, null, metaWindow);
                 return true;

--- a/utils.js
+++ b/utils.js
@@ -13,6 +13,10 @@ function debug() {
         print(Array.prototype.join.call(arguments, " | "));
 }
 
+function warn(...args) {
+    print("WARNING:", ...args);
+}
+
 function assert(condition, message, ...dump) {
     if (!condition) {
         throw new Error(message + "\n", dump);

--- a/utils.js
+++ b/utils.js
@@ -13,6 +13,12 @@ function debug() {
         print(Array.prototype.join.call(arguments, " | "));
 }
 
+function assert(condition, message, ...dump) {
+    if (!condition) {
+        throw new Error(message + "\n", dump);
+    }
+}
+
 function print_stacktrace(error) {
     let trace;
     if (!error) {


### PR DESCRIPTION
Some ramblings:


## Current design (this PR)
### Action
An action is simply a described function that can be invoked by the user with context depending arguments. The actual function is called the action handler.
Same as (interactive) functions in emacs.
The handler have a defined interface\: (not yet stabilized)
`handler(selectedWindow, selectedSpace, ...)`

#### Options
opensNavigator: open the navigator on invocation (when invoked through a binding)
activeInNavigator: action makes sense when navigator is open
activeInScratch: action makes sense when the scratch layer have focus

### Keybindings (accelerators (ie. key combos) bound actions)
It makes sense to slightly alter what the action does depending on how it's invoked(?)

The example in mind is actions that opens the navigator: currently it doesn't make sense to open it unless invoked through a binding since the navigator can only be open while the <kbd>Super</kbd> key is held down.

The "opensNavigator" action-option is thus born. (the name doesn't really communicate that it only holds when invoked through a binding..)

Thus: we store internally two action handlers, one that's invoked for through bindings, and one otherwise.

## Critique
### action-option: opensNavigator

As defined now this is really a keybinding-option, not an action-option.

In the future we might have a sticky-mode for the navigator and then it might make sense to open it regardless of the invocation method. BUT: its not obvious that the two behaviors (open-navigator when invoked through a binding and open-sticky-navigator when invoked by other means) should be linked?)

An alternative would be to outsource this to the action-handler: 
```
handler(selectedWindow, ..., invokingBinding) {
  if(invokingBinding) {
      // let navigator = 
      ensureNavigatorOpen()
  }
  actualHandler(selectedWindow, ...)
  // actualHandler(selectedWindow, ..., navigator)
}
```

One downside with that approach is lack of configurability: One must change the handler to change the behavior. Then again - maybe fine-grained control is not needed: either you want the navigator to pop up on bindings, or not?

### action-option: activeIn*
This is a specification of which context the binding is designed for. A list of flags is maybe not the most elegant mechanism?

