### PR TITLE
Enable on install

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ We hang out on [zulip](https://paperwm.zulipchat.com).
 Clone the repo and run the
 [`install.sh`](https://github.com/paperwm/PaperWM/blob/master/install.sh) script
 from the repository. The installer will create a link to the repo in
-`$XDG_DATA_HOME/gnome-shell/extensions/`, it will then ask if you
-want to enable PaperWM, if so it will get gnome-shell to load and enable the extension.
+`$XDG_DATA_HOME/gnome-shell/extensions/`. It will then ask if you want to apply
+the recommended settings (see [Recommended
+Settings](#recommended-gnome-shell-settings) and lastly it will ask to enable PaperWM.
 ```bash
 ./install.sh # install, load and enable paperwm
 ```
@@ -35,12 +36,6 @@ Cloning the repo directly into `$XDG_DATA_HOME` also works (you can then run
 git clone 'https://github.com/paperwm/PaperWM.git' \
     "${XDG_DATA_HOME:-$HOME/.local/share}/gnome-shell/extensions/paperwm@hedning:matrix.org"
 ```
-
-There's a few Gnome Shell settings which works poorly with PaperWM. To use the
-recommended settings run
-[`set-recommended-gnome-shell-settings.sh`](https://github.com/paperwm/PaperWM/blob/master/set-recommended-gnome-shell-settings.sh).
-The script will simply turn off`auto-maximize`, `edge-tiling`, `attach-modal-dialogs` and
-`workspaces-only-on-primary` ([#216](https://github.com/paperwm/PaperWM/issues/216)). A "restore previous settings" script is generated so the original settings is not lost.
 
 Running the extension will automatically install a user config file as described in [Development & user configuration](#development--user-configuration).
 
@@ -244,6 +239,18 @@ Keybindings.bindkey("<Super>j", "my-favorite-width",
 ```
 
 See `examples/keybindings.js` for more examples.
+
+
+## Recommended Gnome Shell Settings ##
+
+To use the recommended settings run
+[`set-recommended-gnome-shell-settings.sh`](https://github.com/paperwm/PaperWM/blob/master/set-recommended-gnome-shell-settings.sh). A "restore previous settings" script is generated so the original settings is not lost.
+
+There's a few Gnome Shell settings which works poorly with PaperWM. Namely
+- `workspaces-only-on-primary`: Multi monitor support require workspaces
+  spanning all monitors
+- `edge-tiling`: We don't support the native half tiled windows
+- `attach-modal-dialogs` off: Attached modal dialogs can cause visual glitching
 
 ## Recommended extensions ##
 

--- a/README.md
+++ b/README.md
@@ -13,25 +13,27 @@ We hang out on [zulip](https://paperwm.zulipchat.com).
 
 ## Installation
 
-Clone the repo and run the [`install.sh`](https://github.com/paperwm/PaperWM/blob/master/install.sh) script from the directory. The installer will link the repo to `$XDG_DATA_HOME/gnome-shell/extensionspaperwm@hedning:matrix.org/` where gnome-shell can find it.
+Clone the repo and run the
+[`install.sh`](https://github.com/paperwm/PaperWM/blob/master/install.sh) script
+from the repository. The installer will create a link to the repo in
+`$XDG_DATA_HOME/gnome-shell/extensions/`, it will then ask if you
+want to enable PaperWM, if so it will get gnome-shell to load and enable the extension.
 ```bash
-./install.sh
+./install.sh # install, load and enable paperwm
 ```
+
+To uninstall simply run `./uninstall.sh`.
 
 You'll by default follow the
 [develop](https://github.com/paperwm/PaperWM/tree/develop) branch. If you want a
 possibly more stable experience you can follow the releases by checking out the
 [master](https://github.com/paperwm/PaperWM/tree/master) branch.
 
-Cloning the repo directly into `$XDG_DATA_HOME` also works:
+Cloning the repo directly into `$XDG_DATA_HOME` also works (you can then run
+`install.sh` to enable PaperWM):
 ```bash
 git clone 'https://github.com/paperwm/PaperWM.git' \
     "${XDG_DATA_HOME:-$HOME/.local/share}/gnome-shell/extensions/paperwm@hedning:matrix.org"
-```
-
-You can then enable the extension in Gnome Tweaks, or enable if from the command line:
-```bash
-gnome-shell-extension-tool -e paperwm@hedning:matrix.org
 ```
 
 There's a few Gnome Shell settings which works poorly with PaperWM. To use the
@@ -41,7 +43,6 @@ The script will simply turn off`auto-maximize`, `edge-tiling`, `attach-modal-dia
 `workspaces-only-on-primary` ([#216](https://github.com/paperwm/PaperWM/issues/216)). A "restore previous settings" script is generated so the original settings is not lost.
 
 Running the extension will automatically install a user config file as described in [Development & user configuration](#development--user-configuration).
-
 
 ### Note for Ubuntu users ###
 

--- a/install.sh
+++ b/install.sh
@@ -41,6 +41,7 @@ try {
 
     extensionSystem.loadExtension(extension);
     extensionSystem.enableExtension(uuid);
+    true
 } catch (e) {
     if (e.message === "paperwm-loaded")
        "paperwm already loaded"

--- a/install.sh
+++ b/install.sh
@@ -6,9 +6,25 @@ EXT_DIR=${XDG_DATA_HOME:-$HOME/.local/share}/gnome-shell/extensions
 mkdir -p "$EXT_DIR"
 ln -sn "$REPO" "$EXT_DIR"/"$UUID"
 
-read -p "Enable the extension [Y/n]: " consent
-case "$p" in
-    Y|"")
+cat <<EOF
+
+PaperWM runs best with some Gnome Shell settings changed:
+ workspaces-only-on-primary off: Required for working multi-monitor support
+ edge-tiling off: Natively tiled windows doesn't work in PaperWM
+ attach-modal-dialogs off: Attached modal dialogs can cause visual glitching
+EOF
+echo
+read -p "Use recommended settings (generates a backup) [Y/n]: " consent
+case "$consent" in
+    (Y|y|"")
+        $REPO/set-recommended-gnome-shell-settings.sh
+    ;;
+esac
+
+echo
+read -p "Enable the extension [Y/n]? " consent
+case "$consent" in
+    (Y|y|"")
     ;;
     *)
         exit

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,67 @@
 #!/usr/bin/env bash
 
+REPO="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+UUID=paperwm@hedning:matrix.org
 EXT_DIR=${XDG_DATA_HOME:-$HOME/.local/share}/gnome-shell/extensions
 mkdir -p "$EXT_DIR"
-ln -s "$(realpath .)" "$EXT_DIR"/'paperwm@hedning:matrix.org'
+ln -sn "$REPO" "$EXT_DIR"/"$UUID"
+
+read -p "Enable the extension [Y/n]: " consent
+case "$p" in
+    Y|"")
+    ;;
+    *)
+        exit
+    ;;
+esac
+
+# Coax gnome-shell to enable the extension, since gnome-extensions enable does't
+# work without a restart
+ENABLE=`cat <<EOF
+try {
+    let path = "$EXT_DIR";
+    let uuid = "$UUID";
+    let Gio = imports.gi.Gio;
+    let extensionUtils, extensionSystem, paperwm;
+    // Work around differences between 3.32 and 3.34
+    if (imports.misc.extensionUtils.createExtensionObject) {
+        extensionSystem = imports.ui.extensionSystem;
+        extensionUtils = imports.misc.extensionUtils;
+        paperwm = extensionUtils[uuid];
+    } else {
+        extensionSystem = imports.ui.main.extensionManager;
+        extensionUtils = extensionSystem;
+        paperwm = extensionSystem.lookup(uuid);
+    }
+    if (paperwm)
+        throw new Error("paperwm-loaded");
+
+    let dir = Gio.File.new_for_path(path + "/" + uuid);
+    let extension = extensionUtils.createExtensionObject(uuid, dir, 2);
+
+    extensionSystem.loadExtension(extension);
+    extensionSystem.enableExtension(uuid);
+} catch (e) {
+    if (e.message === "paperwm-loaded")
+       "paperwm already loaded"
+    else
+        e.message + "  " + e.stack;
+};
+EOF
+`
+echo "Trying to load and enable extension:"
+RET=`gdbus call --session -d org.gnome.Shell -o /org/gnome/Shell -m org.gnome.Shell.Eval "$ENABLE"`
+if [[ "(true, '\"paperwm already loaded\"')" = "$RET" ]]; then
+    echo "paperwm is already loaded, enabling with gnome-extensions"
+    if type gnome-extensions > /dev/null; then
+        gnome-extensions enable "$UUID"
+    else
+        gnome-shell-extension-tool --enable="$UUID"
+    fi
+    echo Success
+elif [[ "(true, 'true')" != "$RET" ]]; then
+    echo something went wrong:
+    echo $RET | sed -e "s/(true, '\"//" | sed -e "s/\\\\n/\n/g"
+else
+    echo Success
+fi

--- a/set-recommended-gnome-shell-settings.sh
+++ b/set-recommended-gnome-shell-settings.sh
@@ -42,8 +42,6 @@ function set-with-backup {
 
 ##### Recommended settings
 
-set-with-backup org.gnome.mutter auto-maximize false
-
 # Multi-monitor support is much more complete with workspaces spanning monitors
 set-with-backup org.gnome.shell.overrides workspaces-only-on-primary false
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# NOTE: gnome-extensions uninstall will delete all files in the linked directory
+
+REPO="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+if [[ -L "$REPO" ]]; then
+   REPO=`readlink --canonicalize "$REPO"`
+fi
+UUID=paperwm@hedning:matrix.org
+if type gnome-extensions > /dev/null; then
+    gnome-extensions disable "$UUID"
+else
+    gnome-shell-extension-tool --disable="$UUID"
+fi
+EXT_DIR=${XDG_DATA_HOME:-$HOME/.local/share}/gnome-shell/extensions
+EXT=$EXT_DIR/$UUID
+LINK=`readlink --canonicalize "$EXT"`
+if [[ "$LINK" != "$REPO" ]]; then
+    echo "$EXT" does not link to "$REPO", refusing to remove
+    exit 1
+fi
+rm $EXT


### PR DESCRIPTION
Apparently `gnome-extensions enable $uuid` doesn't work without a restart (at least not consistently). Use the same trick as in [gnome-shell-mode](https://github.com/paperwm/gnome-shell-mode/blob/master/local/gnome-shell-mode/bootstrap.js) to send js to get gnome-shell to load the extension.

Also add an uninstall script, which simply disables paperwm and removes the installed symlink. One would think `gnome-extensions uninstall` would be suitable, but unfortunately it doesn't handle symlink installs in a sane manner. It will actually go into the symlink, remove _everything_ recurively, including hidden directories like `.git`....,  and after it has wrecked havoc remove the directory :( 

ref #230 