### PR TITLE
Unmaximize window on cycleWidth

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -2447,6 +2447,10 @@ function cycleWindowWidth(metaWindow) {
         targetX = workArea.x + workArea.width - minimumMargin() - targetWidth;
     }
 
+    if (metaWindow.get_maximized() === Meta.MaximizeFlags.BOTH) {
+        metaWindow.unmaximize(Meta.MaximizeFlags.BOTH);
+    }
+
     metaWindow.move_resize_frame(true, targetX, frame.y, targetWidth, frame.height);
 }
 


### PR DESCRIPTION
I find it very annoying when trying to do cycleWidth and nothing is happening. This is usually caused by the window being maximized for some reason. Simply cheeking if it is, and if so unmaximizing it, is a simple fix that works well.