### PR TITLE
Adds winprop preferredWidth to set default window width by wm_class (supports 'px' or '%' values)

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,11 +185,10 @@ GSETTINGS_SCHEMA_DIR=$HOME/.local/share/gnome-shell/extensions/paperwm@hedning:m
 
 It's possible to set window properties using simple rules that will be applied when placing new windows. Properties can applied to windows identified by their `wm_class` or `title`.  The following properties are currently supported:
 
-Property              | Input type                          | Input example(s) | Description
+Property              | Input type                          | Input example | Description
 ----------------------|-------------------------------------|------------------|------------------
-`scratch_layer`       | boolean                             | `true`, `false`  | if `true` window will be placed on the scratch layer.
-`preferredWidth`      | _width in pixels_ (integer)         | `450`, `1024`    | resizes the window width (pixels) of the window when it's created. </br>_Note<sup>1</sup>: property not applicable to windows on scratch layer._</br>_Note<sup>2</sup>: `preferredWith` takes precedence over `preferredWidthRatio`._
-`preferredWidthRatio` | _ratio value_ (double)              | `0.5`, `0.75`    | resizes the window width to the ratio of the input to the available screen width.</br>_Note<sup>1</sup>: property not applicable to windows on scratch layer._
+`scratch_layer`       | Boolean                             | `true`, `false`  | if `true` window will be placed on the scratch layer.
+`preferredWidth`      | String value with `%` or `px` unit         | `"50%"`, `"450px"`    | resizes the window width to the preferred width when it's created. </br>_Note<sup>1</sup>: property not applicable to windows on scratch layer._
 
 Below is a few examples of setting window properties for _Spotify_ and _Alacritty_.  The below examples are best placed in the `init` part of `user.js`:
 
@@ -201,13 +200,13 @@ Below is a few examples of setting window properties for _Spotify_ and _Alacritt
     });
 
     Tiling.defwinprop({
-        wm_class: "Gnome-terminal",
-        preferredWidth: 650,
+        wm_class: "firefox",
+        preferredWidth: "900px",
     });
 
     Tiling.defwinprop({
         wm_class: /alacritty/i,
-        preferredWidthRatio: 0.5,
+        preferredWidth: "50%",
     });
 ```
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Below is a few examples of setting window properties for _Spotify_ and _Alacritt
     });
 
     Tiling.defwinprop({
-        wm_class: "gnome-terminal",
+        wm_class: "Gnome-terminal",
         preferredWidth: 650,
     });
 

--- a/README.md
+++ b/README.md
@@ -183,13 +183,26 @@ GSETTINGS_SCHEMA_DIR=$HOME/.local/share/gnome-shell/extensions/paperwm@hedning:m
 
 ### Winprops
 
-It's possible to create simple rules for placing new windows. Currently most useful when a window should be placed in the scratch layer automatically. An example, best placed in the `init` part of `user.js`:
+It's possible to set window properties using simple rules that will be applied when placing new windows. Properties can applied to windows identified by their `wm_class` or `title`.  The following properties are currently supported:
+
+Property              | Valid Values              | Description
+----------------------|---------------------------|------------------------------------
+`scratch_layer`       | `true`, `false`       | if `true` window will be placed on the scratch layer.
+`preferredWidth`      | _{width in pixels}_       | resizes the window width (pixels) of the window when it's created. </br>_Note<sup>1</sup>: property not applicable to windows on scratch layer._</br>_Note<sup>2</sup>: `preferredWith` takes precedence over `preferredWidthStep`._
+`preferredWidthStep`  | `0`, `1`, `2`, `3`        | selects the window-width step that will be used when the window is created.  The window-width step corresponds to the "useful window widths" that can be cycled through; `0` being the first step, `1` the next step, and `2` being the last step. `3` is a special case which maximises the width of the created window. </br>_Note<sup>1</sup>: property not applicable to windows on scratch layer._
+
+Below is a few examples of setting window properties for _Spotify_ and _Alacritty_.  The below examples are best placed in the `init` part of `user.js`:
 
 ```javascript
     Tiling.defwinprop({
         wm_class: "Spotify",
         title: "Window Title",
         scratch_layer: true,
+    });
+
+    Tiling.defwinprop({
+        wm_class: /alacritty/i,
+        preferredWidthStep: 1,
     });
 ```
 

--- a/README.md
+++ b/README.md
@@ -185,11 +185,11 @@ GSETTINGS_SCHEMA_DIR=$HOME/.local/share/gnome-shell/extensions/paperwm@hedning:m
 
 It's possible to set window properties using simple rules that will be applied when placing new windows. Properties can applied to windows identified by their `wm_class` or `title`.  The following properties are currently supported:
 
-Property              | Valid Values              | Description
-----------------------|---------------------------|------------------------------------
-`scratch_layer`       | `true`, `false`       | if `true` window will be placed on the scratch layer.
-`preferredWidth`      | _{width in pixels}_       | resizes the window width (pixels) of the window when it's created. </br>_Note<sup>1</sup>: property not applicable to windows on scratch layer._</br>_Note<sup>2</sup>: `preferredWith` takes precedence over `preferredWidthStep`._
-`preferredWidthStep`  | `0`, `1`, `2`, `3`        | selects the window-width step that will be used when the window is created.  The window-width step corresponds to the "useful window widths" that can be cycled through; `0` being the first step, `1` the next step, and `2` being the last step. `3` is a special case which maximises the width of the created window. </br>_Note<sup>1</sup>: property not applicable to windows on scratch layer._
+Property              | Input type                          | Input example(s) | Description
+----------------------|-------------------------------------|------------------|------------------
+`scratch_layer`       | boolean                             | `true`, `false`  | if `true` window will be placed on the scratch layer.
+`preferredWidth`      | _width in pixels_ (integer)         | `450`, `1024`    | resizes the window width (pixels) of the window when it's created. </br>_Note<sup>1</sup>: property not applicable to windows on scratch layer._</br>_Note<sup>2</sup>: `preferredWith` takes precedence over `preferredWidthRatio`._
+`preferredWidthRatio` | _ratio value_ (double)              | `0.5`, `0.75`    | resizes the window width to the ratio of the input to the available screen width.</br>_Note<sup>1</sup>: property not applicable to windows on scratch layer._
 
 Below is a few examples of setting window properties for _Spotify_ and _Alacritty_.  The below examples are best placed in the `init` part of `user.js`:
 
@@ -201,8 +201,13 @@ Below is a few examples of setting window properties for _Spotify_ and _Alacritt
     });
 
     Tiling.defwinprop({
+        wm_class: "gnome-terminal",
+        preferredWidth: 650,
+    });
+
+    Tiling.defwinprop({
         wm_class: /alacritty/i,
-        preferredWidthStep: 1,
+        preferredWidthRatio: 0.5,
     });
 ```
 

