### PR TITLE
Make "useful window widths" and "useful window heights" user-configurable through PaperWM extension settings

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -289,6 +289,8 @@
                         </child>
                         <child>
                           <object class="GtkEntry" id="cycle_widths_entry">
+                            <property name="width_chars">24</property>
+                            <property name="max_width_chars">24</property>
                             <layout>
                               <property name="column">2</property>
                               <property name="row">0</property>
@@ -305,7 +307,7 @@
               <object class="GtkListBoxRow" id="general_row_5">
                 <property name="activatable">False</property>
                 <property name="focusable">False</property>
-                <property name="tooltip_text" translatable="yes">Comma separated values representing the "useful window heights" that will be cycled through. Values can be either ratio or pixel values. Mixed ratio and pixel values are not supported.</property>
+                <property name="tooltip_text" translatable="yes">Semicolon separated values of "useful window heights" that will be cycled through. Values types can be either percentage (of available screen width), e.g. "50%" or pixel values, e.g. "500px". Mixed value types are not supported.</property>
                 <child>
                   <object class="GtkGrid" id="workspace_grid12">
                     <property name="focusable">False</property>
@@ -341,6 +343,8 @@
                         </child>
                         <child>
                           <object class="GtkEntry" id="cycle_heights_entry">
+                            <property name="width_chars">24</property>
+                            <property name="max_width_chars">24</property>
                             <layout>
                               <property name="column">1</property>
                               <property name="row">0</property>

--- a/Settings.ui
+++ b/Settings.ui
@@ -249,6 +249,110 @@
                 </child>
               </object>
             </child>
+            <child>
+              <object class="GtkListBoxRow" id="general_row_4">
+                <property name="activatable">False</property>
+                <property name="focusable">False</property>
+                <property name="tooltip_text" translatable="yes">Ratio values (comma or whitespace separated) representing the "useful window widths" that will be cycled through</property>
+                <child>
+                  <object class="GtkGrid" id="workspace_grid3">
+                    <property name="focusable">False</property>
+                    <property name="margin_start">12</property>
+                    <property name="margin_end">12</property>
+                    <property name="margin_top">6</property>
+                    <property name="margin_bottom">6</property>
+                    <property name="column_spacing">32</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="focusable">False</property>
+                        <property name="hexpand">1</property>
+                        <property name="label" translatable="yes">Useful window widths</property>
+                        <property name="xalign">0</property>
+                        <layout>
+                          <property name="column">0</property>
+                          <property name="row">0</property>
+                        </layout>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkGrid">
+                        <layout>
+                          <property name="column">1</property>
+                          <property name="row">0</property>
+                        </layout>
+                        <child>
+                          <object class="GtkButton" id="cycle_widths_reset_button">
+                            <property name="margin_end">8</property>
+                            <property name="label">reset</property>
+                            <property name="tooltip_text" translatable="yes">Resets width values to the default PaperWM width values</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkEntry" id="cycle_widths_entry">
+                            <layout>
+                              <property name="column">2</property>
+                              <property name="row">0</property>
+                            </layout>
+                          </object>
+                        </child>
+                        </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkListBoxRow" id="general_row_5">
+                <property name="activatable">False</property>
+                <property name="focusable">False</property>
+                <property name="tooltip_text" translatable="yes">Ratio values (comma or whitespace separated) representing the "useful window heights" that will be cycled through</property>
+                <child>
+                  <object class="GtkGrid" id="workspace_grid12">
+                    <property name="focusable">False</property>
+                    <property name="margin_start">12</property>
+                    <property name="margin_end">12</property>
+                    <property name="margin_top">6</property>
+                    <property name="margin_bottom">6</property>
+                    <property name="column_spacing">32</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="focusable">False</property>
+                        <property name="hexpand">1</property>
+                        <property name="label" translatable="yes">Useful window heights</property>
+                        <property name="xalign">0</property>
+                        <layout>
+                          <property name="column">0</property>
+                          <property name="row">0</property>
+                        </layout>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkGrid">
+                        <layout>
+                          <property name="column">1</property>
+                          <property name="row">0</property>
+                        </layout>
+                        <child>
+                          <object class="GtkButton" id="cycle_heights_reset_button">
+                            <property name="margin_end">8</property>
+                            <property name="label">reset</property>
+                            <property name="tooltip_text" translatable="yes">Resets height values to the default PaperWM height values</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkEntry" id="cycle_heights_entry">
+                            <layout>
+                              <property name="column">1</property>
+                              <property name="row">0</property>
+                            </layout>
+                          </object>
+                        </child>
+                        </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
           </object>
         </child>
         <child>

