### PR TITLE
set-recommended-gnome-shell-settings: do not prefer static workspaces

### DIFF
--- a/set-recommended-gnome-shell-settings.sh
+++ b/set-recommended-gnome-shell-settings.sh
@@ -44,9 +44,6 @@ set-with-backup org.gnome.mutter auto-maximize false
 # Multi-monitor support is much more complete with workspaces spanning monitors
 set-with-backup org.gnome.shell.overrides workspaces-only-on-primary false
 
-# PaperWM currently works best using static workspaces
-set-with-backup org.gnome.shell.overrides dynamic-workspaces false
-
 # We make no attempt at handing edge-tiling
 set-with-backup org.gnome.shell.overrides edge-tiling false
 


### PR DESCRIPTION
We now support dynamic workspaces well, so there's no longer a good reason to
prefer static workspaces by default.

I've been using dynamic workspaces for a while now and can't see anything really wrong with it anymore. Workspaces that are commonly in use tends to be prioritized which is exactly what one wants.