### PR TITLE
Check gnome version compatibility

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -90,7 +90,7 @@ function init() {
     Extension = imports.misc.extensionUtils.getCurrentExtension();
     convenience = Extension.imports.convenience;
 
-    checkGnomeShellVersionCompatibility();
+    warnAboutGnomeShellVersionCompatibility();
 
     if(initRun) {
         log(`#startup Reinitialized against our will! Skip adding bindings again to not cause trouble.`);
@@ -131,7 +131,9 @@ var GLib = imports.gi.GLib;
 var Main = imports.ui.main;
 var Config = imports.misc.config;
 
-function checkGnomeShellVersionCompatibility() {
+// Checks gnome shell version compatibility and warns the user when running on
+// and unsupported version.
+function warnAboutGnomeShellVersionCompatibility() {
     const gnomeShellVersion = Config.PACKAGE_VERSION;
     const supportedVersions = Extension.metadata["shell-version"];
     for (const version of supportedVersions) {
@@ -142,11 +144,16 @@ function checkGnomeShellVersionCompatibility() {
 
     // did not find a supported version
     print("#paperwm", `WARNING: Running on unsupported version of gnome shell (${gnomeShellVersion})`);
-    print("#paperwm", `WARNING: Supported versions: ${supportedVersions}`);
+    print("#paperwm", `Supported versions: ${supportedVersions}`);
     const msg = `Running on unsupported version of gnome shell (${gnomeShellVersion}).
 Supported versions: ${supportedVersions}.
-Please upgrade/downgrade your gnome shell to a supported version or upgrade/downgrade PaperWM.`;
-    errorNotification("PaperWM warning", msg);
+Click for more information.`;
+
+    const notification = notify("PaperWM Warning", msg);
+    notification.connect('activated', () => {
+        imports.misc.util.spawn(["xdg-open", "https://github.com/paperwm/PaperWM/wiki/Warning:-Running-on-unsupported-version-of-gnome-shell"]);
+        notification.destroy();
+    });
 }
 
 function getConfigDir() {

--- a/extension.js
+++ b/extension.js
@@ -90,6 +90,8 @@ function init() {
     Extension = imports.misc.extensionUtils.getCurrentExtension();
     convenience = Extension.imports.convenience;
 
+    checkGnomeShellVersionCompatibility();
+
     if(initRun) {
         log(`#startup Reinitialized against our will! Skip adding bindings again to not cause trouble.`);
         return;
@@ -127,6 +129,25 @@ function disable() {
 var Gio = imports.gi.Gio;
 var GLib = imports.gi.GLib;
 var Main = imports.ui.main;
+var Config = imports.misc.config;
+
+function checkGnomeShellVersionCompatibility() {
+    const gnomeShellVersion = Config.PACKAGE_VERSION;
+    const supportedVersions = Extension.metadata["shell-version"];
+    for (const version of supportedVersions) {
+        if (gnomeShellVersion.startsWith(version)) {
+            return;
+        }
+    }
+
+    // did not find a supported version
+    print("#paperwm", `WARNING: Running on unsupported version of gnome shell (${gnomeShellVersion})`);
+    print("#paperwm", `WARNING: Supported versions: ${supportedVersions}`);
+    const msg = `Running on unsupported version of gnome shell (${gnomeShellVersion}).
+Supported versions: ${supportedVersions}.
+Please upgrade/downgrade your gnome shell to a supported version or upgrade/downgrade PaperWM.`;
+    errorNotification("PaperWM warning", msg);
+}
 
 function getConfigDir() {
     return Gio.file_new_for_path(GLib.get_user_config_dir() + '/paperwm');


### PR DESCRIPTION
In `init` check the gnome shell compatibility (as specified in the manifest) and display a warning if it is not compatible.

This is useful/necessary because if you git pull PaperWM after you installed it in a compatible version, you might update to an incompatible version. E.g. I imagine the develop branch will eventually move to the next gnome version and that gnome version could be incompatible (like the branches for the other gnome versions).

![Screenshot from 2023-02-26 19-25-05](https://user-images.githubusercontent.com/32217236/221429567-a68700b6-293c-4f4c-b3aa-409f8293e4f4.png)

(Note: I hardcoded the version string to get the screenshots)

The notification reuses the existing `errorNotification` so it will show an editor with the message when clicked.

Questions:
- Should there be a way to disable the warning?
- The notification disappears relatively quickly. But I don't see a way to make it stay.

Fixes #475