### PR TITLE
Fix typo in keybindings example

### DIFF
--- a/examples/keybindings.js
+++ b/examples/keybindings.js
@@ -21,7 +21,7 @@ function gotoByIndex() {
         }
     }
     for(let k = 1; k <= 9; k++) {
-        Keybindings.bindkey(`<Super>${k}`, `goto-coloumn-${i}`,
+        Keybindings.bindkey(`<Super>${k}`, `goto-coloumn-${k}`,
                             goto(k-1), {activeInNavigator: true})
     }
 }


### PR DESCRIPTION
I tried using this example and got an error because `i` should be `k`. With this change it works for me.

Thanks for the great tool! I'm really enjoying it so far.