--- a/Settings.ui
+++ b/Settings.ui
@@ -253,7 +253,7 @@
               <object class="GtkListBoxRow" id="general_row_4">
                 <property name="activatable">False</property>
                 <property name="focusable">False</property>
-                <property name="tooltip_text" translatable="yes">Ratio values (comma or whitespace separated) representing the "useful window widths" that will be cycled through</property>
+                <property name="tooltip_text" translatable="yes">Comma separated values representing the "useful window widths" that will be cycled through. Values can be either ratio or pixel values. Mixed ratio and pixel values are not supported.</property>
                 <child>
                   <object class="GtkGrid" id="workspace_grid3">
                     <property name="focusable">False</property>
@@ -305,7 +305,7 @@
               <object class="GtkListBoxRow" id="general_row_5">
                 <property name="activatable">False</property>
                 <property name="focusable">False</property>
-                <property name="tooltip_text" translatable="yes">Ratio values (comma or whitespace separated) representing the "useful window heights" that will be cycled through</property>
+                <property name="tooltip_text" translatable="yes">Comma separated values representing the "useful window heights" that will be cycled through. Values can be either ratio or pixel values. Mixed ratio and pixel values are not supported.</property>
                 <child>
                   <object class="GtkGrid" id="workspace_grid12">
                     <property name="focusable">False</property>

--- a/Settings.ui
+++ b/Settings.ui
@@ -253,7 +253,7 @@
               <object class="GtkListBoxRow" id="general_row_4">
                 <property name="activatable">False</property>
                 <property name="focusable">False</property>
-                <property name="tooltip_text" translatable="yes">Comma separated values representing the "useful window widths" that will be cycled through. Values can be either ratio or pixel values. Mixed ratio and pixel values are not supported.</property>
+                <property name="tooltip_text" translatable="yes">Semicolon separated values of "useful window widths" that will be cycled through. Values types can be either percentage (of available screen width), e.g. "50%" or pixel values, e.g. "500px". Mixed value types are not supported.</property>
                 <child>
                   <object class="GtkGrid" id="workspace_grid3">
                     <property name="focusable">False</property>

