### PR TITLE
Fix some minor typos/spelling in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Pressing <kbd>Super</kbd><kbd>I</kbd> will move the window to the right below th
 
 Pressing <kbd>Super</kbd><kbd>Above_Tab</kbd> will slide the active workspace down revealing the stack as shown in the above screenshot. You can then flip through the most recently used workspaces with repeated <kbd>Above_Tab</kbd> presses while holding <kbd>Super</kbd> downe. <kbd>Above_Tab</kbd> is the key above <kbd>Tab</kbd> (<kbd>\`</kbd> in a US qwerty layout). Like alt-tab <kbd>Shift</kbd> is added to move in reverse order.
 
-The workspace name is shown in the top left corner replacing the the `Activities` button adding a few enhancements. Scrolling on the name will let you browse the workpace stack just like <kbd>Super</kbd><kbd>Above_Tab</kbd>. Right clicking the name lets you access and change the workspace name and the background color:
+The workspace name is shown in the top left corner replacing the `Activities` button adding a few enhancements. Scrolling on the name will let you browse the workspace stack just like <kbd>Super</kbd><kbd>Above_Tab</kbd>. Right clicking the name lets you access and change the workspace name and the background color:
 
 ![The workspace menu](https://github.com/paperwm/media/blob/master/menu.png)
 
@@ -81,7 +81,7 @@ There's a single scrollable tiling per workspace. Adding another monitor simply 
 ![The floating scratch layer, with the alt tab menu open](https://github.com/paperwm/media/blob/master/scratch.png)
 
 The scratch layer is an escape hatch to a familiar floating layout. This layer is intended to store windows that are globally useful like chat applications and in general serve as the kitchen sink.
-When the scratch layer is active it will float above the tiled windows, when hidden the windows will be minimized. 
+When the scratch layer is active it will float above the tiled windows, when hidden the windows will be minimized.
 
 Opening a window when the scratch layer is active will make it float automatically.
 
@@ -149,7 +149,7 @@ app.action_group.list_actions();
 
 ### Keybindings
 
-Due to limitations in the mutter keybinding API we need to steal some built in Gnome Shell actions by default. Eg. the builtin action `switch-group` with the default <kbd>Super</kbd><kbd>Above_Tab</kbd> keybinding is overriden to cycle through recently used workspaces. If an overriden action have several keybindings they will unfortunately all activate the override, so for instance because <kbd>Alt</kbd><kbd>Above_Tab</kbd> is also bound to `switch-group` it will be overriden by default. If you want to avoid this, eg. you want <kbd>Alt</kbd><kbd>Tab</kbd> and <kbd>Alt</kbd><kbd>Above_Tab</kbd> to use the builtin behavior simply remove the conflicts (ie. <kbd>Super</kbd><kbd>Tab</kbd> and <kbd>Super</kbd><kbd>Above_Tab</kbd> and their <kbd>Shift</kbd> variants) from `/org/gnome/desktop/wm/keybindings/switch-group` (no restarts required).
+Due to limitations in the mutter keybinding API we need to steal some built in Gnome Shell actions by default. Eg. the builtin action `switch-group` with the default <kbd>Super</kbd><kbd>Above_Tab</kbd> keybinding is overridden to cycle through recently used workspaces. If an overridden action has several keybindings they will unfortunately all activate the override, so for instance because <kbd>Alt</kbd><kbd>Above_Tab</kbd> is also bound to `switch-group` it will be overridden by default. If you want to avoid this, eg. you want <kbd>Alt</kbd><kbd>Tab</kbd> and <kbd>Alt</kbd><kbd>Above_Tab</kbd> to use the builtin behavior simply remove the conflicts (ie. <kbd>Super</kbd><kbd>Tab</kbd> and <kbd>Super</kbd><kbd>Above_Tab</kbd> and their <kbd>Shift</kbd> variants) from `/org/gnome/desktop/wm/keybindings/switch-group` (no restarts required).
 
 #### User defined keybindings
 

--- a/schemas/org.gnome.shell.extensions.org-scrollwm.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.org-scrollwm.gschema.xml
@@ -201,7 +201,7 @@
        '#494066', '#826647', '#4B6983', '#807D74', '#5D7555', '#884631',
        '#625B81', '#B39169', '#7590AE', '#BAB5AB', '#83A67F', '#C1665A',
        '#887FA3', '#E0C39E']]]></default>
-      <summary>Minimum gap between windows</summary>
+      <summary>Workspace colors</summary>
     </key>
 
     <child name="keybindings" schema="org.gnome.Shell.Extensions.PaperWM.Keybindings"/>


### PR DESCRIPTION
Fix minor spelling and grammar mistakes in README.md and the workspace colors label in gschema.xml.