### PR TITLE
wip: Added touch scroll gestures support

### DIFF
--- a/gestures.js
+++ b/gestures.js
@@ -144,6 +144,49 @@ function horizontalScroll(actor, event) {
     }
 }
 
+let walk = 0;
+let sdx = null;
+function horizontalTouchScroll(actor, event) {
+  const type = event.type()
+  const [myx, myy] = event.get_coords();
+
+  switch (type) {
+    case Clutter.EventType.TOUCH_BEGIN:
+      this.vx = 0;
+      dxs = [];
+      dts = [];
+      sdx = myx;
+      walk = 0;
+      start = this.targetX;
+      this.hState = Clutter.TouchpadGesturePhase.UPDATE;
+      Tweener.removeTweens(this.cloneContainer);
+      navigator = Navigator.getNavigator();
+      direction = DIRECTIONS.Horizontal;
+      update(this, 0, event.get_time());
+      return Clutter.EVENT_PROPAGATE
+    case Clutter.EventType.TOUCH_UPDATE:
+      let dx = 0;
+      if (sdx !== null) {
+        dx = myx - sdx;
+      }
+      sdx = myx;
+      walk = walk + Math.abs(dx);
+
+      update(this, -dx, event.get_time() * .75)
+      return Clutter.EVENT_PROPAGATE
+    case Clutter.EventType.TOUCH_CANCEL:
+    case Clutter.EventType.TOUCH_END:
+      done(this, event);
+      dxs = [];
+      dts = [];
+      sdx = null;
+      walk = 0;
+      this.hState = Clutter.TouchpadGesturePhase.END;
+      if (walk < 20) return Clutter.EVENT_PROPAGATE; // Don't steal non-swipe events
+      else return Clutter.EVENT_STOP;
+  }
+}
+
 function update(space, dx, t) {
 
     dxs.push(dx);

--- a/tiling.js
+++ b/tiling.js
@@ -52,6 +52,9 @@ var backgroundSettings = new Gio.Settings({
 var interfaceSettings = new Gio.Settings({
     schema_id: "org.gnome.desktop.interface",
 });
+var interfaceSettings = new Gio.Settings({
+  schema_id: "org.gnome.desktop.interface",
+});
 
 var borderWidth = 8;
 // Mutter prevints windows from being placed further off the screen than 75 pixels.
@@ -1443,6 +1446,10 @@ var Spaces = class Spaces extends Map {
         // Initialize spaces _after_ monitors are set up
         this.forEach(space => space.init());
 
+        // Bind to visible workspace when starting up
+        signals.disconnect(Main.panel);
+        signals.connect(Main.panel, "captured-event", Gestures.horizontalTouchScroll.bind(this.get(workspaceManager.get_active_workspace())));
+
         this.stack = this.mru();
     }
 
@@ -1734,6 +1741,10 @@ var Spaces = class Spaces extends Map {
                 continue;
             monitor.clickOverlay.activate();
         }
+
+        // Update panel to handle target workspace
+        signals.disconnect(Main.panel);
+        signals.connect(Main.panel, "captured-event", Gestures.horizontalTouchScroll.bind(toSpace));
 
         inPreview = PreviewMode.NONE;
     }


### PR DESCRIPTION
This allows the user to scroll between windows by swiping on the topbar (or panel). This can be useful for convertibles, or desktops with touch screens.