### PR TITLE
Fix/worspace switching glitch

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -1588,6 +1588,8 @@ class Spaces extends Map {
             // Only start an animation if we're moving between workspaces on the
             // same monitor
             this._initWorkspaceSequence();
+        } else {
+            this.selectedSpace.setMonitor(this.selectedSpace.monitor, false);
         }
 
         this.stack = this.stack.filter(s => s !== toSpace);
@@ -1995,6 +1997,8 @@ class Spaces extends Map {
             return;
         }
 
+        this._updateMonitor();
+
         Tweener.addTween(to.actor,
                          { x: 0,
                            y: 0,
@@ -2019,6 +2023,14 @@ class Spaces extends Map {
             above = above.get_next_sibling();
         }
 
+    }
+
+    _updateMonitor() {
+        let monitorSpaces = this._getOrderedSpaces(this.selectedSpace.monitor);
+        let currentMonitor = this.selectedSpace.monitor;
+        monitorSpaces.forEach((space, i) => {
+            space.setMonitor(currentMonitor, false);
+        });
     }
 
     addSpace(workspace) {


### PR DESCRIPTION
I experience a bug on a two-monitor setup when directly jumping to workspaces (either by using a keybinding or when clicking on notifications) that lie on the monitor that is not currently active:
![image](https://user-images.githubusercontent.com/1208506/102994159-cfa58a00-451e-11eb-9f25-df013ce2c2e4.png)
Moving the cursor in this state to the second monitor causes further glitching of workspaces an windows.

The bug can be reproduced quite reliably by doing the following:
- Have open windows on workspaces 1 to 4
- Restart Gnome Shell (<kbd>Alt</kbd> + <kbd>F2</kbd>, <kbd>r</kbd>, <kbd>Enter</kbd>)
  > workspace 1: visible on monitor 1
  > workspace 2: visible on monitor 2
  > workspace 3: on monitor 1
  > workspace 4: on monitor 1
- Go to monitor 2 and switch to workspace 4 using <kbd>Super</kbd>+<kbd>Above_Tab</kbd>
  > workspace 1: visible on monitor 1
  > workspace 2: on monitor 2
  > workspace 3: on monitor 1
  > workspace 4: visible on monitor 2
- Now switch workspaces directly using keyboard shortcuts assigned to "Switch to workspace x" in Settings
  - switch to workspace 1
  - switch to workspace 2
  - switch to workspace 3

I don't completely understand the involved code, but I could eliminate the bug with the first commit in this pull request.

-----

The second commit changes the behavior when switching workspaces on the active monitor. Before, switching, e.g., from workspace 1 to workspace 5 would trigger an animation that scrolls quickly past all workspaces in-between on the same monitor, adding a lot of visual clutter. This commit makes it use the same more subtle animation that appears when switching to a workspace on another monitor. There appear to be some situations in which this animation is not performed correctly (happened before when switching to another monitor as well), but I cannot reproduce this reliably.