### PR TITLE
Better workspaces-only-on-primary support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can then enable the extension in Gnome Tweaks, or enable if from the command
 gnome-shell-extension-tool -e paperwm@hedning:matrix.org
 ```
 
-There's a few Gnome Shell settings which works poorly with PaperWM. To use the recommended settings run [`set-recommended-gnome-shell-settings.sh`](https://github.com/paperwm/PaperWM/blob/master/set-recommended-gnome-shell-settings.sh). A "restore previous settings" script is generated so the original settings is not lost.
+There's a few Gnome Shell settings which works poorly with PaperWM. To use the recommended settings run [`set-recommended-gnome-shell-settings.sh`](https://github.com/paperwm/PaperWM/blob/master/set-recommended-gnome-shell-settings.sh). A "restore previous settings" script is generated so the original settings is not lost. (The script will turn `auto-maximize`, `edge-tiling`, `attach-modal-dialogs` and `workspaces-only-on-primary` off).
 
 Running the extension will automatic install a user config file as described in [Development & user configuration](#development--user-configuration).
 
@@ -107,7 +107,7 @@ Swiping the trackpad vertically with three fingers lets you navigate the workspa
 
 There's a single scrollable tiling per workspace. Adding another monitor simply makes it possible to have another workspace visible. The workspace stack is shared among all the monitors, windows being resized vertically as necessary when workspace is displayed on another monitor.
 
-PaperWM currently works best using static workspaces, this can be turned on with Gnome Tweaks under Workspaces.
+PaperWM currently works best using the workspaces span monitors preference, this can be turned on with Gnome Tweaks under Workspaces. If you want to use workspaces only on primary you need to place the secondary monitor either below or above the primary (with the best result having it below).
 
 | Workspace Keybindings                                                                                                    |                                                                                   |
 | ------                                                                                                                   | -------                                                                           |

--- a/kludges.js
+++ b/kludges.js
@@ -169,22 +169,28 @@ function _realRecalculateWindowPositions(flags) {
         return;
 
     let space = Tiling.spaces.spaceOf(this.metaWorkspace);
-    clones.sort((a, b) => {
-        let aw = a.metaWindow;
-        let bw = b.metaWindow;
-        let ia = space.indexOf(aw);
-        let ib = space.indexOf(bw);
-        if (ia === -1 && ib === -1) {
+    if (space) {
+        clones.sort((a, b) => {
+            let aw = a.metaWindow;
+            let bw = b.metaWindow;
+            let ia = space.indexOf(aw);
+            let ib = space.indexOf(bw);
+            if (ia === -1 && ib === -1) {
+                return a.metaWindow.get_stable_sequence() - b.metaWindow.get_stable_sequence();
+            }
+            if (ia === -1) {
+                return -1;
+            }
+            if (ib === -1) {
+                return 1;
+            }
+            return ia - ib;
+        });
+    } else {
+        clones.sort((a, b) => {
             return a.metaWindow.get_stable_sequence() - b.metaWindow.get_stable_sequence();
-        }
-        if (ia === -1) {
-            return -1;
-        }
-        if (ib === -1) {
-            return 1;
-        }
-        return ia - ib;
-    });
+        });
+    }
 
     if (this._reservedSlot)
         clones.push(this._reservedSlot);
@@ -198,7 +204,7 @@ function _realRecalculateWindowPositions(flags) {
 function getOriginalPosition() {
     let c = this.metaWindow.clone;
     let space = Tiling.spaces.spaceOfWindow(this.metaWindow);
-    if (space.indexOf(this.metaWindow) === -1) {
+    if (!space || space.indexOf(this.metaWindow) === -1) {
         return [this._boundingBox.x, this._boundingBox.y];
     }
     let [x, y] = [ space.monitor.x + space.targetX + c.targetX, space.monitor.y + c.y];

--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -68,8 +68,9 @@ function createAppIcon(metaWindow, size) {
 /**
  */
 class ClickOverlay {
-    constructor(monitor) {
+    constructor(monitor, onlyOnPrimary) {
         this.monitor = monitor;
+        this.onlyOnPrimary = onlyOnPrimary;
         this.left = new StackOverlay(Meta.MotionDirection.LEFT, monitor);
         this.right = new StackOverlay(Meta.MotionDirection.RIGHT, monitor);
 
@@ -127,6 +128,8 @@ class ClickOverlay {
     }
 
     activate() {
+        if (this.onlyOnPrimary)
+            return;
         let monitor = this.monitor;
         let d = 10;
         this.enterMonitor.set_position(monitor.x + d, monitor.y + d);

--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -131,9 +131,8 @@ class ClickOverlay {
         if (this.onlyOnPrimary)
             return;
         let monitor = this.monitor;
-        let d = 10;
-        this.enterMonitor.set_position(monitor.x + d, monitor.y + d);
-        this.enterMonitor.set_size(monitor.width - 2*d, monitor.height - 2*d);
+        this.enterMonitor.set_position(monitor.x, monitor.y);
+        this.enterMonitor.set_size(monitor.width, monitor.height);
     }
 
     deactivate() {

--- a/tiling.js
+++ b/tiling.js
@@ -1816,16 +1816,7 @@ class Spaces extends Map {
     windowEnteredMonitor(screen, index, metaWindow) {
         debug('window-entered-monitor', index, metaWindow.title);
 
-        if (!metaWindow.get_compositor_private()) {
-            // Doing stuff to a actorless window is usually a bad idea
-            return;
-        }
-
-        if (!metaWindow.clone
-            || metaWindow.unmapped
-            || isWindowAnimating(metaWindow)
-            || this._monitorsChanging
-            || metaWindow.is_on_all_workspaces())
+        if (!inGrab || !metaWindow.get_compositor_private())
             return;
 
         let monitor = Main.layoutManager.monitors[index];
@@ -1833,17 +1824,9 @@ class Spaces extends Map {
         if (space.monitor !== monitor)
             return;
 
-        if (inGrab) {
-            spaces.spaceOfWindow(metaWindow).removeWindow(metaWindow);
-            inGrab.workspace = space.workspace;
-            return;
-        }
-
-        metaWindow.change_workspace(space.workspace);
-
-        // This doesn't play nice with the clickoverlay, disable for now
-        if (metaWindow.has_focus())
-            Main.activateWindow(metaWindow);
+        spaces.spaceOfWindow(metaWindow).removeWindow(metaWindow);
+        inGrab.workspace = space.workspace;
+        return;
     }
 }
 Signals.addSignalMethods(Spaces.prototype);

--- a/tiling.js
+++ b/tiling.js
@@ -1262,6 +1262,13 @@ class Spaces extends Map {
             overlay.destroy();
         }
         this.clickOverlays = [];
+        for (let monitor of Main.layoutManager.monitors) {
+            let overlay = new ClickOverlay(monitor, this.onlyOnPrimary);
+            monitor.clickOverlay = overlay;
+            overlay.activate();
+            this.clickOverlays.push(overlay);
+        }
+
         let mru = this.mru();
         let primary = Main.layoutManager.primaryMonitor;
         let monitors = Main.layoutManager.monitors;
@@ -1290,22 +1297,12 @@ class Spaces extends Map {
         };
 
         if (this.onlyOnPrimary) {
-            let overlay = new ClickOverlay(primary);
-            primary.clickOverlay = overlay;
-            this.clickOverlays.push(overlay);
             this.forEach(space => {
                 space.setMonitor(primary, false);
             });
             this.monitors.set(primary, mru[0]);
             finish();
             return;
-        }
-
-        for (let monitor of Main.layoutManager.monitors) {
-            let overlay = new ClickOverlay(monitor);
-            monitor.clickOverlay = overlay;
-            overlay.activate();
-            this.clickOverlays.push(overlay);
         }
 
 

--- a/tiling.js
+++ b/tiling.js
@@ -1432,8 +1432,8 @@ class Spaces extends Map {
 
     switchMonitor(direction, move) {
         let focus = display.focus_window;
-        let currentSpace = this.selectedSpace;
-        let monitor = currentSpace.monitor;
+        let monitor = Scratch.focusMonitor();
+        let currentSpace = this.monitors.get(monitor);
         let i = display.get_monitor_neighbor_index(monitor.index, direction);
         if (i === -1)
             return;
@@ -1443,7 +1443,7 @@ class Spaces extends Map {
         if (move && focus) {
             let metaWindow = focus.get_transient_for() || focus;
 
-            if (currentSpace.indexOf(metaWindow) !== -1) {
+            if (currentSpace && currentSpace.indexOf(metaWindow) !== -1) {
                 currentSpace.removeWindow(metaWindow);
                 metaWindow.foreach_transient((t) => {
                     currentSpace.removeWindow(t);
@@ -1451,11 +1451,18 @@ class Spaces extends Map {
             } else {
                 metaWindow.move_to_monitor(newMonitor.index);
             }
-            metaWindow.change_workspace(space.workspace);
             metaWindow.foreach_transient((t) => {
                 t.move_to_monitor(newMonitor.index);
             });
-            space.workspace.activate_with_focus(focus, global.get_current_time());
+            if (space) {
+                metaWindow.change_workspace(space.workspace);
+                metaWindow.foreach_transient((t) => {
+                    space.addFloating(t);
+                });
+                space.workspace.activate_with_focus(focus, global.get_current_time());
+            } else {
+                metaWindow.move_to_monitor(newMonitor.index);
+            }
         } else {
             space.workspace.activate(global.get_current_time());
         }

--- a/tiling.js
+++ b/tiling.js
@@ -2069,8 +2069,8 @@ function insertWindow(metaWindow, {existing}) {
 
     let actor = metaWindow.get_compositor_private();
 
-    let connectSizeChanged = (tiled) => {
-        if (tiled)
+    let connectSizeChanged = (show) => {
+        if (show)
             animateWindow(metaWindow);
         actor.opacity = 255;
         metaWindow.unmapped && signals.connect(metaWindow, 'size-changed', resizeHandler);
@@ -2114,8 +2114,13 @@ function insertWindow(metaWindow, {existing}) {
         }
     }
 
-    if (Scratch.isScratchWindow(metaWindow) && !metaWindow.is_on_all_workspaces()) {
-        // Moving from secondary monitor to primary can strip `is_on_all_workspaces`.
+    if (metaWindow.is_on_all_workspaces()) {
+        // Only connect the necessary signals and show windows on shared
+        // secondary monitors.
+        connectSizeChanged(true);
+        return;
+    } else if (Scratch.isScratchWindow(metaWindow)){
+        // And make sure scratch windows are stuck
         Scratch.makeScratch(metaWindow);
         return;
     }

--- a/tiling.js
+++ b/tiling.js
@@ -2114,6 +2114,12 @@ function insertWindow(metaWindow, {existing}) {
         }
     }
 
+    if (Scratch.isScratchWindow(metaWindow) && !metaWindow.is_on_all_workspaces()) {
+        // Moving from secondary monitor to primary can strip `is_on_all_workspaces`.
+        Scratch.makeScratch(metaWindow);
+        return;
+    }
+
     let space = spaces.spaceOfWindow(metaWindow);
     if (!add_filter(metaWindow)) {
         connectSizeChanged();

--- a/tiling.js
+++ b/tiling.js
@@ -1246,6 +1246,7 @@ class Spaces extends Map {
      */
     monitorsChanged() {
         this._monitorsChanging = true;
+        this.onlyOnPrimary = this.overrideSettings.get_boolean('workspaces-only-on-primary');
 
         if (this.monitors)
             oldMonitors = this.monitors;
@@ -1288,7 +1289,7 @@ class Spaces extends Map {
                 20, () => { this._monitorsChanging = false; });
         };
 
-        if (this.overrideSettings.get_boolean('workspaces-only-on-primary')) {
+        if (this.onlyOnPrimary) {
             let overlay = new ClickOverlay(primary);
             primary.clickOverlay = overlay;
             this.clickOverlays.push(overlay);


### PR DESCRIPTION
This adds better support for workspaces-only-on-primary:
- moving windows with grab
- moving between monitors (without or without a window)
- Only works properly when secondary monitors are above or below primary :-1: (Though this isn't a new bug) (I'm seeing some weirdness using a nested gnome-shell to test, which I'm unable to reproduce in a real session).

We now only handle grabs in `window-entered-monitor`, which should hopefully solve windows accidentally moving between workspaces when changing monitors :tada: 

~I opted to remove setting  `workspaces-only-on-primary` to false as a recommended setting, as things should honestly work a bit smoother with workspace only on primary.~