### PR TITLE
Drag and drop windows while navigating

### DIFF
--- a/grab.js
+++ b/grab.js
@@ -211,6 +211,7 @@ var MoveGrab = class MoveGrab {
             return;
         this.dnd = true;
         global.display.end_grab_op(global.get_current_time());
+        global.display.set_cursor(Meta.Cursor.MOVE_OR_RESIZE_WINDOW);
 
         let metaWindow = this.window;
         let frame = metaWindow.get_frame_rect();
@@ -474,6 +475,7 @@ var MoveGrab = class MoveGrab {
         // space.workspace.activate(global.get_current_time());
         Tiling.inGrab = false;
         Navigator.getNavigator().finish();
+        global.display.set_cursor(Meta.Cursor.DEFAULT);
     }
 
     activateDndTarget(zone, first) {

--- a/grab.js
+++ b/grab.js
@@ -184,17 +184,21 @@ var MoveGrab = class MoveGrab {
             return actor;
         }
 
-        const lastClone = space[space.length - 1][0].clone;
-        const fakeClone = {
-            clone: {
-                targetX: lastClone.targetX + lastClone.width + gap,
-                targetY: lastClone.targetY,
-                width: columnZoneMargin,
-                height: tilingHeight
-            }
+        let fakeClone = {
+            targetX: null,
+            targetY: 0,
+            width: columnZoneMargin,
+            height: tilingHeight
         };
+        if (space.length > 0) {
+            const lastClone = space[space.length - 1][0].clone;
+            fakeClone.targetX = lastClone.x + lastClone.width + gap;
+        } else {
+            let [sx, sy] = space.viewportToScroll(Math.round(space.width/2), 0);
+            fakeClone.targetX = sx + halfGap;
+        }
 
-        const columns = [...space, [fakeClone]];
+        const columns = [...space, [{ clone: fakeClone }]];
         for (let j = 0; j < columns.length; j++) {
             const column = columns[j];
             const metaWindow = column[0];
@@ -278,7 +282,7 @@ var MoveGrab = class MoveGrab {
                 return true;
             if (!a || !b)
                 return false;
-            return a.position[0] === b.position[0] && a.position[1] === b.position[1];
+            return a.space === b.space && a.position[0] === b.position[0] && a.position[1] === b.position[1];
         }
 
         // TODO: rename dndTarget to selectedZone ?

--- a/grab.js
+++ b/grab.js
@@ -306,38 +306,6 @@ var MoveGrab = class MoveGrab {
         }
     }
 
-    // positionChanged() {
-    //     let metaWindow = this.window;
-
-    //     let [gx, gy, $] = global.get_pointer();
-
-    //     if (this.dnd) {
-    //         print("SHOULD NOT HAPPEND")
-    //         // this.selectDndZone(gx, gy);  // TODO: dead/obsolete?
-    //     } else {  // Move the window and scroll the space
-    //         let space = this.initialSpace;
-    //         let clone = metaWindow.clone;
-    //         let frame = metaWindow.get_frame_rect();
-    //         // scrollAnchhor = gx - space.monitor.x - space.cloneContainer.x
-    //         // scrollAnchhor - gx + space.monitor.x = - space.cloneContainer.x
-
-    //         space.targetX = gx - space.monitor.x - this.scrollAnchhor;
-    //         space.cloneContainer.x = space.targetX;
-
-    //         const threshold = 300;
-    //         const dy = Math.min(threshold, Math.abs(frame.y - this.initialY));
-    //         let s = 1 - Math.pow(dy / 500, 3);
-    //         let actor = metaWindow.get_compositor_private();
-    //         actor.set_scale(s, s);
-    //         clone.set_scale(s, s);
-    //         [clone.x, clone.y] = space.globalToScroll(frame.x, frame.y);
-
-    //         if (dy >= threshold) {
-    //             this.beginDnD();
-    //         }
-    //     }
-    // }
-
     // scroll(space, actor, event) {
     //     let dir = event.get_scroll_direction();
     //     if (dir === Clutter.ScrollDirection.SMOOTH)

--- a/grab.js
+++ b/grab.js
@@ -228,24 +228,15 @@ var MoveGrab = class MoveGrab {
         let actor = metaWindow.get_compositor_private();
         let clone = metaWindow.clone;
         let space = this.initialSpace;
-        let frame;
-        if (clone.get_parent()) {
-            // let point = clone.apply_transform_to_point(new Clutter.Vertex({x: 0, y: 0}));
-            let point = space.cloneContainer.apply_transform_to_point(new Clutter.Vertex({x: clone.x, y: clone.y}));
-            frame = {x: point.x, y: point.y,
-                width: clone.width,
-                height: clone.height
-            }
-        } else {
-            frame = metaWindow.get_frame_rect();
-        }
 
         let i = space.indexOf(metaWindow);
         let single = i !== -1 && space[i].length === 1;
         space.removeWindow(metaWindow);
         clone.reparent(Main.uiGroup);
-        clone.x = frame.x;
-        clone.y = frame.y;
+        let [gx, gy, $] = global.get_pointer();
+        let [dx, dy] = this.pointerOffset;
+        clone.x = gx - dx;
+        clone.y = gy - dy;
 
         let newScale = clone.scale_x*space.actor.scale_x;
         clone.set_scale(newScale, newScale);
@@ -256,7 +247,6 @@ var MoveGrab = class MoveGrab {
         this.spaceToDndZones = new Map();
         this.monitorToZones = createDndZonesForMonitors();
 
-        let [gx, gy, $] = global.get_pointer();
         let monitor = monitorAtPoint(gx, gy);
 
         let onSame = monitor === space.monitor;

--- a/grab.js
+++ b/grab.js
@@ -181,6 +181,10 @@ var MoveGrab = class MoveGrab {
         global.display.end_grab_op(global.get_current_time());
         global.display.set_cursor(Meta.Cursor.MOVE_OR_RESIZE_WINDOW);
 
+        for (let [monitor, $] of Tiling.spaces.monitors) {
+            monitor.clickOverlay.deactivate();
+        }
+
         let metaWindow = this.window;
         let actor = metaWindow.get_compositor_private();
         let clone = metaWindow.clone;
@@ -312,6 +316,11 @@ var MoveGrab = class MoveGrab {
             clone.x = gx - dx;
             clone.y = gy - dy;
         } else {
+            let monitor = monitorAtPoint(gx, gy);
+            if (monitor !== this.initialSpace.monitor) {
+                this.beginDnD();
+                return;
+            }
             let space = this.initialSpace;
             let clone = metaWindow.clone;
             let [ok, x, y] = space.actor.transform_stage_point(gx, gy);

--- a/grab.js
+++ b/grab.js
@@ -317,6 +317,13 @@ var MoveGrab = class MoveGrab {
                 this.beginDnD();
                 return;
             }
+
+            if (event.get_state() & Clutter.ModifierType.CONTROL_MASK) {
+                // NB: only works in wayland
+                this.beginDnD();
+                return;
+            }
+
             let space = this.initialSpace;
             let clone = metaWindow.clone;
             let [x, y] = space.globalToViewport(gx, gy);

--- a/grab.js
+++ b/grab.js
@@ -302,7 +302,8 @@ var MoveGrab = class MoveGrab {
 
     motion(actor, event) {
         let metaWindow = this.window;
-        let [gx, gy] = event.get_coords();
+        // let [gx, gy] = event.get_coords();
+        let [gx, gy, $] = global.get_pointer();
         let [dx, dy] = this.pointerOffset;
         let clone = metaWindow.clone;
 

--- a/grab.js
+++ b/grab.js
@@ -365,9 +365,10 @@ var MoveGrab = class MoveGrab {
                 let [x, y] = clone.get_position();
                 space.addWindow(metaWindow, ...dndTarget.position);
 
-
-                let [ok, sx, sy] = space.cloneContainer.transform_stage_point(x, y);
-                [clone.x, clone.y] = [sx, sy];
+                let [ok, sx, sy] = space.cloneContainer.transform_stage_point(gx, gy);
+                let [dx, dy] = this.pointerOffset;
+                clone.x = sx - dx;
+                clone.y = sy - dy;
                 let newScale = clone.scale_x/space.actor.scale_x;
                 clone.set_scale(newScale, newScale);
 

--- a/grab.js
+++ b/grab.js
@@ -191,7 +191,8 @@ var MoveGrab = class MoveGrab {
         let space = this.initialSpace;
         let frame = metaWindow.get_frame_rect();
 
-        this.initialY = clone.y;
+        this.initialY = clone.targetY;
+        Tweener.removeTweens(clone);
         let [gx, gy, $] = global.get_pointer();
 
         let px = (gx - actor.x) / actor.width;

--- a/grab.js
+++ b/grab.js
@@ -189,16 +189,20 @@ var MoveGrab = class MoveGrab {
 
         this.initialY = clone.y;
         let [gx, gy, $] = global.get_pointer();
-        this.pointerOffset = [gx - frame.x, gy - frame.y]
 
         let px = (gx - actor.x) / actor.width;
         let py = (gy - actor.y) / actor.height;
         actor.set_pivot_point(px, py);
 
-        let [x, y] = space.globalToScroll(gx, gy);
+        let [ok, x, y] = space.cloneContainer.transform_stage_point(gx, gy);
         px = (x - clone.x) / clone.width;
         py = (y - clone.y) / clone.height;
         clone.set_pivot_point(px, py);
+        if (clone.get_parent()) {
+            this.pointerOffset = [x - clone.x, y - clone.y];
+        } else {
+            this.pointerOffset = [gx - frame.x, gy - frame.y];
+        }
 
         this.signals.connect(global.stage, "button-release-event", this.end.bind(this));
         this.signals.connect(global.stage, "motion-event", this.motion.bind(this));

--- a/grab.js
+++ b/grab.js
@@ -272,10 +272,6 @@ var MoveGrab = class MoveGrab {
     }
 
     spaceMotion(space, background, event) {
-        e = event;
-        // e.get_coords()
-        // let p = new Clutter.Point()
-        // e.get_position(p)
         let [x, y] = event.get_coords();
         let [gx, gy, $] = global.get_pointer();
         let [ok, bx, by] = space.actor.transform_stage_point(gx, gy);

--- a/grab.js
+++ b/grab.js
@@ -315,7 +315,7 @@ var MoveGrab = class MoveGrab {
             let space = this.initialSpace;
             let clone = metaWindow.clone;
             let [ok, x, y] = space.actor.transform_stage_point(gx, gy);
-            space.targetX = x - space.monitor.x - this.scrollAnchor;
+            space.targetX = x - this.scrollAnchor;
             space.cloneContainer.x = space.targetX;
 
             clone.y = y - dy;

--- a/grab.js
+++ b/grab.js
@@ -306,39 +306,6 @@ var MoveGrab = class MoveGrab {
         }
     }
 
-    // scroll(space, actor, event) {
-    //     let dir = event.get_scroll_direction();
-    //     if (dir === Clutter.ScrollDirection.SMOOTH)
-    //         return;
-    //     // print(dir, Clutter.ScrollDirection.SMOOTH, Clutter.ScrollDirection.UP, Clutter.ScrollDirection.DOWN)
-    //     let dx
-    //     log(Utils.ppEnumValue(dir, Clutter.ScrollDirection))
-    //     // let dx = dir === Clutter.ScrollDirection.DOWN ? -1 : 1
-    //     // let [dx, dy] = event.get_scroll_delta()
-
-    //     let [gx, gy] = event.get_coords();
-    //     if (!gx) {
-    //         print("Noooo");
-    //         return;
-    //     }
-    //     print(dx, gx, gy);
-
-    //     switch (dir) {
-    //         case Clutter.ScrollDirection.LEFT:
-    //         case Clutter.ScrollDirection.DOWN:
-    //             space.switchLeft();
-    //             break;
-    //         case Clutter.ScrollDirection.RIGHT:
-    //         case Clutter.ScrollDirection.UP:
-    //             space.switchRight();
-    //             break;
-    //     }
-
-    //     // let speed = 30
-    //     // space.targetX += dx * speed
-    //     // space.cloneContainer.x += dx * speed
-    // }
-
     motion(actor, event) {
         let metaWindow = this.window;
         let [gx, gy] = event.get_coords();

--- a/grab.js
+++ b/grab.js
@@ -215,7 +215,7 @@ var MoveGrab = class MoveGrab {
             const colX = clone.targetX;
             const colW = clone.width;
 
-            // Fast forward if pointer is not inside column
+            // Fast forward if pointer is not inside the column or the column zone
             if (x < colX - gap - columnZoneMargin) {
                 continue;
             }
@@ -242,6 +242,10 @@ var MoveGrab = class MoveGrab {
                 };
                 break;
             }
+
+            // Must be strictly within the column to tile vertically
+            if (x < colX)
+                continue;
 
             for (let i = 0; i < column.length + 1; i++) {
                 let clone;

--- a/grab.js
+++ b/grab.js
@@ -103,6 +103,9 @@ var MoveGrab = class MoveGrab {
         this.center = center;
         this.dnd = true;
         log(`beginDND`)
+        Navigator.getNavigator()
+                 .minimaps.forEach(m => typeof(m) === 'number' ?
+                                   Mainloop.source_remove(m) : m.hide());
         global.display.set_cursor(Meta.Cursor.MOVE_OR_RESIZE_WINDOW);
         let metaWindow = this.window;
         let actor = metaWindow.get_compositor_private();

--- a/grab.js
+++ b/grab.js
@@ -386,7 +386,8 @@ var MoveGrab = class MoveGrab {
             space.targetX = gx - space.monitor.x - this.scrollAnchor;
             space.cloneContainer.x = space.targetX;
 
-            clone.y = gy - dy + space.monitor.y;
+            let [ok, x, y] = space.cloneContainer.transform_stage_point(gx, gy);
+            clone.y = y - dy;
 
             const threshold = 300;
             dy = Math.min(threshold, Math.abs(clone.y - this.initialY));

--- a/grab.js
+++ b/grab.js
@@ -461,7 +461,7 @@ var MoveGrab = class MoveGrab {
         // metaWindow.change_workspace(space.workspace)
         // space.workspace.activate(global.get_current_time());
         Tiling.inGrab = false;
-        Navigator.getNavigator().finish(destSpace);
+        Navigator.getNavigator().finish(destSpace, metaWindow);
         global.display.set_cursor(Meta.Cursor.DEFAULT);
     }
 

--- a/grab.js
+++ b/grab.js
@@ -76,7 +76,7 @@ var MoveGrab = class MoveGrab {
         py = (y - clone.y) / clone.height;
         !center && clone.set_pivot_point(px, py);
         center && clone.set_pivot_point(0, 0);
-        if (clone.get_parent()) {
+        if (clone.get_parent() === this.initialSpace.cloneContainer) {
             this.pointerOffset = [x - clone.x, y - clone.y];
         } else {
             this.pointerOffset = [gx - frame.x, gy - frame.y];

--- a/grab.js
+++ b/grab.js
@@ -16,6 +16,7 @@ var Scratch = Extension.imports.scratch;
 var prefs = Extension.imports.settings.prefs;
 var Utils = Extension.imports.utils;
 var Tweener = Utils.tweener;
+var Navigator = Extension.imports.navigator;
 
 
 function isInRect(x, y, r) {
@@ -389,11 +390,6 @@ var MoveGrab = class MoveGrab {
                 let [x, y] = clone.get_position();
                 space.addWindow(metaWindow, ...dndTarget.position);
 
-                // Make sure the window is on the correct workspace.
-                // If the window is transient this will take care of its parent too.
-                // metaWindow.change_workspace(space.workspace);
-                // space.workspace.activate(global.get_current_time());
-
                 [clone.x, clone.y] = space.globalToScroll(x, y);
 
                 actor.set_scale(1, 1);
@@ -411,7 +407,7 @@ var MoveGrab = class MoveGrab {
                 });
 
                 space.targetX = space.cloneContainer.x;
-                space.selectedWindow = metaWindow
+                space.selectedWindow = metaWindow;
                 if (dndTarget.position) {
                     space.layout(true, {customAllocators: {[dndTarget.position[0]]: Tiling.allocateEqualHeight}});
                 } else {
@@ -422,7 +418,7 @@ var MoveGrab = class MoveGrab {
 
                 clone.raise_top()
             } else {
-                // metaWindow.move_frame(true, )
+                metaWindow.move_frame(true, clone.x, clone.y);
                 Scratch.makeScratch(metaWindow);
                 this.initialSpace.moveDone();
 
@@ -477,6 +473,7 @@ var MoveGrab = class MoveGrab {
         // metaWindow.change_workspace(space.workspace)
         // space.workspace.activate(global.get_current_time());
         Tiling.inGrab = false;
+        Navigator.getNavigator().finish();
     }
 
     activateDndTarget(zone, first) {

--- a/grab.js
+++ b/grab.js
@@ -282,7 +282,13 @@ var MoveGrab = class MoveGrab {
     }
 
     spaceMotion(space, background, event) {
-        let [bx, by] = event.get_coords();
+        e = event;
+        // e.get_coords()
+        // let p = new Clutter.Point()
+        // e.get_position(p)
+        let [x, y] = event.get_coords();
+        let [gx, gy, $] = global.get_pointer();
+        let [ok, bx, by] = space.actor.transform_stage_point(gx, gy);
         this.selectDndZone(space, bx - space.targetX, by);
     }
 
@@ -387,10 +393,10 @@ var MoveGrab = class MoveGrab {
         } else {
             let space = this.initialSpace;
             let clone = metaWindow.clone;
-            space.targetX = gx - space.monitor.x - this.scrollAnchor;
+            let [ok, x, y] = space.actor.transform_stage_point(gx, gy);
+            space.targetX = x - space.monitor.x - this.scrollAnchor;
             space.cloneContainer.x = space.targetX;
 
-            let [ok, x, y] = space.cloneContainer.transform_stage_point(gx, gy);
             clone.y = y - dy;
 
             const threshold = 300;

--- a/grab.js
+++ b/grab.js
@@ -201,7 +201,6 @@ var MoveGrab = class MoveGrab {
         clone.set_pivot_point(px, py);
 
         this.signals.connect(global.stage, "button-release-event", this.end.bind(this));
-        this.signals.connect(global.stage, "button-press-event", this.end.bind(this));
         this.signals.connect(global.stage, "motion-event", this.motion.bind(this));
         this.signals.connect(
             global.screen || global.display, "window-entered-monitor",
@@ -245,9 +244,10 @@ var MoveGrab = class MoveGrab {
 
         let [gx, gy, $] = global.get_pointer();
 
-        this.spaceToDndZones = new Map();
+        this.signals.connect(global.stage, "button-press-event", this.end.bind(this));
         this.signals.connect(global.stage, "scroll-event", this.scroll.bind(this));
 
+        this.spaceToDndZones = new Map();
         this.monitorToZones = createDndZonesForMonitors();
 
         let monitor = monitorAtPoint(gx, gy);
@@ -425,6 +425,8 @@ var MoveGrab = class MoveGrab {
                 let [x, y] = clone.get_position();
                 space.addWindow(metaWindow, ...dndTarget.position);
 
+                this.window = null;
+
                 [clone.x, clone.y] = space.globalToScroll(x, y);
 
                 actor.set_scale(1, 1);
@@ -524,10 +526,10 @@ var MoveGrab = class MoveGrab {
 
             let clone = this.window.clone;
             let space = zone.space;
-            let [x, y] = clone.get_transformed_position()
-            log(...clone.get_transformed_position(), clone.get_parent(), clone.x, clone.y, space.targetX)
-            log(clone.get_transformed_size())
-            zone.actor.set_position(...space.globalToScroll(x, y))
+            // let [x, y] = clone.get_transformed_position()
+            // log(...clone.get_transformed_position(), clone.get_parent(), clone.x, clone.y, space.targetX)
+            // log(clone.get_transformed_size())
+            zone.actor.set_position(...clone.get_transformed_position())
             zone.actor.set_size(...clone.get_transformed_size())
         } else {
             zone.actor[zone.sizeProp] = 0;

--- a/grab.js
+++ b/grab.js
@@ -117,10 +117,16 @@ var MoveGrab = class MoveGrab {
         let clone = metaWindow.clone;
         let space = this.initialSpace;
 
-        let point = {x: clone.x, y: clone.y};
-        if (clone.get_parent() !== Main.uiGroup) {
+        let [gx, gy, $] = global.get_pointer();
+        let point = {};
+        if (center) {
             point = space.cloneContainer.apply_relative_transform_to_point(
-                global.stage, new Clutter.Vertex({x: clone.x, y: clone.y}));
+                global.stage, new Clutter.Vertex({x: Math.round(clone.x), y: Math.round(clone.y)}));
+        } else {
+            // For some reason the above isn't smooth when DnD is triggered from dragging
+            let [dx, dy] = this.pointerOffset;
+            point.x = gx - dx;
+            point.y = gy - dy;
         }
 
         let i = space.indexOf(metaWindow);
@@ -134,7 +140,6 @@ var MoveGrab = class MoveGrab {
         clone.set_scale(newScale, newScale);
 
         let params = {time: prefs.animation_time, scale_x: 0.5, scale_y: 0.5, opacity: 240}
-        let [gx, gy, $] = global.get_pointer();
         if (center) {
             this.pointerOffset = [0, 0];
             clone.set_pivot_point(0, 0)

--- a/grab.js
+++ b/grab.js
@@ -345,6 +345,7 @@ var MoveGrab = class MoveGrab {
         let actor = metaWindow.get_compositor_private();
         let frame = metaWindow.get_frame_rect();
         let clone = metaWindow.clone;
+        let destSpace;
         let [gx, gy, $] = global.get_pointer();
 
         if (this.dnd) {
@@ -356,6 +357,7 @@ var MoveGrab = class MoveGrab {
 
             if (dndTarget) {
                 let space = dndTarget.space;
+                destSpace = space;
                 space.selection.show()
 
                 if (Scratch.isScratchWindow(metaWindow))
@@ -416,6 +418,7 @@ var MoveGrab = class MoveGrab {
             }
         } else if (this.initialSpace.indexOf(metaWindow) !== -1){
             let space = this.initialSpace;
+            destSpace = space;
             space.targetX = space.cloneContainer.x;
 
             actor.set_scale(1, 1);
@@ -449,7 +452,7 @@ var MoveGrab = class MoveGrab {
         // metaWindow.change_workspace(space.workspace)
         // space.workspace.activate(global.get_current_time());
         Tiling.inGrab = false;
-        Navigator.getNavigator().finish();
+        Navigator.getNavigator().finish(destSpace);
         global.display.set_cursor(Meta.Cursor.DEFAULT);
     }
 

--- a/grab.js
+++ b/grab.js
@@ -93,6 +93,7 @@ var MoveGrab = class MoveGrab {
         space.startAnimate();
         // Make sure the window actor is visible
         Tiling.animateWindow(metaWindow);
+        Navigator.getNavigator();
         Tweener.removeTweens(space.cloneContainer);
     }
 

--- a/grab.js
+++ b/grab.js
@@ -147,6 +147,7 @@ var MoveGrab = class MoveGrab {
             params.y = gy
         }
 
+        clone.__oldOpacity = clone.opacity
         Tweener.addTween(clone, params);
 
         this.signals.connect(global.stage, "button-press-event", this.end.bind(this));
@@ -369,7 +370,7 @@ var MoveGrab = class MoveGrab {
             time: prefs.animation_time,
             scale_x: 1,
             scale_y: 1,
-            opacity: 255
+            opacity: clone.__oldOpacity || 255
         };
 
         if (this.dnd) {
@@ -423,7 +424,7 @@ var MoveGrab = class MoveGrab {
                 actor.set_scale(clone.scale_x, clone.scale_y);
                 actor.opacity = clone.opacity;
 
-                clone.opacity = 255;
+                clone.opacity = clone.__oldOpacity || 255;
                 clone.set_scale(1, 1);
                 clone.set_pivot_point(0, 0);
 

--- a/grab.js
+++ b/grab.js
@@ -385,6 +385,8 @@ var MoveGrab = class MoveGrab {
                 if (Scratch.isScratchWindow(metaWindow))
                     Scratch.unmakeScratch(metaWindow);
 
+                // Remember the global coordinates of the clone
+                let [x, y] = clone.get_position();
                 space.addWindow(metaWindow, ...dndTarget.position);
 
                 // Make sure the window is on the correct workspace.
@@ -392,7 +394,7 @@ var MoveGrab = class MoveGrab {
                 // metaWindow.change_workspace(space.workspace);
                 // space.workspace.activate(global.get_current_time());
 
-                [clone.x, clone.y] = space.globalToScroll(clone.x, clone.y);
+                [clone.x, clone.y] = space.globalToScroll(x, y);
 
                 actor.set_scale(1, 1);
                 actor.set_pivot_point(0, 0);
@@ -415,7 +417,7 @@ var MoveGrab = class MoveGrab {
                 } else {
                     space.layout();
                 }
-                Tiling.move_to(space, metaWindow, {x: frame.x - space.monitor.x})
+                Tiling.move_to(space, metaWindow, {x: x - space.monitor.x})
                 Tiling.ensureViewport(metaWindow, space);
 
                 clone.raise_top()

--- a/kludges.js
+++ b/kludges.js
@@ -52,6 +52,11 @@ if (!global.display.get_monitor_neighbor_index) {
     }
 }
 
+
+if (!global.display.set_cursor) {
+    global.display.constructor.prototype.set_cursor = global.screen.set_cursor.bind(global.screen);
+}
+
 // polyfill for 3.28
 if (!Meta.DisplayDirection && Meta.ScreenDirection) {
     Meta.DisplayDirection = Meta.ScreenDirection;

--- a/navigator.js
+++ b/navigator.js
@@ -250,8 +250,9 @@ var Navigator = class Navigator {
 
         if (force) {
             this.space.monitor.clickOverlay.hide();
-            this.space = Tiling.spaces.selectedSpace;
         }
+
+        this.space = Tiling.spaces.selectedSpace;
 
         let from = this.from;
         let selected = this.space.selectedWindow;
@@ -283,22 +284,28 @@ var Navigator = class Navigator {
 
         selected = this.space.indexOf(selected) !== -1 ? selected :
                    this.space.selectedWindow;
-        if (selected &&
-            (!force ||
-             !(display.focus_window && display.focus_window.is_on_all_workspaces())) ) {
 
-            let hasFocus = selected.has_focus();
-            selected.foreach_transient(mw => hasFocus = mw.has_focus() || hasFocus);
-            if (!hasFocus) {
-                Main.activateWindow(selected);
-            } else {
-                // Typically on cancel - the `focus` signal won't run
-                // automatically, so we run it manually
-                this.space.workspace.activate(global.get_current_time());
-                Tiling.focus_handler(selected);
-            }
+        if (Tiling.inGrab && Tiling.inGrab.dnd) {
+            Tiling.spaces.monitors.set(this.monitor, this.space);
+            Tiling.spaces.animateToSpace(this.space);
         } else {
-            this.space.workspace.activate(global.get_current_time());
+            if (selected &&
+                (!force ||
+                !(display.focus_window && display.focus_window.is_on_all_workspaces())) ) {
+
+                let hasFocus = selected.has_focus();
+                selected.foreach_transient(mw => hasFocus = mw.has_focus() || hasFocus);
+                if (!hasFocus) {
+                    Main.activateWindow(selected);
+                } else {
+                    // Typically on cancel - the `focus` signal won't run
+                    // automatically, so we run it manually
+                    this.space.workspace.activate(global.get_current_time());
+                    Tiling.focus_handler(selected);
+                }
+            } else {
+                this.space.workspace.activate(global.get_current_time());
+            }
         }
 
         TopBar.fixTopBar();

--- a/navigator.js
+++ b/navigator.js
@@ -208,6 +208,7 @@ var Navigator = class Navigator {
 
         TopBar.fixTopBar();
 
+        Scratch.animateWindows();
         this.space.startAnimate();
     }
 
@@ -316,6 +317,9 @@ var Navigator = class Navigator {
                 Main.activateWindow(selected);
             }
         }
+
+        if (!Tiling.inGrab)
+            Scratch.showWindows();
 
         TopBar.fixTopBar();
 

--- a/navigator.js
+++ b/navigator.js
@@ -194,6 +194,10 @@ var Navigator = class Navigator {
         this._block = Main.wm._blockAnimations;
         Main.wm._blockAnimations = true;
         // Meta.disable_unredirect_for_screen(screen);
+        //
+        if (Tiling.inGrab && Tiling.inGrab.window) {
+            Tiling.inGrab.beginDnD();
+        }
 
         this.space = Tiling.spaces.spaceOf(workspaceManager.get_active_workspace());
 

--- a/navigator.js
+++ b/navigator.js
@@ -327,6 +327,7 @@ var Navigator = class Navigator {
         TopBar.fixTopBar();
 
         Main.wm._blockAnimations = this._block;
+        this.space.moveDone();
 
         this.emit('destroy', this.was_accepted);
         navigator = false;

--- a/navigator.js
+++ b/navigator.js
@@ -231,14 +231,14 @@ var Navigator = class Navigator {
         this.was_accepted = true;
     }
 
-    finish(space) {
+    finish(space, focus) {
         if (grab)
             return;
         this.accept();
-        this.destroy(space);
+        this.destroy(space, focus);
     }
 
-    destroy(space) {
+    destroy(space, focus) {
         this.minimaps.forEach(m => {
             if (typeof(m) === 'number')
                 Mainloop.source_remove(m);
@@ -304,8 +304,11 @@ var Navigator = class Navigator {
         selected = this.space.indexOf(selected) !== -1 ? selected :
                    this.space.selectedWindow;
 
-        let focus = display.focus_window;
-        if (focus && focus.is_on_all_workspaces())
+        let curFocus = display.focus_window;
+        if (force && curFocus && curFocus.is_on_all_workspaces())
+            selected = curFocus;
+
+        if (focus)
             selected = focus;
 
         if (selected && !Tiling.inGrab) {

--- a/navigator.js
+++ b/navigator.js
@@ -317,6 +317,9 @@ var Navigator = class Navigator {
                 Main.activateWindow(selected);
             }
         }
+        if (selected && Tiling.inGrab && !this.was_accepted) {
+            Tiling.focus_handler(selected)
+        }
 
         if (!Tiling.inGrab)
             Scratch.showWindows();

--- a/navigator.js
+++ b/navigator.js
@@ -268,14 +268,16 @@ var Navigator = class Navigator {
                 selected = display.focus_window;
         }
 
-        if (this.monitor !== this.space.monitor) {
-            this.space.setMonitor(this.monitor, true);
-        }
-
+        let visible = [];
         for (let monitor of Main.layoutManager.monitors) {
-            if (monitor === this.monitor || !monitor.clickOverlay)
+            visible.push( Tiling.spaces.monitors.get(monitor));
+            if (monitor === this.monitor)
                 continue;
             monitor.clickOverlay.activate();
+        }
+
+        if (!visible.includes(space) && this.monitor !== this.space.monitor) {
+            this.space.setMonitor(this.monitor, true);
         }
 
         if (this.space === from) {

--- a/navigator.js
+++ b/navigator.js
@@ -230,14 +230,14 @@ var Navigator = class Navigator {
         this.was_accepted = true;
     }
 
-    finish() {
+    finish(space) {
         if (grab)
             return;
         this.accept();
-        this.destroy();
+        this.destroy(space);
     }
 
-    destroy() {
+    destroy(space) {
         this.minimaps.forEach(m => {
             if (typeof(m) === 'number')
                 Mainloop.source_remove(m);
@@ -255,7 +255,7 @@ var Navigator = class Navigator {
             this.space.monitor.clickOverlay.hide();
         }
 
-        this.space = Tiling.spaces.selectedSpace;
+        this.space = space || Tiling.spaces.selectedSpace;
 
         let from = this.from;
         let selected = this.space.selectedWindow;

--- a/navigator.js
+++ b/navigator.js
@@ -286,7 +286,11 @@ var Navigator = class Navigator {
             // again doesn't trigger a switch signal
             force && Tiling.spaces.animateToSpace(this.space);
         } else {
-            this.space.workspace.activate(global.get_current_time());
+            if (Tiling.inGrab && Tiling.inGrab.window) {
+                this.space.workspace.activate_with_focus(Tiling.inGrab.window, global.get_current_time());
+            } else {
+                this.space.workspace.activate(global.get_current_time());
+            }
         }
 
         selected = this.space.indexOf(selected) !== -1 ? selected :
@@ -296,7 +300,7 @@ var Navigator = class Navigator {
         if (focus && focus.is_on_all_workspaces())
             selected = focus;
 
-        if (selected) {
+        if (selected && !Tiling.inGrab) {
             let hasFocus = selected && selected.has_focus();
             selected.foreach_transient(mw => hasFocus = mw.has_focus() || hasFocus);
             if (hasFocus) {

--- a/navigator.js
+++ b/navigator.js
@@ -294,9 +294,9 @@ var Navigator = class Navigator {
             } else {
                 // Typically on cancel - the `focus` signal won't run
                 // automatically, so we run it manually
+                this.space.workspace.activate(global.get_current_time());
                 Tiling.focus_handler(selected);
             }
-            debug('#preview', 'Finish', selected.title);
         } else {
             this.space.workspace.activate(global.get_current_time());
         }

--- a/navigator.js
+++ b/navigator.js
@@ -278,36 +278,29 @@ var Navigator = class Navigator {
             monitor.clickOverlay.activate();
         }
 
-        if (this.space === from && force) {
+        if (this.space === from) {
             // Animate the selected space into full view - normally this
             // happens on workspace switch, but activating the same workspace
             // again doesn't trigger a switch signal
-            Tiling.spaces.animateToSpace(this.space);
+            force && Tiling.spaces.animateToSpace(this.space);
+        } else {
+            this.space.workspace.activate(global.get_current_time());
         }
 
         selected = this.space.indexOf(selected) !== -1 ? selected :
                    this.space.selectedWindow;
 
-        if (Tiling.inGrab && Tiling.inGrab.dnd) {
-            Tiling.spaces.monitors.set(this.monitor, this.space);
-            Tiling.spaces.animateToSpace(this.space);
-        } else {
-            if (selected &&
-                (!force ||
-                !(display.focus_window && display.focus_window.is_on_all_workspaces())) ) {
+        let focus = display.focus_window;
+        if (focus && focus.is_on_all_workspaces())
+            selected = focus;
 
-                let hasFocus = selected.has_focus();
-                selected.foreach_transient(mw => hasFocus = mw.has_focus() || hasFocus);
-                if (!hasFocus) {
-                    Main.activateWindow(selected);
-                } else {
-                    // Typically on cancel - the `focus` signal won't run
-                    // automatically, so we run it manually
-                    this.space.workspace.activate(global.get_current_time());
-                    Tiling.focus_handler(selected);
-                }
+        if (selected) {
+            let hasFocus = selected && selected.has_focus();
+            selected.foreach_transient(mw => hasFocus = mw.has_focus() || hasFocus);
+            if (hasFocus) {
+                Tiling.focus_handler(selected)
             } else {
-                this.space.workspace.activate(global.get_current_time());
+                Main.activateWindow(selected);
             }
         }
 

--- a/navigator.js
+++ b/navigator.js
@@ -245,6 +245,10 @@ var Navigator = class Navigator {
                 m.destroy();
         });
 
+        if (Tiling.inGrab && !Tiling.inGrab.dnd) {
+            Tiling.inGrab.beginDnD()
+        }
+
         if (Main.panel.statusArea.appMenu)
             Main.panel.statusArea.appMenu.container.show();
 

--- a/navigator.js
+++ b/navigator.js
@@ -153,10 +153,6 @@ var ActionDispatcher = class {
         let metaWindow = space.selectedWindow;
 
         if (action && action.options.activeInNavigator) {
-            if (Tiling.inGrab && !Tiling.inGrab.dnd && Tiling.inGrab.window) {
-                Tiling.inGrab.beginDnD();
-            }
-
             if (!Tiling.inGrab && action.options.opensMinimap) {
                 this.navigator._showMinimap(space);
             }
@@ -165,6 +161,10 @@ var ActionDispatcher = class {
                 this.navigator.minimaps.forEach(m => typeof(m) === 'number' ?
                                                 Mainloop.source_remove(m) : m.hide());
             }
+            if (Tiling.inGrab && !Tiling.inGrab.dnd && Tiling.inGrab.window) {
+                Tiling.inGrab.beginDnD();
+            }
+
             return true;
         } else if (mutterActionId == Meta.KeyBindingAction.MINIMIZE) {
             metaWindow.minimize();

--- a/navigator.js
+++ b/navigator.js
@@ -153,7 +153,11 @@ var ActionDispatcher = class {
         let metaWindow = space.selectedWindow;
 
         if (action && action.options.activeInNavigator) {
-            if (action.options.opensMinimap) {
+            if (Tiling.inGrab && !Tiling.inGrab.dnd && Tiling.inGrab.window) {
+                Tiling.inGrab.beginDnD();
+            }
+
+            if (!Tiling.inGrab && action.options.opensMinimap) {
                 this.navigator._showMinimap(space);
             }
             action.handler(metaWindow, space, {navigator: this.navigator});
@@ -194,11 +198,6 @@ var Navigator = class Navigator {
         this._block = Main.wm._blockAnimations;
         Main.wm._blockAnimations = true;
         // Meta.disable_unredirect_for_screen(screen);
-        //
-        if (Tiling.inGrab && Tiling.inGrab.window) {
-            Tiling.inGrab.beginDnD();
-        }
-
         this.space = Tiling.spaces.spaceOf(workspaceManager.get_active_workspace());
 
         this._startWindow = this.space.selectedWindow;

--- a/navigator.js
+++ b/navigator.js
@@ -284,7 +284,10 @@ var Navigator = class Navigator {
             // Animate the selected space into full view - normally this
             // happens on workspace switch, but activating the same workspace
             // again doesn't trigger a switch signal
-            force && Tiling.spaces.animateToSpace(this.space);
+            if (force) {
+                const workspaceId = this.space.workspace.index();
+                Tiling.spaces.switchWorkspace(null, workspaceId, workspaceId);
+            }
         } else {
             if (Tiling.inGrab && Tiling.inGrab.window) {
                 this.space.workspace.activate_with_focus(Tiling.inGrab.window, global.get_current_time());

--- a/notes.org
+++ b/notes.org
@@ -290,3 +290,7 @@ The absolute path of the an extension: `Extension.dir.get_path()`
 Clutter prints the FPS at regular intervals if ~CLUTTER_SHOW_FPS~ is set when gnome-shell starts. Where the output ends up depends on how gnome-shell was started. On my system it ends up in the system journal (journalctl)
 
 To turn on off without disrupting flow too much use ~GLib.setenv("CLUTTER_SHOW_FPS", "1", true)~ and restart gnome-shell.
+* Invariants
+** Focus and active workspace
+It's not possible the have a focused window which doesn't belong to the active workspace
+~global.display.focus_window.workspace === workspaceManger.get_active_workspace()~

--- a/notes.org
+++ b/notes.org
@@ -294,3 +294,5 @@ To turn on off without disrupting flow too much use ~GLib.setenv("CLUTTER_SHOW_F
 ** Focus and active workspace
 It's not possible the have a focused window which doesn't belong to the active workspace
 ~global.display.focus_window.workspace === workspaceManger.get_active_workspace()~
+* Clutter animation
+  ~time: 0~ does not result in an instant animation. A default duration seems to be selected instead.

--- a/scratch.js
+++ b/scratch.js
@@ -199,6 +199,24 @@ function hide() {
     });
 }
 
+function animateWindows() {
+    let ws = getScratchWindows().filter(w => !w.minimized);
+    ws = global.display.sort_windows_by_stacking(ws);
+    for (let w of ws) {
+        let parent = w.clone.get_parent()
+        parent && parent.remove_child(w.clone);
+        Main.uiGroup.insert_child_below(w.clone, Main.layoutManager.panelBox)
+        let f = w.get_frame_rect();
+        w.clone.set_position(f.x, f.y);
+        Tiling.animateWindow(w);
+    }
+}
+
+function showWindows() {
+    let ws = getScratchWindows().filter(w => !w.minimized);
+    ws.forEach(Tiling.showWindow)
+}
+
 // Monkey patch the alt-space menu
 var PopupMenu = imports.ui.popupMenu;
 var WindowMenu = imports.ui.windowMenu;

--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -373,6 +373,8 @@ var StackOverlay = class StackOverlay {
         let column = space[index];
         this.target = mru.filter(w => column.includes(w))[0];
         let metaWindow = this.target;
+        if (!metaWindow)
+            return;
 
         let overlay = this.overlay;
         let actor = metaWindow.get_compositor_private();

--- a/tiling.js
+++ b/tiling.js
@@ -1078,6 +1078,8 @@ box-shadow: 0px 0px 8px 0px rgba(0, 0, 0, .7);
         this.signals.connect(
             this.background, 'scroll-event',
             (actor, event) => {
+                if (!inGrab && !Navigator.navigating)
+                    return;
                 let dir = event.get_scroll_direction();
                 if (dir === Clutter.ScrollDirection.SMOOTH)
                     return;

--- a/tiling.js
+++ b/tiling.js
@@ -1606,6 +1606,10 @@ class Spaces extends Map {
         let toSpace = this.spaceOf(to);
         let fromSpace = this.spaceOf(from);
 
+        if (inGrab && inGrab.window) {
+            inGrab.window.change_workspace(toSpace.workspace);
+        }
+
         for (let metaWindow of toSpace.getWindows()) {
             // Make sure all windows belong to the correct workspace.
             // Note: The 'switch-workspace' signal (this method) runs before mutter decides on focus window.

--- a/tiling.js
+++ b/tiling.js
@@ -1069,9 +1069,10 @@ box-shadow: 0px 0px 8px 0px rgba(0, 0, 0, .7);
                     ensureViewport(windowAtPoint, this);
                     inGrab = new Extension.imports.grab.MoveGrab(windowAtPoint, Meta.GrabOp.MOVING, this);
                     inGrab.begin();
+                } else {
+                    spaces.selectedSpace = this;
+                    Navigator.getNavigator().finish();
                 }
-                // spaces.selectedSpace = this;
-                // nav.finish();
             });
 
         this.signals.connect(

--- a/tiling.js
+++ b/tiling.js
@@ -787,12 +787,19 @@ class Space extends Array {
         return column.indexOf(metaWindow);
     }
 
+    globalToViewport(gx, gy) {
+        let [ok, vx, vy] = this.actor.transform_stage_point(gx, gy);
+        return [Math.round(vx), Math.round(vy)];
+    }
+
     /** Transform global coordinates to scroll cooridinates (cloneContainer relative) */
-    globalToScroll(gx, gy, useTarget=false) {
-        // NB: must use this.cloneContainer.transform_stage_point(gx, gy) if stuff is not simply translated
-        let x = gx - this.monitor.x - (useTarget ? this.targetX : this.cloneContainer.x);
-        let y = gy - this.monitor.y - this.cloneContainer.y;
-        return [x, y];
+    globalToScroll(gx, gy, {useTarget = false} = {}) {
+        // Use the smart transform on the actor, as that's the one we scale etc.
+        // We can then use straight translation on the scroll which makes it possible to use target instead if wanted.
+        let [vx, vy] = this.globalToViewport(gx, gy);
+        let sx = vx - (useTarget ? this.targetX : this.cloneContainer.x);
+        let sy = vy - this.cloneContainer.y;
+        return [Math.round(sx), Math.round(sy)];
     }
 
     moveDone() {

--- a/tiling.js
+++ b/tiling.js
@@ -1062,7 +1062,8 @@ box-shadow: 0px 0px 8px 0px rgba(0, 0, 0, .7);
                 if (inGrab) {
                     return;
                 }
-                let [x, y] = event.get_coords();
+                let [gx, gy, $] = global.get_pointer();
+                let [ok, x, y] = this.actor.transform_stage_point(gx, gy);
                 let windowAtPoint = !Gestures.gliding && this.getWindowAtPoint(x, y);
                 if (windowAtPoint) {
                     ensureViewport(windowAtPoint, this);

--- a/tiling.js
+++ b/tiling.js
@@ -2706,16 +2706,7 @@ function grabBegin(metaWindow, type) {
         case Meta.GrabOp.MOVING:
             inGrab = new Extension.imports.grab.MoveGrab(metaWindow, type);
 
-            let d;
-            if (Clutter.DeviceManager) {
-                let dm = Clutter.DeviceManager.get_default();
-                d = dm.get_core_device(Clutter.InputDeviceType.KEYBOARD_DEVICE);
-            } else {
-                let backend = Clutter.get_default_backend()
-                let seat = backend.get_default_seat()
-                d = seat.get_keyboard()
-            }
-            if (d.get_modifier_state() & Clutter.ModifierType.CONTROL_MASK) {
+            if (utils.getModiferState() & Clutter.ModifierType.CONTROL_MASK) {
                 inGrab.begin();
                 inGrab.beginDnD();
             } else if (inGrab.initialSpace && inGrab.initialSpace.indexOf(metaWindow) > -1) {

--- a/tiling.js
+++ b/tiling.js
@@ -2706,8 +2706,15 @@ function grabBegin(metaWindow, type) {
         case Meta.GrabOp.MOVING:
             inGrab = new Extension.imports.grab.MoveGrab(metaWindow, type);
 
-            let dm = Clutter.DeviceManager.get_default();
-            let d = dm.get_core_device(Clutter.InputDeviceType.KEYBOARD_DEVICE);
+            let d;
+            if (Clutter.DeviceManager) {
+                let dm = Clutter.DeviceManager.get_default();
+                d = dm.get_core_device(Clutter.InputDeviceType.KEYBOARD_DEVICE);
+            } else {
+                let backend = Clutter.get_default_backend()
+                let seat = backend.get_default_seat()
+                d = seat.get_keyboard()
+            }
             if (d.get_modifier_state() & Clutter.ModifierType.CONTROL_MASK) {
                 inGrab.begin();
                 inGrab.beginDnD();

--- a/tiling.js
+++ b/tiling.js
@@ -802,6 +802,10 @@ class Space extends Array {
         return [Math.round(sx), Math.round(sy)];
     }
 
+    viewportToScroll(vx, vy=0) {
+        return [vx - this.cloneContainer.x, vy - this.cloneContainer.y];
+    }
+
     moveDone() {
         if (this.cloneContainer.x !== this.targetX ||
             this.actor.y !== 0 ||

--- a/tiling.js
+++ b/tiling.js
@@ -1568,7 +1568,11 @@ class Spaces extends Map {
         let fromSpace = this.spaceOf(from);
 
         for (let metaWindow of toSpace.getWindows()) {
-            print("Enforcing workspace memebership", toSpace.name, metaWindow.title)
+            // Make sure all windows belong to the correct workspace.
+            // Note: The 'switch-workspace' signal (this method) runs before mutter decides on focus window.
+            // This simplifies other code moving windows between workspaces.
+            // Eg.: The DnD-window defer changing its workspace until the workspace actually is activated.
+            //      This ensures the DnD window keep focus the whole time.
             metaWindow.change_workspace(toSpace.workspace);
         }
 

--- a/tiling.js
+++ b/tiling.js
@@ -1069,7 +1069,7 @@ box-shadow: 0px 0px 8px 0px rgba(0, 0, 0, .7);
                     ensureViewport(windowAtPoint, this);
                     inGrab = new Extension.imports.grab.MoveGrab(windowAtPoint, Meta.GrabOp.MOVING, this);
                     inGrab.begin();
-                } else {
+                } else if (inPreview) {
                     spaces.selectedSpace = this;
                     Navigator.getNavigator().finish();
                 }

--- a/tiling.js
+++ b/tiling.js
@@ -1057,6 +1057,8 @@ box-shadow: 0px 0px 8px 0px rgba(0, 0, 0, .7);
         this.signals.connect(
             this.background, 'button-press-event',
             (actor, event) => {
+                if (inGrab)
+                    return;
                 let [aX, aY, mask] = global.get_pointer();
                 let [ok, x, y] =
                     this.actor.transform_stage_point(aX, aY);
@@ -1564,6 +1566,11 @@ class Spaces extends Map {
         let from = workspaceManager.get_workspace_by_index(fromIndex);
         let toSpace = this.spaceOf(to);
         let fromSpace = this.spaceOf(from);
+
+        for (let metaWindow of toSpace.getWindows()) {
+            print("Enforcing workspace memebership", toSpace.name, metaWindow.title)
+            metaWindow.change_workspace(toSpace.workspace);
+        }
 
         if (inPreview === PreviewMode.NONE && toSpace.monitor === fromSpace.monitor) {
             // Only start an animation if we're moving between workspaces on the
@@ -2669,7 +2676,7 @@ function grabBegin(metaWindow, type) {
 }
 
 function grabEnd(metaWindow, type) {
-    if (!inGrab)
+    if (!inGrab || inGrab.dnd)
         return;
 
     inGrab.end();

--- a/tiling.js
+++ b/tiling.js
@@ -622,6 +622,8 @@ class Space extends Array {
         this.visible.splice(this.visible.indexOf(metaWindow), 1);
 
         let clone = metaWindow.clone;
+        if (clone.get_parent() !== this.cloneContainer)
+            utils.trace('wrong parent', metaWindow);
         this.cloneContainer.remove_actor(clone);
         // Don't destroy the selection highlight widget
         if (clone.first_child.name === 'selection')
@@ -1060,14 +1062,45 @@ box-shadow: 0px 0px 8px 0px rgba(0, 0, 0, .7);
                 if (inGrab) {
                     return;
                 }
-                let [aX, aY, mask] = global.get_pointer();
-                let [ok, x, y] =
-                    this.actor.transform_stage_point(aX, aY);
+                let [x, y] = event.get_coords();
                 let windowAtPoint = !Gestures.gliding && this.getWindowAtPoint(x, y);
                 if (windowAtPoint) {
                     ensureViewport(windowAtPoint, this);
-                    inGrab = new Extension.imports.grab.MoveGrab(windowAtPoint, Meta.GrabOp.MOVING);
+                    inGrab = new Extension.imports.grab.MoveGrab(windowAtPoint, Meta.GrabOp.MOVING, this);
                     inGrab.begin();
+                }
+                // spaces.selectedSpace = this;
+                // nav.finish();
+            });
+
+        this.signals.connect(
+            this.background, 'scroll-event',
+            (actor, event) => {
+                let dir = event.get_scroll_direction();
+                if (dir === Clutter.ScrollDirection.SMOOTH)
+                    return;
+                // print(dir, Clutter.ScrollDirection.SMOOTH, Clutter.ScrollDirection.UP, Clutter.ScrollDirection.DOWN)
+                let dx
+                log(utils.ppEnumValue(dir, Clutter.ScrollDirection))
+                // let dx = dir === Clutter.ScrollDirection.DOWN ? -1 : 1
+                // let [dx, dy] = event.get_scroll_delta()
+
+                let [gx, gy] = event.get_coords();
+                if (!gx) {
+                    print("Noooo");
+                    return;
+                }
+                print(dx, gx, gy);
+
+                switch (dir) {
+                    case Clutter.ScrollDirection.LEFT:
+                    case Clutter.ScrollDirection.DOWN:
+                        this.switchLeft();
+                        break;
+                    case Clutter.ScrollDirection.RIGHT:
+                    case Clutter.ScrollDirection.UP:
+                        this.switchRight();
+                        break;
                 }
                 // spaces.selectedSpace = this;
                 // nav.finish();

--- a/tiling.js
+++ b/tiling.js
@@ -1057,18 +1057,20 @@ box-shadow: 0px 0px 8px 0px rgba(0, 0, 0, .7);
         this.signals.connect(
             this.background, 'button-press-event',
             (actor, event) => {
-                if (inGrab)
+                if (inGrab) {
                     return;
+                }
                 let [aX, aY, mask] = global.get_pointer();
                 let [ok, x, y] =
                     this.actor.transform_stage_point(aX, aY);
                 let windowAtPoint = !Gestures.gliding && this.getWindowAtPoint(x, y);
-                let nav = Navigator.getNavigator();
                 if (windowAtPoint) {
                     ensureViewport(windowAtPoint, this);
+                    inGrab = new Extension.imports.grab.MoveGrab(windowAtPoint, Meta.GrabOp.MOVING);
+                    inGrab.begin();
                 }
-                spaces.selectedSpace = this;
-                nav.finish();
+                // spaces.selectedSpace = this;
+                // nav.finish();
             });
 
         this.signals.connect(

--- a/tiling.js
+++ b/tiling.js
@@ -540,7 +540,7 @@ class Space extends Array {
 
     isWindowAtPoint(metaWindow, x, y) {
         let clone = metaWindow.clone;
-        let wX = clone.targetX + this.cloneContainer.x;
+        let wX = clone.x + this.cloneContainer.x;
         return x >= wX && x <= wX + clone.width &&
             y >= clone.y && y <= clone.y + clone.height;
     }

--- a/tiling.js
+++ b/tiling.js
@@ -2680,7 +2680,7 @@ function grabBegin(metaWindow, type) {
 }
 
 function grabEnd(metaWindow, type) {
-    if (!inGrab || inGrab.dnd)
+    if (!inGrab || inGrab.dnd || inGrab.grabbed)
         return;
 
     inGrab.end();

--- a/tiling.js
+++ b/tiling.js
@@ -2706,10 +2706,15 @@ function grabBegin(metaWindow, type) {
         case Meta.GrabOp.MOVING:
             inGrab = new Extension.imports.grab.MoveGrab(metaWindow, type);
 
-            if (!inGrab.initialSpace || inGrab.initialSpace.indexOf(metaWindow) === -1)
-                return;
+            let dm = Clutter.DeviceManager.get_default();
+            let d = dm.get_core_device(Clutter.InputDeviceType.KEYBOARD_DEVICE);
+            if (d.get_modifier_state() & Clutter.ModifierType.CONTROL_MASK) {
+                inGrab.begin();
+                inGrab.beginDnD();
+            } else if (inGrab.initialSpace && inGrab.initialSpace.indexOf(metaWindow) > -1) {
+                inGrab.begin();
+            }
 
-            inGrab.begin();
             break;
         case Meta.GrabOp.RESIZING_NW:
         case Meta.GrabOp.RESIZING_N:

--- a/tiling.js
+++ b/tiling.js
@@ -1098,11 +1098,11 @@ box-shadow: 0px 0px 8px 0px rgba(0, 0, 0, .7);
 
                 switch (dir) {
                     case Clutter.ScrollDirection.LEFT:
-                    case Clutter.ScrollDirection.DOWN:
+                    case Clutter.ScrollDirection.UP:
                         this.switchLeft();
                         break;
                     case Clutter.ScrollDirection.RIGHT:
-                    case Clutter.ScrollDirection.UP:
+                    case Clutter.ScrollDirection.DOWN:
                         this.switchRight();
                         break;
                 }

--- a/tiling.js
+++ b/tiling.js
@@ -801,7 +801,7 @@ class Space extends Array {
             Navigator.navigating || inPreview ||
             Main.overview.visible ||
             // Block when we're carrying a window in dnd
-            (inGrab && inGrab.dnd && inGrab.window)
+            (inGrab && inGrab.window)
            ) {
             return;
         }

--- a/utils.js
+++ b/utils.js
@@ -80,6 +80,16 @@ function ppEnumValue(value, genum) {
     }
 }
 
+function ppModiferState(state) {
+    let mods = [];
+    for (let [mod, mask] of Object.entries(imports.gi.Clutter.ModifierType)) {
+        if (mask & state) {
+            mods.push(mod);
+        }
+    }
+    return mods.join(", ")
+}
+
 /**
  * Look up the function by name at call time. This makes it convenient to
  * redefine the function without re-registering all signal handler, keybindings,
@@ -262,6 +272,29 @@ function warpPointer(x, y) {
         let pointer = deviceManager.get_client_pointer();
         pointer.warp(Gdk.Screen.get_default(), x, y)
     }
+}
+
+/**
+ * Return current modifiers state (or'ed Clutter.ModifierType.*)
+ * NB: Only on wayland. (Returns 0 on X11)
+ *
+ * Note: It's possible to get the modifier state through Gdk on X11, but move
+ * grabs is not triggered when ctrl is held down, making it useless for our purpose atm.
+ */
+function getModiferState() {
+    if (!Meta.is_wayland_compositor())
+        return 0;
+
+    let keyboard;
+    if (Clutter.DeviceManager) {
+        let dm = Clutter.DeviceManager.get_default();
+        keyboard = dm.get_core_device(Clutter.InputDeviceType.KEYBOARD_DEVICE);
+    } else {
+        let backend = Clutter.get_default_backend();
+        let seat = backend.get_default_seat();
+        keyboard = seat.get_keyboard();
+    }
+    return keyboard.get_modifier_state();
 }
 
 function monitorOfPoint(x, y) {

--- a/utils.js
+++ b/utils.js
@@ -347,19 +347,28 @@ var tweener = {
     }
 };
 
+function isMetaWindow(obj) {
+    return obj && obj.window_type && obj.get_compositor_private;
+}
 
 function trace(topic, ...args) {
-    windowTrace(topic, ...args);
+    if (!topic.match(/.*/)) {
+        return;
+    }
+
+    if (isMetaWindow(args[0])) {
+        windowTrace(topic, ...args);
+    } else {
+        let trace = shortTrace(1).join(" < ");
+        let extraInfo = args.length > 0 ? "\n\t" + args.map(x => x.toString()).join("\n\t") : ""
+        log(topic, trace, extraInfo);
+    }
 }
 
 let existingWindows = new Set();
 
 function windowTrace(topic, metaWindow, ...rest) {
     if (existingWindows.has(metaWindow)) {
-        return;
-    }
-
-    if (!topic.match(/.*/)) {
         return;
     }
 

--- a/utils.js
+++ b/utils.js
@@ -279,25 +279,10 @@ function warpPointer(x, y) {
 
 /**
  * Return current modifiers state (or'ed Clutter.ModifierType.*)
- * NB: Only on wayland. (Returns 0 on X11)
- *
- * Note: It's possible to get the modifier state through Gdk on X11, but move
- * grabs is not triggered when ctrl is held down, making it useless for our purpose atm.
  */
 function getModiferState() {
-    if (!Meta.is_wayland_compositor())
-        return 0;
-
-    let keyboard;
-    if (Clutter.DeviceManager) {
-        let dm = Clutter.DeviceManager.get_default();
-        keyboard = dm.get_core_device(Clutter.InputDeviceType.KEYBOARD_DEVICE);
-    } else {
-        let backend = Clutter.get_default_backend();
-        let seat = backend.get_default_seat();
-        keyboard = seat.get_keyboard();
-    }
-    return keyboard.get_modifier_state();
+    let [x, y, mods] = global.get_pointer();
+    return mods;
 }
 
 function monitorOfPoint(x, y) {

--- a/utils.js
+++ b/utils.js
@@ -209,12 +209,16 @@ function toggleCloneMarks() {
     // NB: doesn't clean up signal on disable
 
     function markCloneOf(metaWindow) {
-        if (metaWindow.clone)
+        if (metaWindow.clone) {
             metaWindow.clone.opacity = 190;
+            metaWindow.clone.background_color = imports.gi.Clutter.color_from_string("red")[1];
+        }
     }
     function unmarkCloneOf(metaWindow) {
-        if (metaWindow.clone)
+        if (metaWindow.clone) {
             metaWindow.clone.opacity = 255;
+            metaWindow.clone.background_color = null;
+        }
     }
 
     let windows = display.get_tab_list(Meta.TabList.NORMAL_ALL, null);
@@ -274,6 +278,38 @@ function monitorOfPoint(x, y) {
     return null;
 }
 
+
+function indent(level, str) {
+    let blank = ""
+    for (let i = 0; i < level; i++) {
+        blank += "  "
+    }
+    return blank + str
+}
+
+
+function fmt(actor) {
+    let extra = [
+        `${actor.get_position()}`,
+        `${actor.get_size()}`,
+    ];
+    let metaWindow = actor.meta_window || actor.metaWindow;
+    if (metaWindow) {
+        metaWindow = `(mw: ${metaWindow.title})`;
+        extra.push(metaWindow);
+    }
+    return `${actor.toString()} ${extra.join(" | ")}`;
+}
+
+function printActorTree(node, fmt=fmt, limit=Infnity, level=1) {
+    if (level > limit) {
+        return;
+    }
+    print(indent(level, fmt(node)));
+    for (let child of node.get_children()) {
+        printActorTree(child, fmt, limit, level+1);
+    }
+}
 
 class Signals extends Map {
     static get [Symbol.species]() { return Map; }

--- a/utils.js
+++ b/utils.js
@@ -221,12 +221,15 @@ function toggleCloneMarks() {
     function markCloneOf(metaWindow) {
         if (metaWindow.clone) {
             metaWindow.clone.opacity = 190;
+            metaWindow.clone.__oldOpacity = 190;
+
             metaWindow.clone.background_color = imports.gi.Clutter.color_from_string("red")[1];
         }
     }
     function unmarkCloneOf(metaWindow) {
         if (metaWindow.clone) {
             metaWindow.clone.opacity = 255;
+            metaWindow.clone.__oldOpacity = 255;
             metaWindow.clone.background_color = null;
         }
     }


### PR DESCRIPTION
Mutter's window grab blocks all other input, but it's possible to deactivate a grab from js.

So to make navigation while dragging work we implement the whole process using clone's and clutter events. The native `grab-op-begin` signal is only used to initiate a grab (we can't listen to arbitrary button events on WindowActors) which we immediately cancel in favor of the before mentioned implementation.

In addition to navigation while grabbing, we now support `<super><ctrl>button-press` as a shortcut to go straight into DnD mode. This can be very handy when you want to move a floating window into the tiling.