### PR TITLE
fix workspace-label border

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -144,7 +144,8 @@ class Space extends Array {
             p.style = `
                 background-color: transparent;
                 border-image: none;
-                background-image: none
+                background-image: none;
+                border: none;
             `;
         }
         labelParent.add_actor(labelParent2);


### PR DESCRIPTION
Removes small bottom border on workspace label that is visible when not covered by the top bar (especially on multi-monitor setups).

Before:
![image](https://user-images.githubusercontent.com/1208506/100541300-48c50080-3243-11eb-9925-806db83567ab.png)

After:
![image](https://user-images.githubusercontent.com/1208506/100541315-701bcd80-3243-11eb-96dc-ddf712c43e48.png)
