### PR TITLE
fix: hide topbar for fullscreened floating and scratch windows (fixes #451)

### DIFF
--- a/topbar.js
+++ b/topbar.js
@@ -574,34 +574,35 @@ function disable() {
 }
 
 function fixTopBar() {
-    let spaces = Tiling.spaces
-    if (!spaces)
-        return;
-    let space = spaces.monitors.get(panelMonitor);
+    let space = Tiling.spaces?.monitors.get(panelMonitor) ?? false;
     if (!space)
         return;
+    // normal ==> not in overview AND not in tiling workspace view
     let normal = !Main.overview.visible && !Tiling.inPreview
-    let selected = spaces.monitors.get(panelMonitor).selectedWindow
+    // selected is current (tiled) selected window (can be different to focused window)
+    let selected = space.selectedWindow
+    // current focused window (can be different to selected tile window, e.g. focused scratch window)
     let focus = display.focus_window
+    // check if a scratch window is currently focused
     let focusIsScratch = focus && Scratch.isScratchWindow(focus)
-    let fullscreen = selected && selected.fullscreen && !(focusIsScratch);
-    let hideTopBar = !spaces.monitors.get(panelMonitor).showTopBar
-    // hide topbar for fullscreen scratch windows
-    if (focusIsScratch && focus.fullscreen) {
-        panelBox.hide();
-        return;
-    }
-    if (normal && hideTopBar) {
+    // check if currently fullscreened (check both focused scratch and tiled selected)
+    let fullscreen = focusIsScratch ? focus.fullscreen : selected && selected.fullscreen;
+    
+    // if normal view and current workspace is set NOT to show topbar ==> hide topbar
+    if (normal && !space.showTopBar) {
         // Update the workarea to support hide top bar
         panelBox.scale_y = 0;
         panelBox.hide();
         return;
     }
+
+    // if normal view and window (either tiled or scratched) is fullscreen ==> hide topbar
     if (normal && fullscreen) {
         panelBox.hide();
         return;
     }
 
+    // fallback: if here, not fullscreened etc. ==> show topbar
     panelBox.scale_y = 1;
     panelBox.show();
 }

--- a/topbar.js
+++ b/topbar.js
@@ -585,8 +585,8 @@ function fixTopBar() {
     // current focused window (can be different to selected tile window, e.g. floating/scratch window)
     let focused = display.focus_window;
     // check if focused window is floating or a scratch window
-    let focusIsFloatOrScratch = focused && space.isFloating(focused) || focused && Scratch.isScratchWindow(focused);
-    // check if is currently fullscreened (address both focused scratch / tiled selected windows)
+    let focusIsFloatOrScratch = focused && (space.isFloating(focused) || Scratch.isScratchWindow(focused));
+    // check if is currently fullscreened (address both focused scratch, floating or tiled windows)
     let fullscreen = focusIsFloatOrScratch ? focused.fullscreen : selected && selected.fullscreen;
     
     if (normal && !space.showTopBar) {
@@ -595,7 +595,7 @@ function fixTopBar() {
         panelBox.hide();
     }
     else if (normal && fullscreen) {
-        // is normal view and window (either tiled or scratched) is fullscreen ==> hide topbar
+        // is normal view and window (either tiled, floating or scratched) is fullscreen ==> hide topbar
         panelBox.hide();
     }
     else {

--- a/topbar.js
+++ b/topbar.js
@@ -586,6 +586,11 @@ function fixTopBar() {
     let focusIsScratch = focus && Scratch.isScratchWindow(focus)
     let fullscreen = selected && selected.fullscreen && !(focusIsScratch);
     let hideTopBar = !spaces.monitors.get(panelMonitor).showTopBar
+    // hide topbar for fullscreen scratch windows
+    if (focusIsScratch && focus.fullscreen) {
+        panelBox.hide();
+        return;
+    }
     if (normal && hideTopBar) {
         // Update the workarea to support hide top bar
         panelBox.scale_y = 0;
@@ -596,6 +601,7 @@ function fixTopBar() {
         panelBox.hide();
         return;
     }
+
     panelBox.scale_y = 1;
     panelBox.show();
 }

--- a/topbar.js
+++ b/topbar.js
@@ -578,28 +578,22 @@ function fixTopBar() {
     if (!space)
         return;
     
-    // normal ==> not in overview AND not in tiling workspace view
     let normal = !Main.overview.visible && !Tiling.inPreview;
     // selected is current (tiled) selected window (can be different to focused window)
     let selected = space.selectedWindow;
-    // current focused window (can be different to selected tile window, e.g. floating/scratch window)
     let focused = display.focus_window;
-    // check if focused window is floating or a scratch window
     let focusIsFloatOrScratch = focused && (space.isFloating(focused) || Scratch.isScratchWindow(focused));
-    // check if is currently fullscreened (address both focused scratch, floating or tiled windows)
+    // check if is currently fullscreened (check focused-floating, focused-scratch, and selected/tiled window)
     let fullscreen = focusIsFloatOrScratch ? focused.fullscreen : selected && selected.fullscreen;
     
     if (normal && !space.showTopBar) {
-        // is normal view and current workspace is set NOT to show topbar ==> hide topbar
         panelBox.scale_y = 0; // Update the workarea to support hide top bar
         panelBox.hide();
     }
     else if (normal && fullscreen) {
-        // is normal view and window (either tiled, floating or scratched) is fullscreen ==> hide topbar
         panelBox.hide();
     }
     else {
-        // not normal, not fullscreened etc. ==> show topbar
         panelBox.scale_y = 1;
         panelBox.show();
     }

--- a/topbar.js
+++ b/topbar.js
@@ -577,6 +577,7 @@ function fixTopBar() {
     let space = Tiling.spaces?.monitors.get(panelMonitor) ?? false;
     if (!space)
         return;
+    
     // normal ==> not in overview AND not in tiling workspace view
     let normal = !Main.overview.visible && !Tiling.inPreview
     // selected is current (tiled) selected window (can be different to focused window)
@@ -585,26 +586,23 @@ function fixTopBar() {
     let focus = display.focus_window
     // check if a scratch window is currently focused
     let focusIsScratch = focus && Scratch.isScratchWindow(focus)
-    // check if currently fullscreened (check both focused scratch and tiled selected)
+    // check if is currently fullscreened (address both focused scratch / tiled selected windows)
     let fullscreen = focusIsScratch ? focus.fullscreen : selected && selected.fullscreen;
     
-    // if normal view and current workspace is set NOT to show topbar ==> hide topbar
     if (normal && !space.showTopBar) {
-        // Update the workarea to support hide top bar
-        panelBox.scale_y = 0;
+        // is normal view and current workspace is set NOT to show topbar ==> hide topbar
+        panelBox.scale_y = 0; // Update the workarea to support hide top bar
         panelBox.hide();
-        return;
     }
-
-    // if normal view and window (either tiled or scratched) is fullscreen ==> hide topbar
-    if (normal && fullscreen) {
+    else if (normal && fullscreen) {
+        // is normal view and window (either tiled or scratched) is fullscreen ==> hide topbar
         panelBox.hide();
-        return;
     }
-
-    // fallback: if here, not fullscreened etc. ==> show topbar
-    panelBox.scale_y = 1;
-    panelBox.show();
+    else {
+        // not normal, not fullscreened etc. ==> show topbar
+        panelBox.scale_y = 1;
+        panelBox.show();
+    }
 }
 
 /**

--- a/topbar.js
+++ b/topbar.js
@@ -579,15 +579,15 @@ function fixTopBar() {
         return;
     
     // normal ==> not in overview AND not in tiling workspace view
-    let normal = !Main.overview.visible && !Tiling.inPreview
+    let normal = !Main.overview.visible && !Tiling.inPreview;
     // selected is current (tiled) selected window (can be different to focused window)
-    let selected = space.selectedWindow
-    // current focused window (can be different to selected tile window, e.g. focused scratch window)
-    let focus = display.focus_window
-    // check if a scratch window is currently focused
-    let focusIsScratch = focus && Scratch.isScratchWindow(focus)
+    let selected = space.selectedWindow;
+    // current focused window (can be different to selected tile window, e.g. floating/scratch window)
+    let focused = display.focus_window;
+    // check if focused window is floating or a scratch window
+    let focusIsFloatOrScratch = focused && space.isFloating(focused) || focused && Scratch.isScratchWindow(focused);
     // check if is currently fullscreened (address both focused scratch / tiled selected windows)
-    let fullscreen = focusIsScratch ? focus.fullscreen : selected && selected.fullscreen;
+    let fullscreen = focusIsFloatOrScratch ? focused.fullscreen : selected && selected.fullscreen;
     
     if (normal && !space.showTopBar) {
         // is normal view and current workspace is set NOT to show topbar ==> hide topbar


### PR DESCRIPTION
Fixes #451.

Checks if the window is fullscreen and on the scratch layer (or is fullscreen and floating), if so it hides the topbar.