### PR TITLE
Ensure 'startup-complete' is not connected twice

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -1750,9 +1750,11 @@ Signals.addSignalMethods(Spaces.prototype);
 
 function registerWindow(metaWindow) {
     if (metaWindow.clone) {
-        // Temp workaround - sometimes called twice on enable
-        return false;
+        // Should no longer be possible, but leave a trace just to be sure
+        utils.warn("window already registered", metaWindow.title);
+        utils.print_stacktrace();
     }
+
     if (metaWindow.is_override_redirect()) {
         return false;
     }
@@ -1850,10 +1852,7 @@ function enable() {
         // Defer workspace initialization until existing windows are accessible.
         // Otherwise we're unable to restore the tiling-order. (when restarting
         // gnome-shell)
-        let id = Main.layoutManager.connect('startup-complete', function() {
-            Main.layoutManager.disconnect(id);
-            initWorkspaces();
-        });
+        signals.connectOneShot(Main.layoutManager, 'startup-complete', initWorkspaces);
     } else {
         initWorkspaces();
     }


### PR DESCRIPTION
Windows sometimes was registered (`registerWindow`) twice on startup (observed
on X11 3.28) causing all sorts of problems.

Seems like the extension sometimes is enabled/disabled twice on startup causing
the 'startup-complete' signal to be connected twice. Use the `Signals` class to
manage the signal to guard against this scenario.

I added a one-shot function to `Signals` since it's an error to disconnect an
already disconnected signal and that would happen on disable if the
'startup-complete' signal disconnected the signal itself.

assoc: d8069078f2bbad01a73b72bf2e4ddaf08ca0f585