### PR TITLE
CSS style improvements and polishing

### DIFF
--- a/minimap.js
+++ b/minimap.js
@@ -33,18 +33,22 @@ var Minimap = class Minimap extends Array {
         super();
         this.space = space;
         this.monitor = monitor;
-        let actor = new St.Widget({name: 'minimap-background',
-                                    style_class: 'switcher-list'});
+        let actor = new St.Widget({
+            name: 'minimap',
+            style_class: 'paperwm-minimap switcher-list'
+        });
         this.actor = actor;
         actor.height = space.height*0.20;
 
-        let highlight = new St.Widget({name: 'minimap-highlight',
-                                       style_class: 'item-box'});
+        let highlight = new St.Widget({
+            name: 'minimap-selection',
+            style_class: 'paperwm-minimap-selection item-box'
+        });
         highlight.add_style_pseudo_class('selected');
         this.highlight = highlight;
-        let label = new St.Label();
+        let label = new St.Label({style_class: 'paperwm-minimap-label'});
         label.clutter_text.ellipsize = Pango.EllipsizeMode.END;
-        this.label = label;;
+        this.label = label;
 
         let clip = new St.Widget({name: 'container-clip'});
         this.clip = clip;

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,9 +1,3 @@
-.paper-mm-selected-window {
-    border: 10px cyan; /* if we need to operate in pre-scaled dimension */
-    border-radius: 5px;
-}
-
-
 .workspace-icon-button {
     -st-icon-style: symbolic;
     border: none;
@@ -16,5 +10,10 @@
 }
 
 .paperwm-selection {
+    /* matches border radius of default gnome windows */
+    border-radius: 12px 12px 0px 0px;
+}
+
+.paperwm-minimap-selection {
     border-radius: 8px;
 }


### PR DESCRIPTION
This PR improves CSS styling a little (see comparison pics below... yes, I know if might be nitpicking!) and also adds mini-map CSS classes so users can customise the look/feel of the minimap (and mini-map selected/highlighted tile).

**_Note: I'm overriding the default PaperWM styles with the following `user.css` to highlight the differences better_**
```css
.paperwm-selection, .paperwm-minimap-selection {
    border-color: #d64161;
}
.paperwm-selection {
    background-color: #d64161;
}
.paperwm-minimap {
    background-color: rgba(0, 0, 0, 0.7);
}
```

### Subtle change to tiled window border
`paperwm-selection` default border-radius style was changed to match standard gnome window border radii:

#### Current window border radii
<img src="https://user-images.githubusercontent.com/30424662/210122038-33737e82-0ac1-4d5d-8aac-b0270f7a1549.png" width="250px">  <img src="https://user-images.githubusercontent.com/30424662/210122040-eb3b2a36-8606-4d05-8cb8-d819b5db74d9.png" width="250px">

#### New window border radii
<img src="https://user-images.githubusercontent.com/30424662/210122252-95fac2d9-d531-4727-ad3f-8e32d429cdcd.png" width="250px">  <img src="https://user-images.githubusercontent.com/30424662/210122256-ac5b3e07-2773-4a93-a259-c89f6f8ea042.png" width="250px">

### New CSS classes for mini-map styling
The following CSS classes have been added:

CSS class              | Description
------------------------ |------------------------------------
`paperwm-minimap` | styles the main mini-map element
`paperwm-minimap-selection` | styles the currently selected mini-map tile element
`paperwm-minimap-label` | styles the tile label (that shows the currently selected window title)

Allowing users to style the mini-map can make a big difference to being able to visually process / see where you are in the current window stack (in the mini-map) - especially if you have lots of windows in the stack.  Simple example below:

#### Current mini-map view (allows no styling so this is what you get)
![current-minimap](https://user-images.githubusercontent.com/30424662/210127020-b7b51652-3b46-4db1-8ef2-0de20b604e78.png)

#### New mini-map (with simple `border-color` and `background-color` styles added to `user.css`)
![new-minimap](https://user-images.githubusercontent.com/30424662/210127033-7a6607a5-71b8-4b2b-843e-a1676a03fdb4.png)

_NOTE: this PR has been implemented in the [PaperWM-redux](https://github.com/PaperWM-redux/PaperWM) fork, which you can install if you want this, or any of [my other open PRs](https://github.com/paperwm/PaperWM/pulls/jtaala)._