### PR TITLE
Actually support only on primary

### DIFF
--- a/scratch.js
+++ b/scratch.js
@@ -68,6 +68,8 @@ function makeScratch(metaWindow) {
 
     metaWindow[float] = true;
     metaWindow.make_above();
+    let space = Tiling.spaces.spaceOfWindow(metaWindow);
+    space.removeWindow(metaWindow);
     metaWindow.stick();  // NB! Removes the window from the tiling (synchronously)
 
     if (!metaWindow.minimized)

--- a/tiling.js
+++ b/tiling.js
@@ -2159,7 +2159,17 @@ function insertWindow(metaWindow, {existing}) {
         return;
     }
 
-    let space = spaces.spaceOfWindow(metaWindow);
+    // We now handle windows that are on only one workspace
+
+    /*
+      The window might have moved workspaces, while still being tiled on an old
+      space.
+
+      Since we delay removing tiled windows until it's added to another space we
+      need to look at what _workspace_ the window is on, not which _space_.
+     */
+    let workspace = metaWindow.get_workspace();
+    let space = spaces.spaceOf(workspace);
     if (!add_filter(metaWindow)) {
         connectSizeChanged();
         space.addFloating(metaWindow);

--- a/tiling.js
+++ b/tiling.js
@@ -2516,7 +2516,7 @@ function showHandler(actor) {
     let metaWindow = actor.meta_window;
     let onActive = metaWindow.get_workspace() === workspaceManager.get_active_workspace();
 
-    if (!metaWindow.clone.get_parent() && !metaWindow.unmapped)
+    if (!metaWindow.clone || (!metaWindow.clone.get_parent() && !metaWindow.unmapped))
         return;
 
     // HACK: use opacity instead of hidden on new windows

--- a/tiling.js
+++ b/tiling.js
@@ -1126,16 +1126,20 @@ box-shadow: 0px 0px 8px 0px rgba(0, 0, 0, .7);
                 Scratch.makeScratch(meta_window);
                 return;
             }
-            if(this.indexOf(meta_window) < 0 && add_filter(meta_window)) {
+            if(this.includes(meta_window) && add_filter(meta_window)) {
                 this.addWindow(meta_window, this.length);
             }
         })
 
-        let tabList = display.get_tab_list(Meta.TabList.NORMAL, workspace)
-            .filter(metaWindow => { return this.indexOf(metaWindow) !== -1; });
-        if (tabList[0]) {
-            this.selectedWindow = tabList[0]
-            // ensureViewport(space.selectedWindow, space);
+        if (oldSpace) {
+            this.selectedWindow = oldSpace.selectedWindow;
+        } else {
+            let tabList = display.get_tab_list(Meta.TabList.NORMAL, workspace)
+                .filter(metaWindow => { return this.indexOf(metaWindow) !== -1; });
+            if (tabList[0]) {
+                this.selectedWindow = tabList[0]
+                // ensureViewport(space.selectedWindow, space);
+            }
         }
     }
 

--- a/tiling.js
+++ b/tiling.js
@@ -564,6 +564,8 @@ class Space extends Array {
         if (this.indexOf(metaWindow) !== -1)
             return false;
 
+        metaWindow._workspace = this.workspace;
+
         if (row !== undefined && this[index]) {
             let column = this[index];
             column.splice(row, 0, metaWindow);
@@ -588,6 +590,7 @@ class Space extends Array {
         let index = this.indexOf(metaWindow);
         if (index === -1)
             return this.removeFloating(metaWindow);
+        metaWindow._workspace = null;
 
         let selected = this.selectedWindow;
         if (selected === metaWindow) {
@@ -760,6 +763,10 @@ class Space extends Array {
                 return i;
         }
         return -1;
+    }
+
+    includes(metaWindow) {
+        return metaWindow._workspace === this.workspace;
     }
 
     rowOf(metaWindow) {
@@ -1746,7 +1753,10 @@ class Spaces extends Map {
     };
 
     spaceOfWindow(meta_window) {
-        return this.get(meta_window.get_workspace());
+        let workspace = meta_window._workspace;
+        if (!workspace)
+            workspace = meta_window.get_workspace();
+        return this.get(workspace);
     };
 
     spaceOf(workspace) {

--- a/tiling.js
+++ b/tiling.js
@@ -564,6 +564,11 @@ class Space extends Array {
         if (this.indexOf(metaWindow) !== -1)
             return false;
 
+        let space = spaces.spaceOfWindow(metaWindow);
+        if (space.indexOf(metaWindow) !== -1 && space._populated) {
+            space.removeWindow(metaWindow);
+        }
+
         metaWindow._workspace = this.workspace;
 
         if (row !== undefined && this[index]) {
@@ -2033,11 +2038,11 @@ function remove_handler(workspace, meta_window) {
     // window has already received the `focus` signal at this point.
     // Not sure if we can check directly if _this_ window had focus when closed.
 
-    let space = spaces.spaceOf(workspace);
-    space.removeWindow(meta_window);
-
     let actor = meta_window.get_compositor_private();
     if (!actor) {
+        let space = spaces.spaceOf(workspace);
+        space.removeWindow(meta_window);
+
         signals.disconnect(meta_window);
         if (meta_window.clone && meta_window.clone.mapped) {
             meta_window.clone.destroy();

--- a/tiling.js
+++ b/tiling.js
@@ -1436,6 +1436,9 @@ class Spaces extends Map {
         for (let [workspace, space] of this) {
             if (workspaces[space.workspace] !== true) {
                 debug('workspace removed', space.workspace);
+                space.getWindows().forEach(mw => {
+                    space.removeWindow(mw);
+                });
                 this.removeSpace(space);
 
                 // Maps in javascript (and thus Spaces) remember insertion order

--- a/tiling.js
+++ b/tiling.js
@@ -2466,6 +2466,12 @@ function focus_handler(metaWindow, user_data) {
     }
 
     let space = spaces.spaceOfWindow(metaWindow);
+    // Do not act on stuck windows when switching to an empty workspace
+    if (metaWindow.on_all_workspaces && space !== spaces.selectedSpace &&
+        space.indexOf(metaWindow) !== -1)
+    {
+        return;
+    }
     space.monitor.clickOverlay.show();
 
     /**

--- a/tiling.js
+++ b/tiling.js
@@ -2144,6 +2144,10 @@ function insertWindow(metaWindow, {existing}) {
     if (metaWindow.is_on_all_workspaces()) {
         // Only connect the necessary signals and show windows on shared
         // secondary monitors.
+        let space = spaces.spaceOfWindow(metaWindow);
+        if (space.includes(metaWindow)) {
+            return;
+        }
         connectSizeChanged();
         showWindow(metaWindow);
         return;

--- a/tiling.js
+++ b/tiling.js
@@ -624,12 +624,12 @@ class Space extends Array {
         if (actor)
             actor.remove_clip();
 
-        this.layout();
         if (selected) {
-            ensureViewport(selected, this);
+            this.selectedWindow = selected;
         } else {
             this.selectedWindow = null;
         }
+        this.layout();
 
         this.emit('window-removed', metaWindow, index, row);
         return true;
@@ -783,7 +783,6 @@ class Space extends Array {
         if (this.cloneContainer.x !== this.targetX ||
             this.actor.y !== 0 ||
             Navigator.navigating || inPreview ||
-            Main.overview.visible ||
             // Only block on grab if we haven't detached the window yet
             (inGrab && !inGrab.workspace)
            ) {
@@ -831,7 +830,7 @@ class Space extends Array {
             const ch = Math.max(0, monitor.y + monitor.height - b.y - y);
             actor.set_clip(x, y, cw, ch);
 
-            showWindow(w);
+            !Main.overview.visible && showWindow(w);
         });
 
         this._floating.forEach(showWindow);


### PR DESCRIPTION
Here's an attempt to support workspaces-only-on-primary fully. In particular this means making secondary monitors to the left/right of primary work.

TODO: Fix window placement when removing secondary monitors.