### PR TITLE
Fix showing margin on display edges when switching apps

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -2519,10 +2519,10 @@ function ensuredX(meta_window, space) {
         x = 0;
     } else if (index == 0 && x <= min) {
         // Always align the first window to the display's left edge
-        x = min;
+        x = min + prefs.horizontal_margin;
     } else if (index == space.length-1 && x + frame.width >= max) {
         // Always align the first window to the display's right edge
-        x = max - frame.width;
+        x = max - frame.width - prefs.horizontal_margin;
     } else if (frame.width > workArea.width*0.9 - 2*(prefs.horizontal_margin + prefs.window_gap)) {
         // Consider the window to be wide and center it
         x = min + Math.round((workArea.width - frame.width)/2);

--- a/tiling.js
+++ b/tiling.js
@@ -2515,7 +2515,7 @@ function ensuredX(meta_window, space) {
     let workArea = space.workArea();
     let min = workArea.x;
     let max = min + workArea.width;
-    if (meta_window.fullscreen) {
+    if (meta_window.fullscreen || meta_window.maximized_horizontally) {
         x = 0;
     } else if (index == 0 && x <= min) {
         // Always align the first window to the display's left edge
@@ -2526,7 +2526,6 @@ function ensuredX(meta_window, space) {
     } else if (frame.width > workArea.width*0.9 - 2*(prefs.horizontal_margin + prefs.window_gap)) {
         // Consider the window to be wide and center it
         x = min + Math.round((workArea.width - frame.width)/2);
-
     } else if (x + frame.width > max) {
         // Align to the right prefs.horizontal_margin
         x = max - prefs.horizontal_margin - frame.width;


### PR DESCRIPTION
When cycling through applications and reaching the begin or the end, didn't display the horizontal margin.

Before:
![image](https://user-images.githubusercontent.com/334779/103584650-00ec6580-4ee2-11eb-9fb8-f74ba07d7002.png)

After:
![image](https://user-images.githubusercontent.com/334779/103584694-195c8000-4ee2-11eb-82b7-daff81cb9148.png)
