### PR TITLE
Alt tab with instant preview

### DIFF
--- a/keybindings.js
+++ b/keybindings.js
@@ -66,11 +66,12 @@ function init() {
     let liveAltTab = dynamic_function_ref('liveAltTab', LiveAltTab);
     let previewNavigate = dynamic_function_ref("preview_navigate", Navigator);
 
-    registerPaperAction('live-alt-tab',
-                          liveAltTab);
-    registerPaperAction('live-alt-tab-backward',
-                          liveAltTab,
-                          Meta.KeyBindingFlags.IS_REVERSED);
+    let settings = convenience.getSettings('org.gnome.Shell.Extensions.PaperWM.Keybindings');
+    registerAction('live-alt-tab',
+                   liveAltTab, {settings});
+    registerAction('live-alt-tab-backward',
+                   liveAltTab,
+                   {settings, mutterFlags: Meta.KeyBindingFlags.IS_REVERSED});
 
     registerNavigatorAction('previous-workspace', Tiling.selectPreviousSpace);
     registerNavigatorAction('previous-workspace-backward',

--- a/liveAltTab.js
+++ b/liveAltTab.js
@@ -18,7 +18,12 @@ var LiveAltTab = Lang.Class({
     Name: 'LiveAltTab',
     Extends: AltTab.WindowSwitcherPopup,
 
-    _getWindowList: function () {
+    _init(reverse) {
+        this.reverse = reverse;
+        this.parent();
+    },
+
+    _getWindowList: function (reverse) {
         let tabList = global.display.get_tab_list(
             Meta.TabList.NORMAL_ALL,
             global.workspace_manager.get_active_workspace())
@@ -26,11 +31,11 @@ var LiveAltTab = Lang.Class({
 
         let scratch = Scratch.getScratchWindows();
 
-        if (Scratch.isScratchActive()) {
-            return scratch.concat(tabList);
-        } else {
+        if (Scratch.isScratchWindow(global.display.focus_window)) {
             // Access scratch windows in mru order with shift-super-tab
-            return tabList.concat(scratch.reverse());
+            return scratch.concat(this.reverse ? tabList.reverse() : tabList);
+        } else {
+            return tabList.concat(this.reverse ? scratch.reverse() : scratch);
         }
     },
 
@@ -159,6 +164,6 @@ var LiveAltTab = Lang.Class({
 })
 
 function liveAltTab(meta_window, space, {display, screen, binding}) {
-    let tabPopup = new LiveAltTab();
+    let tabPopup = new LiveAltTab(binding.is_reversed());
     tabPopup.show(binding.is_reversed(), binding.get_name(), binding.get_mask());
 }

--- a/liveAltTab.js
+++ b/liveAltTab.js
@@ -89,13 +89,13 @@ var LiveAltTab = Lang.Class({
             break;
             ;;
         }
-        let action = Keybindings.byId(mutterActionId);
-        if (action && action.options.activeInNavigator) {
-            let space = Tiling.spaces.selectedSpace;
-            let metaWindow = space.selectedWindow;
-            action.handler(metaWindow, space);
-            return true;
-        }
+        // let action = Keybindings.byId(mutterActionId);
+        // if (action && action.options.activeInNavigator) {
+        //     let space = Tiling.spaces.selectedSpace;
+        //     let metaWindow = space.selectedWindow;
+        //     action.handler(metaWindow, space);
+        //     return true;
+        // }
         return this.parent(keysym, mutterActionId);
     },
 

--- a/utils.js
+++ b/utils.js
@@ -93,6 +93,26 @@ function isPointInsideActor(actor, x, y) {
         && (actor.y <= y && y <= actor.y+actor.height);
 }
 
+function setBackgroundImage(actor, resource_path) {
+    // resource://{resource_path}
+    const Clutter = imports.gi.Clutter;
+    const GdkPixbuf = imports.gi.GdkPixbuf;
+    const Cogl = imports.gi.Cogl;
+
+    let image = new Clutter.Image();
+
+    let pixbuf = GdkPixbuf.Pixbuf.new_from_resource(resource_path)
+
+    image.set_data(pixbuf.get_pixels() ,
+                   pixbuf.get_has_alpha() ? Cogl.PixelFormat.RGBA_8888
+                   : Cogl.PixelFormat.RGB_888,
+                   pixbuf.get_width() ,
+                   pixbuf.get_height() ,
+                   pixbuf.get_rowstride());
+    actor.set_content(image);
+    actor.content_repeat = Clutter.ContentRepeat.BOTH
+}
+
 
 //// Debug and development utils
 


### PR DESCRIPTION
Replace the current alt-tab behavior (which will go a bunch of back and forth) with having instant previews of the window at the actual position it will land if selected.