### PR TITLE
Show next stackoverlay window preview when switching to offscreen window with mouse

### DIFF
--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -228,13 +228,17 @@ var StackOverlay = class StackOverlay {
                 this.clone.destroy();
                 this.clone = null;
             }
+
+            // remove/cleanup the previous preview
+            this.removePreview();
+            Mainloop.timeout_add(200, this.triggerPreview.bind(this));
             return true;
         });
 
         this.signals.connect(overlay, 'enter-event', this.triggerPreview.bind(this));
         this.signals.connect(overlay,'leave-event', this.removePreview.bind(this));
         this.signals.connect(Settings.settings, 'changed::pressure-barrier',
-                             this.updateBarrier.bind(this, true));
+            this.updateBarrier.bind(this, true));
 
         this.updateBarrier();
 
@@ -275,7 +279,8 @@ var StackOverlay = class StackOverlay {
             clone.set_position(x, y);
         });
 
-        this._removeId = Mainloop.timeout_add_seconds(2, this.removePreview.bind(this));
+        // uncomment to remove the preview after a timeout
+        //this._removeId = Mainloop.timeout_add_seconds(2, this.removePreview.bind(this));
     }
 
     removePreview() {

--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -231,7 +231,13 @@ var StackOverlay = class StackOverlay {
 
             // remove/cleanup the previous preview
             this.removePreview();
-            Mainloop.timeout_add(200, this.triggerPreview.bind(this));
+            Mainloop.timeout_add(200, () => {
+                // if pointer is still at edge (within 2px), trigger preview
+                let [x, y, mask] = global.get_pointer();
+                if (x <= 2 || x >= this.monitor.width - 2) {
+                    this.triggerPreview.bind(this)();
+                }
+            });
             return true;
         });
 


### PR DESCRIPTION
Closes #470.

This PR automatically shows the next stackoverlay window preview (if window exists) when a user clicks with the current preview.  Previous behaviour did not show the next window preview meaning users had to move the mouse away, and then back against the screen edge to show the next preview.

Note: I've also removed the 2 second timeout on showing next window previews.  This feels better to me - but please comment if you think the original (2 second timeout for previews) is better.

_NOTE: this PR has been implemented in the [PaperWM-redux](https://github.com/PaperWM-redux/PaperWM) fork, which you can install if you want this, or any of [my other open PRs](https://github.com/paperwm/PaperWM/pulls/jtaala)._