### PR TITLE
No longer minimise all scratch windows when a single scratch window is unscratched

### DIFF
--- a/scratch.js
+++ b/scratch.js
@@ -135,7 +135,6 @@ function unmakeScratch(metaWindow) {
 function toggle(metaWindow) {
     if (isScratchWindow(metaWindow)) {
         unmakeScratch(metaWindow);
-        hide();
     } else {
         makeScratch(metaWindow);
 


### PR DESCRIPTION
Resolves #455.

As mentioned in issue #455 I'm not sure why this behaviour was implemented - that is, what the use-case was for having every other scratch window minimize when one of the scratch windows is unscratched (which seems unexpected and annoying...).

_NOTE: this PR has been implemented in the [PaperWM-redux](https://github.com/PaperWM-redux/PaperWM) fork, which you can install if you want this, or any of [my other open PRs](https://github.com/paperwm/PaperWM/pulls/jtaala)._