### PR TITLE
Handle adding/removing workspaces on the fly

### DIFF
--- a/kludges.js
+++ b/kludges.js
@@ -314,7 +314,12 @@ function enable() {
             if (workspaceManager.n_workspaces <= Main.layoutManager.monitors.length + 1)
                 break;
             if (emptyWorkspaces[i] && i != lastEmptyIndex) {
-                workspaceManager.remove_workspace(this._workspaces[i], global.get_current_time());
+                let space = Tiling.spaces.spaceOf(this._workspaces[i]);
+                let visibleSpace = Tiling.spaces.monitors.get(space.monitor);
+                // Never remove visible spaces
+                if (space !== visibleSpace) {
+                    workspaceManager.remove_workspace(this._workspaces[i], global.get_current_time());
+                }
             }
         }
 

--- a/tiling.js
+++ b/tiling.js
@@ -214,9 +214,12 @@ class Space extends Array {
         this.leftStack = 0; // not implemented
         this.rightStack = 0; // not implemented
 
+        this.init();
     }
 
     init() {
+        if (this._populated || Main.layoutManager._startingUp)
+            return;
         let workspace = this.workspace;
         let oldSpace = oldSpaces.get(workspace);
 

--- a/tiling.js
+++ b/tiling.js
@@ -1139,7 +1139,12 @@ class Spaces extends Map {
             OVERRIDE_SCHEMA = 'org.gnome.mutter';
         }
         this.overrideSettings = new Gio.Settings({ schema_id: OVERRIDE_SCHEMA });
-        this.monitorsChanged();
+
+        // Make sure spaces are visible immediately when starting the first time. This will not add any extra workspaces
+        // Else leave it up to this.init() to handle the monitors.
+        if (Main.layoutManager._startingUp) {
+            this.monitorsChanged();
+        }
     }
 
     init() {
@@ -1276,6 +1281,14 @@ class Spaces extends Map {
         for (let monitor of monitors) {
             if (this.monitors.get(monitor) === undefined) {
                 let space = mru[0];
+                if (space === undefined && !Main.layoutManager._startingUp) {
+                    let workspace = workspaceManager.append_new_workspace(
+                        false, global.get_current_time());
+                    space = this.spaceOf(workspace);
+                }
+                if (space === undefined) {
+                    break;
+                }
                 this.monitors.set(monitor, space);
                 space.setMonitor(monitor, false);
                 mru = mru.slice(1);

--- a/topbar.js
+++ b/topbar.js
@@ -459,7 +459,7 @@ function enable () {
         if (!Tiling.spaces.selectedSpace.showTopBar)
             return;
 
-        if (display.focus_window.fullscreen) {
+        if (display.focus_window && display.focus_window.fullscreen) {
             hide();
         } else {
             panelBox.show();


### PR DESCRIPTION
- handle dynamic-workspaces when used with multiple monitors
- make sure every monitor has a space
- actually hook up spaces correctly when they're created on the fly