### PR TITLE
Setting a minimap_scale preference of 0 hides mini-map

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -47,7 +47,7 @@
   </object>
   <object class="GtkAdjustment" id="minimap_scale">
     <property name="upper">95</property>
-    <property name="lower">5</property>
+    <property name="lower">0</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>
@@ -567,7 +567,8 @@
                       <object class="GtkLabel" id="workspace_label11">
                         <property name="focusable">False</property>
                         <property name="hexpand">1</property>
-                        <property name="label" translatable="yes">Mini-map scale size (%)</property>
+                        <property name="label" translatable="yes">Mini-map scale &lt;i&gt;(0 hides Mini-map)&lt;/i&gt;</property>
+                        <property name="use_markup">1</property>
                         <property name="xalign">0</property>
                         <layout>
                           <property name="column">0</property>

--- a/minimap.js
+++ b/minimap.js
@@ -115,6 +115,12 @@ var Minimap = class Minimap extends Array {
     show(animate) {
         if (this.destroyed)
             return;
+
+        // if minimap_scale preference is 0, then don't show
+        if (prefs.minimap_scale <= 0) {
+            return;
+        }
+        
         this.layout();
         let time = animate ? 0.25 : 0;
         this.actor.show();


### PR DESCRIPTION
Fixes #173 and #325 .

Some users would prefer to not show the mini-map when switching windows with shortcut keys.

This PR allows hiding (not showing) the minimap by setting a value of `0` for the `Mini-map Scale` setting in the PaperWM user preferences.

https://user-images.githubusercontent.com/30424662/222705545-7d2dc0b8-6c12-43a4-8cce-4eb7c131a52f.mp4

_NOTE: this PR has been implemented in the [PaperWM-redux](https://github.com/PaperWM-redux/PaperWM) fork, which you can install if you want to try this, or any of [my other open PRs](https://github.com/paperwm/PaperWM/pulls/jtaala)._