### PR TITLE
fix uninstall.sh

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -19,4 +19,12 @@ if [[ "$LINK" != "$REPO" ]]; then
     echo "$EXT" does not link to "$REPO", refusing to remove
     exit 1
 fi
-rm $EXT
+if [ -L "$EXT" ]; then
+    rm "$EXT"
+else
+    read -p "Remove $EXT? (y/N): " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        rm -rf $EXT
+    fi
+fi


### PR DESCRIPTION
fixes the errors
"rm: cannot remove '/home/reacocard/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org': Is a directory"
and
"rm: remove write-protected regular file '/home/reacocard/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org/.git/objects/pack/pack-3c3158f6621fdd04f2b4c3870a93934d2f6b695f.pack'?"
by adding -r and -f respectively to rm.