### PR TITLE
Gnome 3.28 compatibility fixes for #182

### DIFF
--- a/kludges.js
+++ b/kludges.js
@@ -52,7 +52,9 @@ if (!global.display.get_monitor_neighbor_index) {
 }
 
 // polyfill for 3.28
-Meta.DisplayDirection = Meta.ScreenDirection;
+if (!Meta.DisplayDirection && Meta.ScreenDirection) {
+    Meta.DisplayDirection = Meta.ScreenDirection;
+}
 
 if (!St.Settings) {
     // `St.Settings` doesn't exist in 3.28 - polyfill:

--- a/kludges.js
+++ b/kludges.js
@@ -44,6 +44,16 @@ if (!global.display.get_monitor_scale) {
     global.display.constructor.prototype.get_monitor_scale = () => 1.0;
 }
 
+if (!global.display.get_monitor_neighbor_index) {
+    // `get_monitor_neighbor_index` polyfill a fallback for 3.28
+    global.display.constructor.prototype.get_monitor_neighbor_index = function(...args) {
+        return global.screen.get_monitor_neighbor_index(...args);
+    }
+}
+
+// polyfill for 3.28
+Meta.DisplayDirection = Meta.ScreenDirection;
+
 if (!St.Settings) {
     // `St.Settings` doesn't exist in 3.28 - polyfill:
     let Gtk = imports.gi.Gtk;


### PR DESCRIPTION
add global.display.get_monitor_neighbor_index that uses global.screen.get_monitor_neighbor_index
Meta.DisplayDirection = Meta.ScreenDirection;