### PR TITLE
Modernize the workspace menu

### DIFF
--- a/examples/keybindings.js
+++ b/examples/keybindings.js
@@ -115,55 +115,13 @@ function cycleWorkspaceSettings(binding = "<Super>q") {
     var Settings = Extension.imports.settings;
     var Utils = Extension.imports.utils;
 
-    function rotated(list, dir=1) {
-        return [].concat(
-            list.slice(dir),
-            list.slice(0, dir)
-        );
-    }
-
-    function cycle(mw, dir=1) {
-        let n = global.workspace_manager.get_n_workspaces();
-        let N = Settings.workspaceList.get_strv('list').length;
-        let space = Tiling.spaces.selectedSpace;
-        let wsI = space.workspace.index();
-
-        // 2 6 7 8   <-- indices
-        // x a b c   <-- settings
-        // a b c x   <-- rotated settings
-
-        let uuids = Settings.workspaceList.get_strv('list');
-        // Work on tuples of [uuid, settings] since we need to uuid association
-        // in the last step
-        let settings = uuids.map(
-            uuid => [uuid, Settings.getWorkspaceSettingsByUUID(uuid)]
-        );
-        settings.sort((a, b) => a[1].get_int('index') - b[1].get_int('index'));
-
-        let unbound = settings.slice(n);
-        let strip = [settings[wsI]].concat(unbound);
-
-        strip = rotated(strip, dir);
-
-        let nextSettings = strip[0];
-        unbound = strip.slice(1);
-
-        nextSettings[1].set_int('index', wsI);
-        space.setSettings(nextSettings); // ASSUMPTION: ok that two settings have same index here
-
-        // Re-assign unbound indices:
-        for (let i = n; i < N; i++) {
-            unbound[i-n][1].set_int('index', i);
-        }
-    }
-
     Keybindings.bindkey(
         binding, "next-space-setting",
-        mw => cycle(mw, -1), { activeInNavigator: true }
+        mw => Tiling.cycleWorkspaceSettings(-1), { activeInNavigator: true }
     );
     Keybindings.bindkey(
         "<Shift>"+binding, "prev-space-setting",
-        mw => cycle(mw,  1), { activeInNavigator: true }
+        mw => Tiling.cycleWorkspaceSettings(1), { activeInNavigator: true }
     );
 }
 

--- a/topbar.js
+++ b/topbar.js
@@ -180,6 +180,8 @@ class WorkspaceMenu extends PanelMenu.Button {
                              'switch-workspace',
                              this.workspaceSwitched.bind(this));
 
