### PR TITLE
fix: moving windows between workspaces should not take windows in between

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -1835,10 +1835,15 @@ var Spaces = class Spaces extends Map {
         let from = monitorSpaces.indexOf(this.selectedSpace);
         let newSpace = this.selectedSpace;
         let to = from;
+
         if (move && this.selectedSpace.selectedWindow) {
-            takeWindow(this.selectedSpace.selectedWindow,
-                       this.selectedSpace,
-                       {navigator: Navigator.getNavigator()});
+            const navigator = Navigator.getNavigator();
+
+            if (navigator._moving == null || (Array.isArray(navigator._moving) && navigator._moving.length === 0)) {
+                takeWindow(this.selectedSpace.selectedWindow,
+                    this.selectedSpace,
+                    {navigator: Navigator.getNavigator()});
+            }
         }
 
         if (direction === Meta.MotionDirection.DOWN)

--- a/tiling.js
+++ b/tiling.js
@@ -1842,7 +1842,7 @@ var Spaces = class Spaces extends Map {
             if (navigator._moving == null || (Array.isArray(navigator._moving) && navigator._moving.length === 0)) {
                 takeWindow(this.selectedSpace.selectedWindow,
                     this.selectedSpace,
-                    {navigator: Navigator.getNavigator()});
+                    { navigator });
             }
         }
 


### PR DESCRIPTION
## Description

This PR adds a check to the `selectSequenceSpace` function in `tiling.js` so that it only takes windows during a move operation if there are no windows in the current navigator's `_moving` stack. 

This allows the move operation to take the focused window from the workspace it was originally triggered in, while preventing it from taking additional windows from workspaces that the user might navigate through on the way to their destination.

## Motivation

Fixes #442. See that issue for a more detailed description.
