### PR TITLE
Remove navigator timeout for keybindings without mods

### DIFF
--- a/navigator.js
+++ b/navigator.js
@@ -99,7 +99,7 @@ var ActionDispatcher = class {
         if (this._noModsTimeoutId != 0)
             Mainloop.source_remove(this._noModsTimeoutId);
 
-        this._noModsTimeoutId = Mainloop.timeout_add(SwitcherPopup.NO_MODS_TIMEOUT,
+        this._noModsTimeoutId = Mainloop.timeout_add(0,
                                                      () => {
                                                          this._finish(global.get_current_time());
                                                          this._noModsTimeoutId = 0;


### PR DESCRIPTION
This simple change will disable timeouts when using keybindings without modifiers for switching between windows, eg. Volume Up/Down keys. This resolves https://github.com/paperwm/PaperWM/issues/355.