+        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem(_('Workspace Settings')));
+
         this.entry = new PopupMenuEntry(this._label.text);
         this.menu.addMenuItem(this.entry);
         let changed = () => {

--- a/topbar.js
+++ b/topbar.js
@@ -249,10 +249,12 @@ class WorkspaceMenu extends PanelMenu.Button {
         this.nextIcon.connect('clicked', () => {
             let space = Tiling.cycleWorkspaceSettings(-1);
             this.entry.label.text = space.name;
+            menu.nextIcon.grab_key_focus();
         });
         this.prevIcon.connect('clicked', () => {
             let space = Tiling.cycleWorkspaceSettings(1);
             this.entry.label.text = space.name;
+            menu.prevIcon.grab_key_focus();
         });
 
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());

--- a/topbar.js
+++ b/topbar.js
@@ -214,10 +214,10 @@ class WorkspaceMenu extends PanelMenu.Button {
         // this._contentBox.add_actor(this.colors.actor);
         // this.menu.box.add_actor(this._contentBox);
 
-        this._zenItem = new PopupMenu.PopupSwitchMenuItem('show top bar', true);
+        this._zenItem = new PopupMenu.PopupSwitchMenuItem('Hide top bar', false);
         this.menu.addMenuItem(this._zenItem);
         this._zenItem.connect('toggled', item => {
-            Tiling.spaces.selectedSpace.settings.set_boolean('show-top-bar', item.state);
+            Tiling.spaces.selectedSpace.settings.set_boolean('show-top-bar', !item.state);
         });
 
         function createButton(icon_name, accessible_name) {
@@ -454,7 +454,7 @@ class WorkspaceMenu extends PanelMenu.Button {
         let space = Tiling.spaces.spaceOf(workspaceManager.get_active_workspace());
         this.entry.label.text = space.name;
 
-        this._zenItem._switch.setToggleState(space.showTopBar);
+        this._zenItem._switch.setToggleState(!space.showTopBar);
     }
 
     workspaceSwitched(wm, fromIndex, toIndex) {

--- a/topbar.js
+++ b/topbar.js
@@ -455,6 +455,7 @@ class WorkspaceMenu extends PanelMenu.Button {
 
         let space = Tiling.spaces.spaceOf(workspaceManager.get_active_workspace());
         this.entry.label.text = space.name;
+        GLib.idle_add(GLib.PRIORITY_DEFAULT, this.entry.activate.bind(this.entry));
 
         this._zenItem._switch.setToggleState(!space.showTopBar);
     }

--- a/topbar.js
+++ b/topbar.js
@@ -168,8 +168,13 @@ class WorkspaceMenu extends PanelMenu.Button {
 
         this.actor.name = 'workspace-button';
 
+        let scale = display.get_monitor_scale(Main.layoutManager.primaryIndex);
         this._label = new St.Label({
-            y_align: Clutter.ActorAlign.CENTER });
+            y_align: Clutter.ActorAlign.CENTER,
+            // Avoid moving the menu on short names
+            // TODO: update on scale changes
+            min_width: 60*scale
+        });
 
         this.setName(Meta.prefs_get_workspace_name(workspaceManager.get_active_workspace_index()));
 

--- a/topbar.js
+++ b/topbar.js
@@ -218,12 +218,19 @@ class WorkspaceMenu extends PanelMenu.Button {
             Tiling.spaces.selectedSpace.settings.set_boolean('show-top-bar', item.state);
         });
 
-        this.prefsIcon = new St.Button({ reactive: true,
-                                         can_focus: true,
-                                         track_hover: true,
-                                         accessible_name: 'workspace preference',
-                                         style_class: 'system-menu-action' });
-        this.prefsIcon.child = new St.Icon({ icon_name: 'gtk-preferences' });
+        function createButton(icon_name, accessible_name) {
+            return new St.Button({reactive: true,
+                                  can_focus: true,
+                                  track_hover: true,
+                                  accessible_name,
+                                  style_class: 'system-menu-action',
+                                  child: new St.Icon({icon_name})
+            });
+        }
+
+        this.prefsIcon = createButton('gtk-preferences', 'workspace preference');
+        this.prevIcon = createButton('go-previous-symbolic', 'previous workspace setting');
+        this.nextIcon = createButton('go-next-symbolic', 'next workspace setting');
 
         this.prefsIcon.connect('clicked', () => {
             this.menu.close(true);
@@ -237,7 +244,23 @@ class WorkspaceMenu extends PanelMenu.Button {
             }
         });
 
-        this.menu.box.add(this.prefsIcon, { expand: true, x_fill: false });
+        this.nextIcon.connect('clicked', () => {
+            let space = Tiling.cycleWorkspaceSettings(-1);
+            this.entry.label.text = space.name;
+        });
+        this.prevIcon.connect('clicked', () => {
+            let space = Tiling.cycleWorkspaceSettings(1);
+            this.entry.label.text = space.name;
+        });
+
+        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+
+        this.iconBox = new St.BoxLayout();
+        this.menu.box.add(this.iconBox);
+
+        this.iconBox.add(this.prevIcon, { expand: true, x_fill: false });
+        this.iconBox.add(this.prefsIcon, { expand: true, x_fill: false });
+        this.iconBox.add(this.nextIcon, { expand: true, x_fill: false });
 
         // this.entry.actor.width = this.colors.actor.width;
         // this.colors.entry.actor.width = this.colors.actor.width;

--- a/utils.js
+++ b/utils.js
@@ -19,9 +19,8 @@ var version = imports.misc.config.PACKAGE_VERSION.split('.').map(Number);
     if (version[0] >= 3 && version[1] > 30) {
         registerClass = GObject.registerClass;
     } else {
-        registerClass = (x => x);
+        registerClass = (x, y) => y ? y : x;
     }
-
 }
 
 var debug_all = false; // Turn off by default


### PR DESCRIPTION
- Remove the `Set ...` buttons, just update the name on the fly instead
- Remove the color selection, didn't really work all that great. Perhaps rather add 3 sliders ala. the volume?
- Add buttons to select other workspace settings 

![image](https://user-images.githubusercontent.com/71978/67200693-cdb8d600-f404-11e9-8734-34af056877cf.png)

