### PR TITLE
Require a threshold motion to trigger workspace switch

### DIFF
--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -76,9 +76,20 @@ class ClickOverlay {
 
         this.signals = new utils.Signals();
 
+        this._lastPointer = [];
         this.signals.connect(
             enterMonitor, 'motion-event',
-            () => {
+            (actor, event) => {
+                let [x, y, z] = global.get_pointer();
+                let [lX, lY] = this._lastPointer;
+                this._lastPointer = [x, y];
+                Mainloop.timeout_add(500, () => {
+                    this._lastPointer = [];
+                });
+                if (lX === undefined ||
+                    Math.sqrt((lX - x)**2 + (lY - y)**2) < 10)
+                    return;
+                log(`event: ${event.x}`);
                 this.deactivate();
                 let space = Tiling.spaces.monitors.get(this.monitor);
                 let display = global.display;


### PR DESCRIPTION
On multi monitor setups we usually want the monitor focus to follow the mouse pointer since non-active workspaces don't react to the pointer at all.

Unfortunately it's not possible to warp the pointer from gnome-shell extensions in wayland yet. The pointer will be left on an inactive monitor when switching workspaces using the keyboard. This makes it extremely easy to trigger an motion event and inadvertently switching monitor focus (in fact this simply happens the moment we activate the motion listener).

So add a motion threshold to filter out pointer motions without user intent.

ref #https://github.com/paperwm/PaperWM/issues/135