### PR TITLE
Remove and combine duplicated sentences in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,10 +156,8 @@ When the scratch layer is active it will float above the tiled windows, when hid
 
 Opening a window when the scratch layer is active will make it float automatically.
 
-Pressing <kbd>Super</kbd><kbd>Escape</kbd> toggles between showing and hiding the windows in the scratch layer. Activating windows in the scratch layer is done using <kbd>Super</kbd><kbd>Tab</kbd>, the floating windows having priority in the list while active. <
-
 Pressing <kbd>Super</kbd><kbd>Escape</kbd> toggles between showing and hiding the windows in the scratch layer.
-When the scratch layer is active <kbd>Super</kbd><kbd>Tab</kbd> gives priority to floating windows.
+Activating windows in the scratch layer is done using <kbd>Super</kbd><kbd>Tab</kbd>, the floating windows having priority in the list while active.
 When the tiling is active <kbd>Super</kbd><kbd>Shift</kbd><kbd>Tab</kbd> selects the most recently used scratch window.
 
 <kbd>Super</kbd><kbd>Ctrl</kbd><kbd>Escape</kbd> will move a tiled window into the scratch layer or alternatively tile an already floating window. This functionality can also be accessed through the window context menu (<kbd>Alt</kbd><kbd>Space</kbd>).


### PR DESCRIPTION
Small fixups with duplicated sentences in `README`. The two paragraphs are combined.