### PR TITLE
prefs: don't scroll the tabs

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -523,10 +523,9 @@
       </packing>
     </child>
     <child>
-      <object class="GtkBox" id="keybindings">
+      <object class="GtkBox">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="margin_top">24</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkSearchEntry" id="keybinding_search">
@@ -543,7 +542,40 @@
           </packing>
         </child>
         <child>
-          <placeholder/>
+          <object class="GtkScrolledWindow">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="hscrollbar_policy">never</property>
+            <property name="shadow_type">in</property>
+            <child>
+              <object class="GtkViewport">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkBox" id="keybindings">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="vexpand">True</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
         </child>
       </object>
       <packing>

--- a/prefs.js
+++ b/prefs.js
@@ -63,13 +63,11 @@ class SettingsWidget {
     constructor(selectedTab=0, selectedWorkspace=0 ) {
         this._settings = Convenience.getSettings();
 
-        this.builder = new Gtk.Builder();
-        this.builder.add_from_file(Extension.path + '/Settings.ui');
+        this.builder = Gtk.Builder.new_from_file(Extension.path + '/Settings.ui');
 
-        this.widget = new Gtk.ScrolledWindow({ hscrollbar_policy: Gtk.PolicyType.NEVER });
         this._notebook = this.builder.get_object('paperwm_settings');
+        this.widget = this._notebook;
         this._notebook.page = selectedTab;
-        this.widget.add(this._notebook);
 
         // General
 
@@ -380,12 +378,12 @@ function createKeybindingWidget(settings, searchEntry) {
             ]);
 
     let treeView = new Gtk.TreeView();
+    treeView.set_enable_search(false);
     treeView.model = filteredModel;
     treeView.headers_visible = false;
     treeView.margin_start = 12;
     treeView.margin_end = 12;
     treeView.search_column = COLUMN_DESCRIPTION;
-    treeView.enable_search = true;
     treeView.tooltip_column = COLUMN_TOOLTIP;
 
     let descriptionRenderer = new Gtk.CellRendererText();


### PR DESCRIPTION
We previously wrapper the `notebook` in a `ScrolledWindow` which made the tab bar scroll. Move scrolling into the keybinding tab (don't think it's necessary to have any in the other tabs).  Also made the search bar sticky.

The default tree view search doesn't work and can pop up outside the scroll so
disable it.

TODO: add something like `ctrl-f`, `/` to focus the search input

![image](https://user-images.githubusercontent.com/71978/66063925-ab8a1180-e544-11e9-8143-b68d49f61f80.png)
