### PR TITLE
Port to 3.32

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 PaperWM is an experimental [Gnome Shell](https://wiki.gnome.org/Projects/GnomeShell) extension providing scrollable tiling of windows and per monitor workspaces. It's inspired by paper notebooks and tiling window managers.
 
-Supports Gnome Shell 3.28 and 3.30 on X11 and wayland.
+Supports Gnome Shell 3.28, 3.30 and 3.32 on X11 and wayland.
 
 While technically an [extension](https://wiki.gnome.org/Projects/GnomeShell/Extensions) it's to a large extent built on top of the Gnome desktop rather than merely extending it.
 

--- a/liveAltTab.js
+++ b/liveAltTab.js
@@ -1,6 +1,5 @@
 var Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.org'];
 var Clutter = imports.gi.Clutter;
-var Lang = imports.lang;
 var Meta = imports.gi.Meta;
 var AltTab = imports.ui.altTab;
 var Main = imports.ui.main;
@@ -14,16 +13,14 @@ var debug = utils.debug;
 
 var prefs = Extension.imports.settings.prefs;
 
-var LiveAltTab = Lang.Class({
-    Name: 'LiveAltTab',
-    Extends: AltTab.WindowSwitcherPopup,
+var LiveAltTab = class LiveAltTab extends AltTab.WindowSwitcherPopup {
 
-    _init(reverse) {
+    constructor(reverse) {
         this.reverse = reverse;
-        this.parent();
-    },
+        super();
+    }
 
-    _getWindowList: function (reverse) {
+    _getWindowList(reverse) {
         let tabList = global.display.get_tab_list(
             Meta.TabList.NORMAL_ALL,
             global.workspace_manager.get_active_workspace())
@@ -37,9 +34,9 @@ var LiveAltTab = Lang.Class({
         } else {
             return tabList.concat(this.reverse ? scratch.reverse() : scratch);
         }
-    },
+    }
 
-    _initialSelection: function(backward, actionName) {
+    _initialSelection(backward, actionName) {
         this._block = Main.wm._blockAnimations;
         Main.wm._blockAnimations = true;
         this.space = Tiling.spaces.selectedSpace;
@@ -65,10 +62,10 @@ var LiveAltTab = Lang.Class({
         Main.uiGroup.insert_child_above(fog, global.window_group);
         this.fog = fog;
 
-        this.parent(backward, actionName);
-    },
+        super._initialSelection(backward, actionName);
+    }
 
-    _keyPressHandler: function(keysym, mutterActionId) {
+    _keyPressHandler(keysym, mutterActionId) {
         if (keysym === Clutter.KEY_Escape)
             return Clutter.EVENT_PROPAGATE;
         // After the first super-tab the mutterActionId we get is apparently
@@ -96,10 +93,10 @@ var LiveAltTab = Lang.Class({
         //     action.handler(metaWindow, space);
         //     return true;
         // }
-        return this.parent(keysym, mutterActionId);
-    },
+        return super._keyPressHandler(keysym, mutterActionId);
+    }
 
-    _select: function(num) {
+    _select(num) {
 
         let from = this._switcherList.windows[this._selectedIndex];
         let to = this._switcherList.windows[num];
@@ -111,11 +108,11 @@ var LiveAltTab = Lang.Class({
         let clone = new Clutter.Clone({source: actor});
         clone.position = actor.position;
 
-            let space = Tiling.spaces.spaceOfWindow(to);
+        let space = Tiling.spaces.spaceOfWindow(to);
         if (space.indexOf(to) !== -1) {
             let x = Tiling.ensuredX(to, space) + space.monitor.x;
-        clone.x = x + space.monitor.x ;
-        clone.x -= frame.x - actor.x;
+            clone.x = x + space.monitor.x ;
+            clone.x -= frame.x - actor.x;
         }
 
         this.clone = clone;
@@ -124,24 +121,24 @@ var LiveAltTab = Lang.Class({
         // Tiling.ensureViewport(to, space);
         this._selectedIndex = num;
         this._switcherList.highlight(num);
-    },
+    }
 
-    _finish: function() {
-        this.parent();
+    _finish() {
+        super._finish();
         this.was_accepted = true;
-    },
+    }
 
-    _itemEnteredHandler: function() {
+    _itemEnteredHandler() {
         // The item-enter (mouse hover) event is triggered even after a item is
         // accepted. This can cause _select to run on the item below the pointer
         // ensuring the wrong window.
         if(!this.was_accepted) {
-            this.parent.apply(this, arguments);
+            super._itemEnteredHandler.apply(this, arguments);
         }
-    },
+    }
 
-    _onDestroy: function() {
-        this.parent();
+    _onDestroy() {
+        super._onDestroy();
         debug('#preview', 'onDestroy', this.was_accepted);
         Main.wm._blockAnimations = this._block;
         if(!this.was_accepted) {
@@ -162,7 +159,7 @@ var LiveAltTab = Lang.Class({
         let to = this._switcherList.windows[this._selectedIndex];
         Tiling.focus_handler(to);
     }
-})
+}
 
 function liveAltTab(meta_window, space, {display, screen, binding}) {
     let tabPopup = new LiveAltTab(binding.is_reversed());

--- a/liveAltTab.js
+++ b/liveAltTab.js
@@ -50,8 +50,8 @@ class LiveAltTab extends AltTab.WindowSwitcherPopup {
                                      opacity: 0
                                     });
 
-        this.blur = new Clutter.BlurEffect();
-        this.space.cloneContainer.add_effect(this.blur);
+        // this.blur = new Clutter.BlurEffect();
+        // this.space.cloneContainer.add_effect(this.blur);
         this.space.setSelectionInactive();
         fog.background_color = Clutter.color_from_string("black")[1];
         Tweener.addTween(fog, {
@@ -152,7 +152,7 @@ class LiveAltTab extends AltTab.WindowSwitcherPopup {
             transition: 'easeInOutQuad',
             onComplete: () => {
                 this.fog.destroy();
-                this.space.cloneContainer.remove_effect(this.blur);
+                // this.space.cloneContainer.remove_effect(this.blur);
                 this.clone && this.clone.destroy();
                 this.space.moveDone();
             }

--- a/liveAltTab.js
+++ b/liveAltTab.js
@@ -13,11 +13,12 @@ var debug = utils.debug;
 
 var prefs = Extension.imports.settings.prefs;
 
-var LiveAltTab = class LiveAltTab extends AltTab.WindowSwitcherPopup {
+var LiveAltTab = utils.registerClass(
+class LiveAltTab extends AltTab.WindowSwitcherPopup {
 
-    constructor(reverse) {
+    _init(reverse) {
         this.reverse = reverse;
-        super();
+        super._init();
     }
 
     _getWindowList(reverse) {
@@ -159,7 +160,7 @@ var LiveAltTab = class LiveAltTab extends AltTab.WindowSwitcherPopup {
         let to = this._switcherList.windows[this._selectedIndex];
         Tiling.focus_handler(to);
     }
-}
+});
 
 function liveAltTab(meta_window, space, {display, screen, binding}) {
     let tabPopup = new LiveAltTab(binding.is_reversed());

--- a/metadata.json
+++ b/metadata.json
@@ -4,6 +4,6 @@
   "description": "Tiling window manager with a twist",
   "url": "https://github.com/paperwm/PaperWM",
   "settings-schema": "org.gnome.Shell.Extensions.PaperWM",
-  "shell-version": [ "3.28", "3.30"],
+  "shell-version": [ "3.28", "3.30", "3.32"],
   "version": "beta"
 }

--- a/minimap.js
+++ b/minimap.js
@@ -159,6 +159,8 @@ class Minimap extends Array {
     }
 
     show(animate) {
+        if (this.destroyed)
+            return;
         let time = animate ? 0.25 : 0;
         this.actor.show();
         Tweener.addTween(this.actor,
@@ -193,6 +195,8 @@ class Minimap extends Array {
     }
 
     layout() {
+        if (this.destroyed)
+            return;
         let gap = prefs.window_gap;
         let x = 0;
         for (let column of this) {
@@ -274,7 +278,11 @@ class Minimap extends Array {
     }
 
     destroy() {
-        this.actor.destroy();
+        if (this.destroyed)
+            return;
+        this.destroyed = true;
         this.signals.destroy();
+        this.splice(0,this.length);
+        this.actor.destroy();
     }
 }

--- a/minimap.js
+++ b/minimap.js
@@ -227,8 +227,10 @@ class Minimap extends Array {
             this.highlight.hide();
             return;
         }
-        highlight.show();
         let [index, row] = position;
+        if (!(index in this && row in this[index]))
+            return;
+        highlight.show();
         let clip = this.clip;
         let container = this.container;
         let label = this.label;

--- a/navigator.js
+++ b/navigator.js
@@ -30,9 +30,6 @@ var display = global.display;
 var scale = 0.9;
 var navigating = false;
 
-// Dummy class to satisfy `SwitcherPopup.SwitcherPopup`
-
-
 var PreviewedWindowNavigator = utils.registerClass(
 class PreviewedWindowNavigator extends SwitcherPopup.SwitcherPopup {
     _init() {
@@ -43,14 +40,20 @@ class PreviewedWindowNavigator extends SwitcherPopup.SwitcherPopup {
         // HACK: workaround to enable moving from empty workspace. See check in
         // SwitcherPopup.show
         super._init([1]);
+        if (!('actor' in this)) { // 3.30 compat
+            this.actor = this;
+        }
         this._switcherList = new SwitcherPopup.SwitcherList();
+        if (!('actor' in this._switcherList)) {
+            this._switcherList.actor = this._switcherList;
+        }
         debug('#preview', 'init', this._switcherList);
     }
 
     _initialSelection(backward, actionName) {
         debug('#preview', '_initialSelection');
         this.navigator = getNavigator();
-        this._switcherList.hide();
+        this._switcherList.actor.hide();
         let actionId = Keybindings.idOf(actionName);
         if(actionId === Meta.KeyBindingAction.NONE) {
             try {
@@ -112,7 +115,7 @@ class PreviewedWindowNavigator extends SwitcherPopup.SwitcherPopup {
     }
 
     destroy() {
-        this.hide(); // Prevents finalized crap
+        this.actor.hide(); // Prevents finalized crap
         super.destroy();
         this.navigator.destroy();
     }

--- a/navigator.js
+++ b/navigator.js
@@ -7,7 +7,6 @@
 
 var Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.org'];
 var SwitcherPopup = imports.ui.switcherPopup;
-var Lang = imports.lang;
 var Meta = imports.gi.Meta;
 var Main = imports.ui.main;
 var Mainloop = imports.mainloop;
@@ -39,24 +38,21 @@ class SwitcherList {
 }
 Signals.addSignalMethods(SwitcherList.prototype);
 
-var PreviewedWindowNavigator = new Lang.Class({
-    Name: 'PreviewedWindowNavigator',
-    Extends: SwitcherPopup.SwitcherPopup,
-
-    _init: function() {
+var PreviewedWindowNavigator = class PreviewedWindowNavigator extends SwitcherPopup.SwitcherPopup {
+    constructor() {
         // Do the absolute minimal here, as `parent.show` is buggy and can
         // return early making cleanup hard. We do most initialization in
         // `_initialSelection` instead.
 
         // HACK: workaround to enable moving from empty workspace. See check in
         // SwitcherPopup.show
-        this.parent([1]);
+        super([1]);
         this._switcherList = new SwitcherList();
         debug('#preview', 'init', this._switcherList);
 
-    },
+    }
 
-    _initialSelection: function(backward, actionName) {
+    _initialSelection(backward, actionName) {
         debug('#preview', '_initialSelection');
         this.navigator = getNavigator();
         let actionId = Keybindings.idOf(actionName);
@@ -71,9 +67,9 @@ var PreviewedWindowNavigator = new Lang.Class({
         }
 
         this._doAction(actionId);
-    },
+    }
 
-    _doAction: function(mutterActionId) {
+    _doAction(mutterActionId) {
 
         let action = Keybindings.byId(mutterActionId);
         let space = Tiling.spaces.selectedSpace;
@@ -94,37 +90,37 @@ var PreviewedWindowNavigator = new Lang.Class({
         }
 
         return false;
-    },
+    }
 
-    _keyPressHandler: function(keysym, action) {
+    _keyPressHandler(keysym, action) {
         if (keysym !== Clutter.KEY_Escape && this._doAction(action)) {
             return Clutter.EVENT_STOP;
         } else {
             return Clutter.EVENT_PROPAGATE;
         }
-    },
+    }
 
-    _finish: function(timestamp) {
+    _finish(timestamp) {
         debug('#preview', 'finish');
         this.navigator.accept();
-        this.parent(timestamp);
-    },
+        super._finish(timestamp);
+    }
 
-    _itemEnteredHandler: function() {
+    _itemEnteredHandler() {
         // The item-enter (mouse hover) event is triggered even after a item is
         // accepted. This can cause _select to run on the item below the pointer
         // ensuring the wrong window.
         if(!this.was_accepted) {
-            this.parent.apply(this, arguments);
+            super._itemEnteredHandler.apply(this, arguments);
         }
-    },
+    }
 
-    destroy: function() {
+    destroy() {
         this.actor.hide(); // Prevents finalized crap
-        this.parent();
+        super.destroy();
         this.navigator.destroy();
     }
-});
+};
 
 var navigator;
 var Navigator = class Navigator {

--- a/navigator.js
+++ b/navigator.js
@@ -85,7 +85,8 @@ var PreviewedWindowNavigator = new Lang.Class({
             }
             action.handler(metaWindow, space, {navigator: this.navigator});
             if (space !== Tiling.spaces.selectedSpace) {
-                this.navigator.minimaps.forEach(m => m.hide());
+                this.navigator.minimaps.forEach(m => typeof(m) === 'number' ?
+                                                Mainloop.source_remove(m) : m.hide());
             }
             return true;
         } else if (mutterActionId == Meta.KeyBindingAction.MINIMIZE) {

--- a/navigator.js
+++ b/navigator.js
@@ -31,30 +31,26 @@ var scale = 0.9;
 var navigating = false;
 
 // Dummy class to satisfy `SwitcherPopup.SwitcherPopup`
-class SwitcherList {
-    constructor() {
-        this.actor = new Clutter.Actor();
-    }
-}
-Signals.addSignalMethods(SwitcherList.prototype);
 
-var PreviewedWindowNavigator = class PreviewedWindowNavigator extends SwitcherPopup.SwitcherPopup {
-    constructor() {
+
+var PreviewedWindowNavigator = utils.registerClass(
+class PreviewedWindowNavigator extends SwitcherPopup.SwitcherPopup {
+    _init() {
         // Do the absolute minimal here, as `parent.show` is buggy and can
         // return early making cleanup hard. We do most initialization in
         // `_initialSelection` instead.
 
         // HACK: workaround to enable moving from empty workspace. See check in
         // SwitcherPopup.show
-        super([1]);
-        this._switcherList = new SwitcherList();
+        super._init([1]);
+        this._switcherList = new SwitcherPopup.SwitcherList();
         debug('#preview', 'init', this._switcherList);
-
     }
 
     _initialSelection(backward, actionName) {
         debug('#preview', '_initialSelection');
         this.navigator = getNavigator();
+        this._switcherList.hide();
         let actionId = Keybindings.idOf(actionName);
         if(actionId === Meta.KeyBindingAction.NONE) {
             try {
@@ -116,11 +112,11 @@ var PreviewedWindowNavigator = class PreviewedWindowNavigator extends SwitcherPo
     }
 
     destroy() {
-        this.actor.hide(); // Prevents finalized crap
+        this.hide(); // Prevents finalized crap
         super.destroy();
         this.navigator.destroy();
     }
-};
+});
 
 var navigator;
 var Navigator = class Navigator {

--- a/prefs.js
+++ b/prefs.js
@@ -4,7 +4,6 @@ const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const Gdk = imports.gi.Gdk;
-const Lang = imports.lang;
 const Mainloop = imports.mainloop;
 
 const ExtensionUtils = imports.misc.extensionUtils;

--- a/scratch.js
+++ b/scratch.js
@@ -194,7 +194,6 @@ function hide() {
 }
 
 // Monkey patch the alt-space menu
-var Lang = imports.lang;
 var PopupMenu = imports.ui.popupMenu;
 var WindowMenu = imports.ui.windowMenu;
 var originalBuildMenu = WindowMenu.WindowMenu.prototype._buildMenu;

--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -2,7 +2,6 @@ var Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.o
 var Tiling = Extension.imports.tiling;
 var Clutter = imports.gi.Clutter;
 var Tweener = imports.ui.tweener;
-var Lang = imports.lang;
 var Main = imports.ui.main;
 var Mainloop = imports.mainloop;
 var Shell = imports.gi.Shell;
@@ -153,10 +152,8 @@ class ClickOverlay {
     }
 }
 
-var StackOverlay = new Lang.Class({
-    Name: 'Stackoverlay',
-
-    _init: function(direction, monitor) {
+var StackOverlay = class StackOverlay {
+    constructor(direction, monitor) {
 
         this._direction = direction;
 
@@ -194,7 +191,7 @@ var StackOverlay = new Lang.Class({
         Main.layoutManager.trackChrome(overlay);
 
         this.overlay = overlay;
-    },
+    }
 
     triggerPreview() {
         if ("_previewId" in this)
@@ -221,7 +218,7 @@ var StackOverlay = new Lang.Class({
                 x = monitor.x;
             clone.set_position(x, y);
         });
-    },
+    }
 
     removePreview() {
         if ("_previewId" in this) {
@@ -237,9 +234,9 @@ var StackOverlay = new Lang.Class({
         let space = Tiling.spaces.spaceOfWindow(this.target);
         // Show the WindowActors again and re-apply clipping
         space.moveDone();
-    },
+    }
 
-    removeBarrier: function() {
+    removeBarrier() {
         if (this.barrier) {
             if (this.pressureBarrier)
                 this.pressureBarrier.removeBarrier(this.barrier);
@@ -248,9 +245,9 @@ var StackOverlay = new Lang.Class({
             this.barrier = null;
         }
         this._removeBarrierTimeoutId = 0;
-    },
+    }
 
-    updateBarrier: function(force) {
+    updateBarrier(force) {
         if (force)
             this.removeBarrier();
 
@@ -289,9 +286,9 @@ var StackOverlay = new Lang.Class({
             directions
         });
         this.pressureBarrier.addBarrier(this.barrier);
-    },
+    }
 
-    setTarget: function(space, index) {
+    setTarget(space, index) {
 
         if (this.clone) {
             this.clone.destroy();
@@ -360,5 +357,5 @@ var StackOverlay = new Lang.Class({
         this.updateBarrier();
 
         return true;
-    },
-});
+    }
+};

--- a/tiling.js
+++ b/tiling.js
@@ -194,9 +194,6 @@ class Space extends Array {
         actor.add_actor(cloneClip);
         cloneClip.add_actor(cloneContainer);
 
-        container.set_child_below_sibling(clip,
-                                          container.first_child);
-
         let monitor = Main.layoutManager.primaryMonitor;
         let oldSpace = oldSpaces.get(workspace);
         this.targetX = 0;
@@ -1080,10 +1077,7 @@ class Spaces extends Map {
         spaceContainer.hide();
         this.spaceContainer = spaceContainer;
 
-        backgroundGroup.add_actor(spaceContainer);
-        backgroundGroup.set_child_above_sibling(
-            spaceContainer,
-            backgroundGroup.last_child);
+        backgroundGroup.add_child(this.spaceContainer);
 
         // Hook up existing workspaces
         for (let i=0; i < workspaceManager.n_workspaces; i++) {

--- a/tiling.js
+++ b/tiling.js
@@ -756,10 +756,8 @@ class Space extends Array {
             let b = w.get_buffer_rect();
             const x = Math.max(0, monitor.x - b.x);
             const y = Math.max(0, monitor.y - b.y);
-            const cw = b.width - x
-                  - Math.max(0, (b.x + b.width) - (monitor.x + monitor.width));
-            const ch = actor.height - y
-                  - Math.max(0, (b.y + b.height) - (monitor.y + monitor.height));
+            const cw = Math.max(0, monitor.x + monitor.width - b.x - x);
+            const ch = Math.max(0, monitor.y + monitor.height - b.y - y);
             actor.set_clip(x, y, cw, ch);
 
             showWindow(w);

--- a/tiling.js
+++ b/tiling.js
@@ -1,7 +1,6 @@
 var Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.org'];
 var GLib = imports.gi.GLib;
 var Tweener = imports.ui.tweener;
-var Lang = imports.lang;
 var Meta = imports.gi.Meta;
 var Clutter = imports.gi.Clutter;
 var St = imports.gi.St;

--- a/tiling.js
+++ b/tiling.js
@@ -1622,8 +1622,9 @@ class Spaces extends Map {
 
         debug('window-created', metaWindow.title);
         let actor = metaWindow.get_compositor_private();
+        animateWindow(metaWindow);
         let signal = actor.connect(
-            'show',
+            'first-frame',
             () =>  {
                 actor.disconnect(signal);
                 insertWindow(metaWindow, {});
@@ -2282,12 +2283,13 @@ function showHandler(actor) {
     let metaWindow = actor.meta_window;
     let onActive = metaWindow.get_workspace() === workspaceManager.get_active_workspace();
 
-    if (!metaWindow.clone.get_parent())
+    if (!metaWindow.clone.get_parent() && !metaWindow.unmapped)
         return;
 
     if (!onActive
         || isWindowAnimating(metaWindow)
-           // The built-in workspace-change animation is running: suppress it
+        || metaWindow.unmapped
+        // The built-in workspace-change animation is running: suppress it
         || actor.get_parent() !== global.window_group
        ) {
         animateWindow(metaWindow);

--- a/tiling.js
+++ b/tiling.js
@@ -1828,7 +1828,7 @@ function remove_handler(workspace, meta_window) {
     let actor = meta_window.get_compositor_private();
     if (!actor) {
         signals.disconnect(meta_window);
-        if (meta_window.clone)
+        if (meta_window.clone && meta_window.clone.mapped)
             meta_window.clone.destroy();
     }
 }

--- a/topbar.js
+++ b/topbar.js
@@ -396,11 +396,12 @@ function enable () {
         let point = new Clutter.Vertex({x: 0, y: 0});
         let r = label.apply_relative_transform_to_point(Main.panel.actor, point);
 
-        for (let [workspace, space] of Tiling.spaces) {
-            space.label.set_position(Math.round(r.x), Math.round(r.y));
-            let fontDescription = label.clutter_text.font_description;
-            space.label.clutter_text.set_font_description(fontDescription);
-        }
+        imports.mainloop.timeout_add(0, () => {
+            for (let [workspace, space] of Tiling.spaces) {
+                space.label.set_position(Math.round(r.x), Math.round(r.y));
+                let fontDescription = label.clutter_text.font_description;
+                space.label.clutter_text.set_font_description(fontDescription);
+            }})
     });
     Main.panel.addToStatusArea('WorkspaceMenu', menu, 0, 'left');
     menu.actor.show();

--- a/topbar.js
+++ b/topbar.js
@@ -109,9 +109,10 @@ class ColorEntry {
     }
 }
 
+var WorkspaceMenu = Utils.registerClass(
 class WorkspaceMenu extends PanelMenu.Button {
-    constructor(panel) {
-        super(0.5, 'WorkspaceMenu', false);
+    _init() {
+        super._init(0.5, 'WorkspaceMenu', false);
 
         this.actor.name = 'workspace-button';
 
@@ -139,12 +140,12 @@ class WorkspaceMenu extends PanelMenu.Button {
 
         this.colors = new ColorEntry();
 
-        this.contentBox = new St.BoxLayout({vertical: true});
-        this.contentBox.layout_manager.spacing = 10;
-        this.contentBox.set_style('margin: 10px 20px;');
-        this.contentBox.add_actor(this.entry.actor);
-        this.contentBox.add_actor(this.colors.actor);
-        this.menu.box.add_actor(this.contentBox);
+        this._contentBox = new St.BoxLayout({vertical: true});
+        this._contentBox.layout_manager.spacing = 10;
+        this._contentBox.set_style('margin: 10px 20px;');
+        this._contentBox.add_actor(this.entry.actor);
+        this._contentBox.add_actor(this.colors.actor);
+        this.menu.box.add_actor(this._contentBox);
 
         this.prefsIcon = new St.Button({ reactive: true,
                                          can_focus: true,
@@ -374,7 +375,7 @@ class WorkspaceMenu extends PanelMenu.Button {
         else
             this._label.text = orginalActivitiesText;
     }
-};
+});
 
 var menu;
 var orginalActivitiesText;

--- a/utils.js
+++ b/utils.js
@@ -6,6 +6,19 @@ var Meta = imports.gi.Meta;
 var workspaceManager = global.workspace_manager;
 var display = global.display;
 
+var GObject = imports.gi.GObject;
+var registerClass;
+
+{
+    let version = imports.misc.config.PACKAGE_VERSION.split('.');
+    if (version[0] >= 3 && version[1] > 30) {
+        registerClass = GObject.registerClass;
+    } else {
+        registerClass = (x => x);
+    }
+
+}
+
 var debug_all = false; // Turn off by default
 var debug_filter = {'#paperwm': true, '#stacktrace': true};
 function debug() {


### PR DESCRIPTION
- Upstream now mostly use `class` which `Last.Class` can't extend see https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/361
- Extending GObject classes is still possible with `Lang.Class`
- Extending js classes that extends GObject classes now require wrapping with `GObject.registerClass`
- Blur causes rendering issues, where things simply fail to render.
- `set_child_above_sibling` now skips asserts when using a release build of mutter, this makes for some truly strange behavior. The child would be removed from the parent, but the parent link would remain. Simply avoid setting actors above/below themselves.

Known issues:

- [x] opening the workspace menu causes the shell crash, probably related to `registerClass`. Results from building mutter without checks... Apparently adding an entry with existing text crashes the shell.
- [x] Navigator needs be registered and fixed
- [x] opening copyq in scratch crashes the shell: fixed by https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/450
- [x] the `show` signal no longer works on window-created, `first-frame` does the job, but causes some visual glitches on X11. I went with 'first-frame' for 3.32, but show for the rest.
 