### PR TITLE
Add instruction on windows matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,11 +191,12 @@ It's possible to create simple rules for placing new windows. Currently most use
 ```javascript
     Tiling.defwinprop({
         wm_class: "Spotify",
+        title: "Window Title",
         scratch_layer: true,
     });
 ```
 
-The `wm_class` of a window can be found by using looking glass: <kbd>Alt</kbd><kbd>F2</kbd> `lg` <kbd>Return</kbd> Go to the "Windows" section at the top right and find the window. X11 users can also use the `xprop` command line tool.
+The `wm_class` or `title` of a window can be found by using looking glass: <kbd>Alt</kbd><kbd>F2</kbd> `lg` <kbd>Return</kbd> Go to the "Windows" section at the top right and find the window. X11 users can also use the `xprop` command line tool (`title` is referred as `WM_NAME` in `xprop`). The match of `wm_class` and `title` are with an OR condition; and in addition to a plain string matching, a constructed [`RegExp()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/RegExp) can be used to utilise regex matching.
 
 ### New Window Handlers
 

--- a/settings.js
+++ b/settings.js
@@ -290,14 +290,14 @@ var winprops = [];
 function winprop_match_p(meta_window, prop) {
     let wm_class = meta_window.wm_class || "";
     let title = meta_window.title;
-    if (prop.wm_class.constructor === RegExp) {
+    if (prop.wm_class instanceof RegExp) {
         if (!wm_class.match(prop.wm_class))
             return false;
     } else if (prop.wm_class !== wm_class) {
         return false;
     }
     if (prop.title) {
-        if (prop.title.constructor === RegExp) {
+        if (prop.title instanceof RegExp) {
             if (!title.match(prop.title))
                 return false;
         } else {


### PR DESCRIPTION
I was trying to find a way to put a window that has no defined `wm_class` to scratch layer. I had thought of using `title` to match the window and only realised that it had already been implemented without being mentioned in the README.

This PR adds some hints to such an approach for window matching.