### PR TITLE
dtolnay's local patches

### DIFF
--- a/navigator.js
+++ b/navigator.js
@@ -145,12 +145,14 @@ var ActionDispatcher = class {
 
         if (action && action.options.activeInNavigator) {
             if (action.options.opensMinimap) {
-                this.navigator._showMinimap(space);
+                //this.navigator._showMinimap(space);
             }
             action.handler(metaWindow, space, {navigator: this.navigator});
             if (space !== Tiling.spaces.selectedSpace) {
                 this.navigator.minimaps.forEach(m => typeof(m) === 'number' ?
                                                 Mainloop.source_remove(m) : m.hide());
+            } else {
+                Main.activateWindow(space.selectedWindow);
             }
             return true;
         } else if (mutterActionId == Meta.KeyBindingAction.MINIMIZE) {

--- a/tiling.js
+++ b/tiling.js
@@ -1434,7 +1434,7 @@ class Spaces extends Map {
         if (selected && selected.fullscreen) {
             Tweener.addTween(selected.clone, {
                 y: Main.panel.actor.height + prefs.vertical_margin,
-                time: prefs.animation_time,
+                time: 0,
             });
         }
     }
@@ -1503,7 +1503,7 @@ class Spaces extends Map {
 
             Tweener.addTween(actor,
                              {y: h*space.height,
-                              time: prefs.animation_time,
+                              time: 0,
                               scale_x: scale + (to - i)*0.01,
                               scale_y: scale + (to - i)*0.01,
                               transition, onComplete
@@ -1538,7 +1538,7 @@ class Spaces extends Map {
                            y: 0,
                            scale_x: 1,
                            scale_y: 1,
-                           time: prefs.animation_time,
+                           time: 0,
                            transition: 'easeInOutQuad',
                            onComplete: () => {
                                // Meta.enable_unredirect_for_screen(screen);
@@ -1567,7 +1567,7 @@ class Spaces extends Map {
             if (!visible.get(space)) {
                 Tweener.addTween(space.actor,
                                  {x: 0, y: space.height + 20,
-                                  time: prefs.animation_time, transition: 'easeInOutQuad' });
+                                  time: 0, transition: 'easeInOutQuad' });
             }
             above = above.get_next_sibling();
         }

--- a/topbar.js
+++ b/topbar.js
@@ -430,7 +430,7 @@ function enable () {
     menu.actor.show();
 
     // Force transparency
-    Main.panel.actor.set_style('background-color: rgba(0, 0, 0, 0.35);');
+    Main.panel.actor.set_style('background-color: rgba(0, 0, 0, 0.9);');
     [Main.panel._rightCorner, Main.panel._leftCorner]
         .forEach(c => c.actor.opacity = 0);
 
@@ -445,7 +445,7 @@ function enable () {
         if (display.focus_window.fullscreen) {
             hide();
         } else {
-            panelBox.show();
+            //panelBox.show();
         }
     });
 }
@@ -466,6 +466,7 @@ function disable() {
 }
 
 function show() {
+    return;
     panelBox.show();
     Tweener.addTween(panelBox, {
         scale_y: 1,
@@ -477,6 +478,7 @@ function show() {
 }
 
 function hide() {
+    return;
     Tweener.addTween(panelBox, {
         scale_y: 0,
         time: prefs.animation_time,


### PR DESCRIPTION
I arrived at a PaperWM setup that I am quite happy with, so I thought I'd share to give you an idea of what I am doing. It is sort of a hybrid between default PaperWM and a few things from awesomeWM.

Thanks for the great extension! I know I may not be using it as intended, but at least I have found it easy to tweak the things I want.

---

Changes in this commit to suite my workflow:

- I never want to see the minimap. If I lose track of what windows are in a workspace, I can pop into Activities or I can scrub left and right through the full-sized windows.

- I never want to see the spaces stack. The mru order is not helpful to me; I keep track of spaces by absolute index and jump straight to the workspace I want with a keyboard shortcut.

- I never want to see the topbar except in Activities.

- I want previous window / next window keybindings that take effect immediately. As soon as the key is pressed (not yet released) I want focus in the other window.

- I want workspace changes to happen immediately on key press with no animation.

My keybindings:

- Activities: <kbd>Super</kbd>
- Previous window: <kbd>Super</kbd><kbd>J</kbd>
- Next window: <kbd>Super</kbd><kbd>K</kbd>
- Move window: <kbd>Shift</kbd><kbd>Super</kbd><kbd>J</kbd>, <kbd>Shift</kbd><kbd>Super</kbd><kbd>K</kbd>
- Consume window: <kbd>Super</kbd><kbd>I</kbd>
- Expel window: <kbd>Super</kbd><kbd>O</kbd>
- Maximize width: <kbd>Super</kbd><kbd>F</kbd>
- Close window: <kbd>Super</kbd><kbd>Backspace</kbd>
- Switch to workspace: <kbd>Super</kbd><kbd>1</kbd> .. <kbd>Super</kbd><kbd>5</kbd>
- Move to workspace: <kbd>Shift</kbd><kbd>Super</kbd><kbd>1</kbd> .. <kbd>Shift</kbd><kbd>Super</kbd><kbd>5</kbd>
- Open terminal: <kbd>Super</kbd><kbd>Return</kbd>
- Open web browser: <kbd>Super</kbd><kbd>X</kbd>
- Open run box (commonly Alt+F2): <kbd>Super</kbd><kbd>Z</kbd>
- All others disabled

My PaperWM configurations:

- Gap between windows = 0
- Horizontal margin = 0
- Vertical margin = 0
- Workspace names = "1." "2." "3." "4." "5."

My related GNOME Shell extensions:

- [Hide top bar](https://extensions.gnome.org/extension/545/hide-top-bar/)
- [Disable workspace switcher popup](https://extensions.gnome.org/extension/959/disable-workspace-switcher-popup/)

Other adjustments:

- Patched version of rxvt-unicode that sets `szHint.width_inc` and `szHint.height_inc` both to 1 so that terminal width and height are not rounded down to the nearest multiple of column/row size; terminal can fill the full screen.

- Patched version of Yaru theme that eliminates rounded top-left and top-right corners in the titlebar, removes box shadows, and removes close buttons.