### PR TITLE
uninstall.sh: Actually remove $EXT

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -19,4 +19,4 @@ if [[ "$LINK" != "$REPO" ]]; then
     echo "$EXT" does not link to "$REPO", refusing to remove
     exit 1
 fi
-rm $EXT
+rm -Rf $EXT


### PR DESCRIPTION
uninstall.sh currently exits with `rm: cannot remove '/home/jc/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org': Is a directory` Adding -R will allow removing the directory and depending on distribution, -f disallows asking for 'if you want to delete this file in the directory' for each file deleted.