### PR TITLE
Fix crash under Gnome 3.34

### DIFF
--- a/examples/keybindings.js
+++ b/examples/keybindings.js
@@ -1,4 +1,4 @@
-var Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.org'];
+var Extension = imports.misc.extensionUtils.getCurrentExtension();
 var Keybindings = Extension.imports.keybindings;
 var Main = imports.ui.main;
 var Tiling = Extension.imports.tiling;

--- a/extension.js
+++ b/extension.js
@@ -85,7 +85,7 @@ function init() {
 
     // var Gio = imports.gi.Gio;
     // let extfile = Gio.file_new_for_path( Extension.imports.extension.__file__);
-    Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.org'];
+    Extension = imports.misc.extensionUtils.getCurrentExtension();
     convenience = Extension.imports.convenience;
 
     if(initRun) {

--- a/gestures.js
+++ b/gestures.js
@@ -1,4 +1,10 @@
-var Extension = imports.misc.extensionUtils.getCurrentExtension();
+var Extension;
+if (imports.misc.extensionUtils.extensions) {
+    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning:matrix.org"];
+} else {
+    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning:matrix.org");
+}
+
 var Meta = imports.gi.Meta;
 var St = imports.gi.St;
 var Gio = imports.gi.Gio;

--- a/gestures.js
+++ b/gestures.js
@@ -1,4 +1,4 @@
-var Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.org'];
+var Extension = imports.misc.extensionUtils.getCurrentExtension();
 var Meta = imports.gi.Meta;
 var St = imports.gi.St;
 var Gio = imports.gi.Gio;

--- a/keybindings.js
+++ b/keybindings.js
@@ -1,4 +1,10 @@
-var Extension = imports.misc.extensionUtils.getCurrentExtension();
+var Extension;
+if (imports.misc.extensionUtils.extensions) {
+    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning:matrix.org"];
+} else {
+    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning:matrix.org");
+}
+
 var Me = Extension.imports.keybindings;
 var Gdk = imports.gi.Gdk;
 var Gtk = imports.gi.Gtk;

--- a/keybindings.js
+++ b/keybindings.js
@@ -1,4 +1,4 @@
-var Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.org'];
+var Extension = imports.misc.extensionUtils.getCurrentExtension();
 var Me = Extension.imports.keybindings;
 var Gdk = imports.gi.Gdk;
 var Gtk = imports.gi.Gtk;

--- a/kludges.js
+++ b/kludges.js
@@ -4,7 +4,7 @@
   around these problems.
  */
 
-var Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.org'];
+var Extension = imports.misc.extensionUtils.getCurrentExtension();
 
 var Meta = imports.gi.Meta;
 var Main = imports.ui.main;

--- a/kludges.js
+++ b/kludges.js
@@ -4,7 +4,13 @@
   around these problems.
  */
 
-var Extension = imports.misc.extensionUtils.getCurrentExtension();
+var Extension;
+if (imports.misc.extensionUtils.extensions) {
+    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning:matrix.org"];
+} else {
+    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning:matrix.org");
+}
+
 
 var Meta = imports.gi.Meta;
 var Main = imports.ui.main;

--- a/liveAltTab.js
+++ b/liveAltTab.js
@@ -1,4 +1,4 @@
-var Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.org'];
+var Extension = imports.misc.extensionUtils.getCurrentExtension();
 var Clutter = imports.gi.Clutter;
 var Meta = imports.gi.Meta;
 var AltTab = imports.ui.altTab;

--- a/liveAltTab.js
+++ b/liveAltTab.js
@@ -1,4 +1,10 @@
-var Extension = imports.misc.extensionUtils.getCurrentExtension();
+var Extension;
+if (imports.misc.extensionUtils.extensions) {
+    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning:matrix.org"];
+} else {
+    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning:matrix.org");
+}
+
 var Clutter = imports.gi.Clutter;
 var Meta = imports.gi.Meta;
 var AltTab = imports.ui.altTab;

--- a/minimap.js
+++ b/minimap.js
@@ -1,4 +1,4 @@
-var Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.org']
+var Extension = imports.misc.extensionUtils.getCurrentExtension();
 var Clutter = imports.gi.Clutter;
 var Tweener = imports.ui.tweener;
 var Main = imports.ui.main;

--- a/minimap.js
+++ b/minimap.js
@@ -1,4 +1,10 @@
-var Extension = imports.misc.extensionUtils.getCurrentExtension();
+var Extension;
+if (imports.misc.extensionUtils.extensions) {
+    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning:matrix.org"];
+} else {
+    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning:matrix.org");
+}
+
 var Clutter = imports.gi.Clutter;
 var Tweener = imports.ui.tweener;
 var Main = imports.ui.main;

--- a/navigator.js
+++ b/navigator.js
@@ -5,7 +5,7 @@
   `SwitcherPopup.SwitcherPopup` when we really should just take full control.
  */
 
-var Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.org'];
+var Extension = imports.misc.extensionUtils.getCurrentExtension();
 var SwitcherPopup = imports.ui.switcherPopup;
 var Meta = imports.gi.Meta;
 var Main = imports.ui.main;

--- a/navigator.js
+++ b/navigator.js
@@ -5,7 +5,13 @@
   `SwitcherPopup.SwitcherPopup` when we really should just take full control.
  */
 
-var Extension = imports.misc.extensionUtils.getCurrentExtension();
+var Extension;
+if (imports.misc.extensionUtils.extensions) {
+    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning:matrix.org"];
+} else {
+    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning:matrix.org");
+}
+
 var SwitcherPopup = imports.ui.switcherPopup;
 var Meta = imports.gi.Meta;
 var Main = imports.ui.main;

--- a/scratch.js
+++ b/scratch.js
@@ -1,4 +1,10 @@
-var Extension = imports.misc.extensionUtils.getCurrentExtension();
+var Extension;
+if (imports.misc.extensionUtils.extensions) {
+    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning:matrix.org"];
+} else {
+    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning:matrix.org");
+}
+
 var Meta = imports.gi.Meta;
 var Main = imports.ui.main;
 

--- a/scratch.js
+++ b/scratch.js
@@ -1,4 +1,4 @@
-var Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.org'];
+var Extension = imports.misc.extensionUtils.getCurrentExtension();
 var Meta = imports.gi.Meta;
 var Main = imports.ui.main;
 

--- a/settings.js
+++ b/settings.js
@@ -3,7 +3,7 @@
    Settings utility shared between the running extension and the preference UI.
 
  */
-var Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.org'];
+var Extension = imports.misc.extensionUtils.getCurrentExtension();
 var Gio = imports.gi.Gio;
 var GLib = imports.gi.GLib;
 var Gtk = imports.gi.Gtk;

--- a/settings.js
+++ b/settings.js
@@ -3,7 +3,13 @@
    Settings utility shared between the running extension and the preference UI.
 
  */
-var Extension = imports.misc.extensionUtils.getCurrentExtension();
+var Extension;
+if (imports.misc.extensionUtils.extensions) {
+    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning:matrix.org"];
+} else {
+    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning:matrix.org");
+}
+
 var Gio = imports.gi.Gio;
 var GLib = imports.gi.GLib;
 var Gtk = imports.gi.Gtk;

--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -1,4 +1,4 @@
-var Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.org'];
+var Extension = imports.misc.extensionUtils.getCurrentExtension();
 var Tiling = Extension.imports.tiling;
 var Clutter = imports.gi.Clutter;
 var Tweener = imports.ui.tweener;

--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -1,4 +1,10 @@
-var Extension = imports.misc.extensionUtils.getCurrentExtension();
+var Extension;
+if (imports.misc.extensionUtils.extensions) {
+    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning:matrix.org"];
+} else {
+    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning:matrix.org");
+}
+
 var Tiling = Extension.imports.tiling;
 var Clutter = imports.gi.Clutter;
 var Tweener = imports.ui.tweener;

--- a/tiling.js
+++ b/tiling.js
@@ -1,4 +1,4 @@
-var Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.org'];
+var Extension = imports.misc.extensionUtils.getCurrentExtension();
 var GLib = imports.gi.GLib;
 var Tweener = imports.ui.tweener;
 var Meta = imports.gi.Meta;

--- a/tiling.js
+++ b/tiling.js
@@ -1774,7 +1774,7 @@ function registerWindow(metaWindow) {
     clone.meta_window = metaWindow;
 
     metaWindow.clone = clone;
-    metaWindow.clone.actor = cloneActor;
+    metaWindow.clone.cloneActor = cloneActor;
 
     signals.connect(metaWindow, "focus", focus_wrapper);
     // Note: runs before gnome-shell's minimize handling code
@@ -1792,7 +1792,7 @@ function allocateClone(actor) {
     // Adjust the clone's origin to the north-west, so it will line up
     // with the frame.
     let clone = metaWindow.clone;
-    let cloneActor = clone.actor;
+    let cloneActor = clone.cloneActor;
     cloneActor.set_position(actor.x - frame.x,
                        actor.y - frame.y);
     clone.set_size(frame.width, frame.height);
@@ -2179,7 +2179,7 @@ function ensureViewport(meta_window, space, force) {
 
 function updateSelection(space, metaWindow) {
     let clone = metaWindow.clone;
-    let cloneActor = clone.actor;
+    let cloneActor = clone.cloneActor;
     space.setSelectionActive();
     if (space.selection.get_parent() === clone)
         return;
@@ -2383,7 +2383,7 @@ function showWindow(metaWindow) {
     let actor = metaWindow.get_compositor_private();
     if (!actor)
         return false;
-    metaWindow.clone.actor.hide();
+    metaWindow.clone.cloneActor.hide();
     actor.show();
     return true;
 }
@@ -2392,14 +2392,14 @@ function animateWindow(metaWindow) {
     let actor = metaWindow.get_compositor_private();
     if (!actor)
         return false;
-    metaWindow.clone.actor.show();
+    metaWindow.clone.cloneActor.show();
     actor.hide();
     return true;
 }
 
 function isWindowAnimating(metaWindow) {
     let clone = metaWindow.clone;
-    return clone.get_parent() && clone.actor.visible;
+    return clone.get_parent() && clone.cloneActor.visible;
 }
 
 function toggleMaximizeHorizontally(metaWindow) {

--- a/tiling.js
+++ b/tiling.js
@@ -1,4 +1,10 @@
-var Extension = imports.misc.extensionUtils.getCurrentExtension();
+var Extension;
+if (imports.misc.extensionUtils.extensions) {
+    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning:matrix.org"];
+} else {
+    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning:matrix.org");
+}
+
 var GLib = imports.gi.GLib;
 var Tweener = imports.ui.tweener;
 var Meta = imports.gi.Meta;

--- a/topbar.js
+++ b/topbar.js
@@ -2,7 +2,13 @@
   Functionality related to the top bar, often called the statusbar.
  */
 
-var Extension = imports.misc.extensionUtils.getCurrentExtension();
+var Extension;
+if (imports.misc.extensionUtils.extensions) {
+    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning:matrix.org"];
+} else {
+    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning:matrix.org");
+}
+
 var Meta = imports.gi.Meta;
 var St = imports.gi.St;
 var Gio = imports.gi.Gio;

--- a/topbar.js
+++ b/topbar.js
@@ -2,7 +2,7 @@
   Functionality related to the top bar, often called the statusbar.
  */
 
-var Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.org'];
+var Extension = imports.misc.extensionUtils.getCurrentExtension();
 var Meta = imports.gi.Meta;
 var St = imports.gi.St;
 var Gio = imports.gi.Gio;

--- a/utils.js
+++ b/utils.js
@@ -1,4 +1,9 @@
-const Extension = imports.misc.extensionUtils.getCurrentExtension();
+var Extension;
+if (imports.misc.extensionUtils.extensions) {
+    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning:matrix.org"];
+} else {
+    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning:matrix.org");
+}
 const Gdk = imports.gi.Gdk;
 var GLib = imports.gi.GLib;
 var Meta = imports.gi.Meta;

--- a/utils.js
+++ b/utils.js
@@ -1,4 +1,4 @@
-const Extension = imports.misc.extensionUtils.extensions['paperwm@hedning:matrix.org']
+const Extension = imports.misc.extensionUtils.getCurrentExtension();
 const Gdk = imports.gi.Gdk;
 var GLib = imports.gi.GLib;
 var Meta = imports.gi.Meta;


### PR DESCRIPTION
`extenstionUtils.extensions` is undefined in 3.34 and thus crashes the extension.
`extensionUtils.getCurrentExtension();` was previously used in some places so I assume that it also exists in older versions or otherwise the current version of the extension should have already crashed there.

Window placement is messed up as well so this does not give full 3.34 compatibility but not crashing is a start.