### PR TITLE
fix: cannot switch windows using navigator on X11

### DIFF
--- a/navigator.js
+++ b/navigator.js
@@ -223,8 +223,8 @@ function getModLock(mods) {
     _finish(timestamp) {
         let nav = getNavigator();
         getNavigator().accept();
-        dismissDispatcher(Clutter.GrabState.KEYBOARD)
         !this._destroy && nav.destroy();
+        dismissDispatcher(Clutter.GrabState.KEYBOARD)
     }
 
     destroy() {


### PR DESCRIPTION
## Solution
Just moved the `dismissDispatcher(Clutter.GrabState.KEYBOARD)` after the `nav.destroy()`

## Info
When the keyboard dispatcher is dismissed before destroying the navigator, a focus signal is emitted to the starting window. This causes a ensureViewport, that changes the selected window to the first one, overriding the selected one. Since the logic that activate the new window is done inside the destroy function, the selected window is wrong after the dismissDispatcher.

Not sure why this happens only on X11 and on the last GNOME version. I don't understand why the focused window is focused a second time, like if the navigator is stealing the focus.