--- a/README.md
+++ b/README.md
@@ -267,8 +267,9 @@ See `examples/keybindings.js` for more examples.
 
 ## Fixed Window Size ##
 
-Currently it is not possible to have a default fixed window size.
-Please check the following issues for progress / info:
+See the [Winprops](#winprops) section for a way to set the default _width_ of windows identified by their `wm_class` window property.
+
+Currently it is not possible to have a default fixed window height.  Please check the following issues for progress / info:
 
 * https://github.com/paperwm/PaperWM/issues/304
 * https://github.com/paperwm/PaperWM/pull/189

--- a/settings.js
+++ b/settings.js
@@ -84,6 +84,7 @@ function setSchemas() {
         settings_schema: schemaSource.lookup(WORKSPACE_LIST_KEY, true)
     });
 }
+
 setSchemas(); // Initialize imediately so prefs.js can import properly
 function init() {
     settings.connect('changed', setState);

--- a/settings.js
+++ b/settings.js
@@ -351,6 +351,4 @@ function defwinprop(spec) {
     } else {
         winprops.push(spec);
     }
-
-    winprops.push(spec);
 }

--- a/settings.js
+++ b/settings.js
@@ -335,12 +335,21 @@ function find_winprop(meta_window)  {
 function defwinprop(spec) {
     // process preferredWidth - expects inputs like 50% or 400px
     if (spec.preferredWidth) {
-        let value = new Number((spec.preferredWidth.match(/\d+/) ?? ['0'])[0]);
-        let unit = (spec.preferredWidth.match(/[a-zA-Z%]+/) ?? ['no unit'])[0].toLowerCase();
         spec.preferredWidth = {
-            value,
-            unit,
+            // value is first contiguous block of digits
+            value: new Number((spec.preferredWidth.match(/\d+/) ?? ['0'])[0]),
+            // unit is first contiguous block of apha chars or % char
+            unit: (spec.preferredWidth.match(/[a-zA-Z%]+/) ?? ['NO_UNIT'])[0],
         }
+    }
+
+    // if spec with same wm_class already exists, update it (to avoid duplicates)
+    // need to wrap in `String()` to correctly compare regex wm_class
+    let existing = winprops.findIndex(s => String(s.wm_class) === String(spec.wm_class));
+    if (existing >= 0) {
+        winprops.splice(existing, spec); // replace
+    } else {
+        winprops.push(spec);
     }
 
     winprops.push(spec);

--- a/settings.js
+++ b/settings.js
@@ -333,5 +333,15 @@ function find_winprop(meta_window)  {
 }
 
 function defwinprop(spec) {
+    // process preferredWidth - expects inputs like 50% or 400px
+    if (spec.preferredWidth) {
+        let value = new Number((spec.preferredWidth.match(/\d+/) ?? ['0'])[0]);
+        let unit = (spec.preferredWidth.match(/[a-zA-Z%]+/) ?? ['no unit'])[0].toLowerCase();
+        spec.preferredWidth = {
+            value,
+            unit,
+        }
+    }
+
     winprops.push(spec);
 }

--- a/tiling.js
+++ b/tiling.js
@@ -342,6 +342,26 @@ var Space = class Space extends Array {
 
             let resizable = !mw.fullscreen &&
                 mw.get_maximized() !== Meta.MaximizeFlags.BOTH;
+            
+            if (mw.preferredWidthStep) {
+                let ws = mw.preferredWidthStep;
+                let widths = getCycleWindowWidths(mw);
+                if (ws == 3) {
+                    signals.connectOneShot(mw.get_compositor_private(),'transitions-completed', () => {
+                        toggleMaximizeHorizontally(mw);
+                    });
+                }
+                else if (typeof widths[ws] == 'undefined') {
+                    utils.warn("Could not set preferredWidthStep");
+                } else {
+                    targetWidth = widths[ws];
+                }
+                delete mw.preferredWidthStep;
+            }
+            if (mw.preferredWidth) {
+                targetWidth = mw.preferredWidth;
+                delete mw.preferredWidth;
+            }
 
             if (resizable) {
                 const hasNewTarget = mw._targetWidth !== targetWidth || mw._targetHeight !== targetHeight;
@@ -401,7 +421,6 @@ var Space = class Space extends Array {
         }
         return [targetWidth, widthChanged || heightChanged, y];
     }
-
 
     layout(animate = true, options={}) {
         // Guard against recursively calling layout
@@ -2530,6 +2549,10 @@ function insertWindow(metaWindow, {existing}) {
             if (winprop.focus) {
                 Main.activateWindow(metaWindow);
             }
+
+            // pass winprop properties to metaWindow
+            metaWindow.preferredWidth = winprop.preferredWidth;
+            metaWindow.preferredWidthStep = winprop.preferredWidthStep;
         }
 
         if (addToScratch) {
@@ -3083,14 +3106,11 @@ function resizeWDec(metaWindow) {
     metaWindow.move_resize_frame(true, targetX, frame.y, targetWidth, frame.height);
 }
 
-function cycleWindowWidth(metaWindow) {
+function getCycleWindowWidths(metaWindow) {
     let steps = prefs.cycle_width_steps;
-
     let frame = metaWindow.get_frame_rect();
-    let monitor = Main.layoutManager.monitors[metaWindow.get_monitor()];
     let space = spaces.spaceOfWindow(metaWindow);
     let workArea = space.workArea();
-    workArea.x += space.monitor.x;
 
     if (steps[0] <= 1) {
         // Steps are specifed as ratios -> convert to pixels
@@ -3099,8 +3119,17 @@ function cycleWindowWidth(metaWindow) {
         steps = steps.map(x => Math.floor(x*availableWidth));
     }
 
+   return steps;
+}
+
+function cycleWindowWidth(metaWindow) {
+    let frame = metaWindow.get_frame_rect();
+    let space = spaces.spaceOfWindow(metaWindow);
+    let workArea = space.workArea();
+    workArea.x += space.monitor.x;
+
     // 10px slack to avoid locking up windows that only resize in increments > 1px
-    let targetWidth = Math.min(utils.findNext(frame.width, steps, sizeSlack), workArea.width);
+    let targetWidth = Math.min(utils.findNext(frame.width, getCycleWindowWidths(metaWindow), sizeSlack), workArea.width);
     let targetX = frame.x;
 
     if (Scratch.isScratchWindow(metaWindow)) {

--- a/tiling.js
+++ b/tiling.js
@@ -342,14 +342,23 @@ var Space = class Space extends Array {
 
             let resizable = !mw.fullscreen &&
                 mw.get_maximized() !== Meta.MaximizeFlags.BOTH;
-            
-            if (mw.preferredWidthRatio) {
-                let availableWidth = space.workArea().width - prefs.horizontal_margin*2 - prefs.window_gap;
-                targetWidth = Math.floor(availableWidth * Math.min(mw.preferredWidthRatio, 1.0));
-                delete mw.preferredWidthRatio;
-            }
+
             if (mw.preferredWidth) {
-                targetWidth = mw.preferredWidth;
+                let prop = mw.preferredWidth;
+                if (prop.value <= 0) {
+                    utils.warn("invalid preferredWidth value");
+                }
+                else if (prop.unit == 'px') {
+                    targetWidth = prop.value;
+                }
+                else if (prop.unit == '%') {
+                    let availableWidth = space.workArea().width - prefs.horizontal_margin*2 - prefs.window_gap;
+                    targetWidth = Math.floor(availableWidth * Math.min(prop.value/100.0, 1.0));
+                }
+                else {
+                    utils.warn("invalid preferredWidth unit:", prop.unit);
+                }
+
                 delete mw.preferredWidth;
             }
 
@@ -2542,7 +2551,6 @@ function insertWindow(metaWindow, {existing}) {
 
             // pass winprop properties to metaWindow
             metaWindow.preferredWidth = winprop.preferredWidth;
-            metaWindow.preferredWidthRatio = winprop.preferredWidthRatio;
         }
 
         if (addToScratch) {

--- a/tiling.js
+++ b/tiling.js
@@ -343,20 +343,10 @@ var Space = class Space extends Array {
             let resizable = !mw.fullscreen &&
                 mw.get_maximized() !== Meta.MaximizeFlags.BOTH;
             
-            if (mw.preferredWidthStep) {
-                let ws = mw.preferredWidthStep;
-                let widths = getCycleWindowWidths(mw);
-                if (ws == 3) {
-                    signals.connectOneShot(mw.get_compositor_private(),'transitions-completed', () => {
-                        toggleMaximizeHorizontally(mw);
-                    });
-                }
-                else if (typeof widths[ws] == 'undefined') {
-                    utils.warn("Could not set preferredWidthStep");
-                } else {
-                    targetWidth = widths[ws];
-                }
-                delete mw.preferredWidthStep;
+            if (mw.preferredWidthRatio) {
+                let availableWidth = space.workArea().width - prefs.horizontal_margin*2 - prefs.window_gap;
+                targetWidth = Math.floor(availableWidth * Math.min(mw.preferredWidthRatio, 1.0));
+                delete mw.preferredWidthRatio;
             }
             if (mw.preferredWidth) {
                 targetWidth = mw.preferredWidth;
@@ -2552,7 +2542,7 @@ function insertWindow(metaWindow, {existing}) {
 
             // pass winprop properties to metaWindow
             metaWindow.preferredWidth = winprop.preferredWidth;
-            metaWindow.preferredWidthStep = winprop.preferredWidthStep;
+            metaWindow.preferredWidthRatio = winprop.preferredWidthRatio;
         }
 
         if (addToScratch) {

--- a/tiling.js
+++ b/tiling.js
@@ -356,7 +356,7 @@ var Space = class Space extends Array {
                     targetWidth = Math.floor(availableWidth * Math.min(prop.value/100.0, 1.0));
                 }
                 else {
-                    utils.warn("invalid preferredWidth unit:", prop.unit);
+                    utils.warn("invalid preferredWidth unit:", "'" + prop.unit + "'", "(should be 'px' or '%')");
                 }
 
                 delete mw.preferredWidth;


### PR DESCRIPTION
Adds user configurable window property (settable in `user.js` for example) `preferredWidth`.  This property allows setting an initial window width.  Accepts a String value with unit `px` or `%` (e.g. `"50%"`, `"500px"`, etc).

See `README.md` changes in this PR for more details (under section `Winprops`).

This approach builds on / extends (and relates to) #304.  ~~I wouldn't say it fixes that PR(?) since it only addresses the width (and not the vertical height).~~
_I'm going to say this fixes #304 since the discussion in that issue focuses on width (with some comments re height being tricky).  Can create another issue for setting `preferredHeight` if there is appetite for that)._

Thoughts and feedback welcome!