--- a/prefs.js
+++ b/prefs.js
@@ -115,7 +115,7 @@ var SettingsWidget = class SettingsWidget {
         cycleWidths.connect('changed', () => {
             let varr = cycleWidths.get_text()
                 .replaceAll(',', ' ')
-                .split(' ')
+                .split(/\s+/)
                 .filter(Number);
             this._settings.set_value('cycle-width-steps', new GLib.Variant('ad', varr));
         });
@@ -130,7 +130,7 @@ var SettingsWidget = class SettingsWidget {
         cycleHeights.connect('changed', () => {
             let varr = cycleHeights.get_text()
                 .replaceAll(',', ' ')
-                .split(' ')
+                .split(/\s+/)
                 .filter(Number);
             this._settings.set_value('cycle-height-steps', new GLib.Variant('ad', varr));
         });

--- a/prefs.js
+++ b/prefs.js
@@ -109,6 +109,36 @@ var SettingsWidget = class SettingsWidget {
             this._settings.set_int('vertical-margin-bottom', bottomMargin.get_value());
         });
 
+        let cycleWidths = this.builder.get_object('cycle_widths_entry');
+        let widthArray = this._settings.get_value('cycle-width-steps').deep_unpack();
+        cycleWidths.set_text(widthArray.toString().replaceAll(',', ', '));
+        cycleWidths.connect('changed', () => {
+            let varr = cycleWidths.get_text()
+                .replaceAll(',', ' ')
+                .split(' ')
+                .filter(Number);
+            this._settings.set_value('cycle-width-steps', new GLib.Variant('ad', varr));
+        });
+        this.builder.get_object('cycle_widths_reset_button').connect('clicked', () => {
+            // text value here should match the gshema value for cycle-width-steps
+            cycleWidths.set_text('0.38195, 0.5, 0.61804');
+        });
+
+        let cycleHeights = this.builder.get_object('cycle_heights_entry');
+        let heightArray = this._settings.get_value('cycle-height-steps').deep_unpack();
+        cycleHeights.set_text(heightArray.toString().replaceAll(',', ', '));
+        cycleHeights.connect('changed', () => {
+            let varr = cycleHeights.get_text()
+                .replaceAll(',', ' ')
+                .split(' ')
+                .filter(Number);
+            this._settings.set_value('cycle-height-steps', new GLib.Variant('ad', varr));
+        });
+        this.builder.get_object('cycle_heights_reset_button').connect('clicked', () => {
+            // text value here should match the gshema value for cycle-height-steps
+            cycleHeights.set_text('0.38195, 0.5, 0.61804');
+        });
+
         let vSens = this.builder.get_object('vertical-sensitivity');
         let hSens = this.builder.get_object('horizontal-sensitivity');
         let [sx, sy] = this._settings.get_value('swipe-sensitivity').deep_unpack();

--- a/prefs.js
+++ b/prefs.js
@@ -159,7 +159,7 @@ var SettingsWidget = class SettingsWidget {
                 }
                 element.remove_css_class('error');
                 
-                this._settings.set_value('cycle-width-steps', new GLib.Variant('ad', varr));
+                this._settings.set_value(settingName, new GLib.Variant('ad', varr));
             });
             this.builder.get_object(resetElementName).connect('clicked', () => {
                 // text value here should match the gshema value for cycle-width-steps

--- a/prefs.js
+++ b/prefs.js
@@ -126,10 +126,10 @@ var SettingsWidget = class SettingsWidget {
 
             element.connect('changed', () => {
                 // process values
-                // check if values are ratio or pixel
+                // check if values are percent or pixel
                 let value = element.get_text();
-                let isPercent = value.includes('%');
-                let isPixels = value.includes("px");
+                let isPercent = value.split(';').map(v => v.trim()).every(v => /^.*%$/.test(v));
+                let isPixels = value.split(';').map(v => v.trim()).every(v => /^.*px$/.test(v));
                 if (isPercent && isPixels) {
                     log("cycle width/height values cannot mix percentage and pixel values");
                     element.add_css_class('error');


### PR DESCRIPTION
Resolves #316, resolves #402 

This PR makes the "useful window widths" and "useful window heights" user-settable through the extension pref settings ui.

Inputs supported are percentage or pixel values, e.g. `38.195%; 50%; 61.804%` or `400px; 800px; 900px`.  Mixed input types (e.g. input with `%` AND `px` in it) are not supported and will cause the input box to turn red (error css class), as will any invalid input:
![image](https://user-images.githubusercontent.com/30424662/209928988-f7ec9fb9-fc42-43f1-b2e1-fee4f939cce3.png)
![image](https://user-images.githubusercontent.com/30424662/209928895-db071c04-5cf9-4c1e-b780-b76032fe1cdd.png)
![image](https://user-images.githubusercontent.com/30424662/209928938-e45353b4-b731-467c-bf95-d6f340bd8a07.png)

Changes are applied immediately (no need to logout/login etc.).

Reset buttons are also provided which will reset width/height values back to the default PaperWM cycle values.

Feedback welcome!

![image](https://user-images.githubusercontent.com/30424662/209930853-013995a6-7b16-444f-9589-35f4b498aa85.png)