### PR TITLE
Remove unneded topbar workspace label

### DIFF
--- a/topbar.js
+++ b/topbar.js
@@ -428,7 +428,7 @@ function enable () {
 
         imports.mainloop.timeout_add(0, () => {
             for (let [workspace, space] of Tiling.spaces) {
-                space.label.set_position(Math.round(r.x), Math.round(r.y));
+                space.label.set_position(Main.panel.actor.x + Math.round(r.x), Main.panel.actor.y + Math.round(r.y));
                 let fontDescription = label.clutter_text.font_description;
                 space.label.clutter_text.set_font_description(fontDescription);
             }})


### PR DESCRIPTION
Hi,
when using a theme that messes with the style/positioning of the topbar, the label of the spaces won't perfectly position. For example with the Sweet-Dark shell theme:
![label-on](https://user-images.githubusercontent.com/35728419/61186704-9f3e9880-a668-11e9-8769-a525aff87a81.png)
Instead of trying to re-position it so it overlaps nicely, I just completely hid it, as I don't see any use for the label:
![label-off](https://user-images.githubusercontent.com/35728419/61186724-e593f780-a668-11e9-8fe0-4a367cbf00d1.png)

Cheers

