### PR TITLE
wip: Edge dock 

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -2236,6 +2236,9 @@ function insertWindow(metaWindow, {existing}) {
         metaWindow.unmaximize(Meta.MaximizeFlags.BOTH);
         toggleMaximizeHorizontally(metaWindow);
     }
+    if (metaWindow.maximized_vertically) {
+        metaWindow.unmaximize(Meta.MaximizeFlags.VERTICAL);
+    }
 
     if (!existing) {
         actor.opacity = 0;

--- a/tiling.js
+++ b/tiling.js
@@ -778,7 +778,7 @@ class Space extends Array {
             Navigator.navigating || inPreview ||
             Main.overview.visible ||
             // Only block on grab if we haven't detached the window yet
-            (inGrab && !inGrab.workspace)
+            (inGrab && this.indexOf(inGrab.window) !== -1)
            ) {
             return;
         }


### PR DESCRIPTION
Fixes #50.

Make gnome-shelled tiled windows docked.

![image](https://user-images.githubusercontent.com/71978/67636322-bdef3500-f8cf-11e9-88ea-a49e81ccad23.png)
