### PR TITLE
WIP: Add button in settings to reload css

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -709,6 +709,12 @@
                 </child>
               </object>
             </child>
+            <child>
+              <object class="GtkButton" id="reload-css">
+                <property name="label">Reload CSS</property>
+                <property name="tooltip_text" translatable="yes">Reload all currently loaded CSS files (from all extensions and the user.css)</property>
+              </object>
+            </child>>
           </object>
         </child>
       </object>

--- a/extension.js
+++ b/extension.js
@@ -105,6 +105,13 @@ function init() {
 
 function enable() {
     log(`#paperwm enable ${SESSIONID}`);
+
+    let userStylesheet = getConfigDir().get_child("user.css");
+    if (userStylesheet.query_exists(null)) {
+        let themeContext = St.ThemeContext.get_for_stage(global.stage);
+        themeContext.get_theme().load_stylesheet(userStylesheet);
+    }
+
     if (enabled) {
         log('enable called without calling disable');
         return;
@@ -209,12 +216,6 @@ function initUserConfig() {
 
     if (hasUserConfigFile()) {
         Extension.imports.searchPath.push(getConfigDir().get_path());
-    }
-
-    let userStylesheet = getConfigDir().get_child("user.css");
-    if (userStylesheet.query_exists(null)) {
-        let themeContext = St.ThemeContext.get_for_stage(global.stage);
-        themeContext.get_theme().load_stylesheet(userStylesheet);
     }
 }
 

--- a/prefs.js
+++ b/prefs.js
@@ -1,3 +1,10 @@
+/*
+ * Defines the extensions settings window.
+ *
+ * This file is automatically loaded by gnome-shell when opening the settings
+ * for this extension (e.g. by clicking the "Settings" button in the Extensions
+ * app).
+ */
 
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
@@ -237,6 +244,13 @@ var SettingsWidget = class SettingsWidget {
         topbarFollowFocus.connect('state-set', (obj, state) => {
             this._settings.set_boolean('topbar-follow-focus',
                 state);
+        });
+
+        let reloadCssButton = this.builder.get_object('reload-css');
+        log("reload-css button", reloadCssButton);
+        reloadCssButton.connect('clicked', () => {
+            log("reload-css clicked");
+            imports.ui.main.loadTheme();
         });
 
         // Workspaces
@@ -833,6 +847,7 @@ function syncStringSetting(settings, key, callback) {
 }
 
 function init() {
+    log("prefs here");
     const provider = new Gtk.CssProvider();
     provider.load_from_path(Extension.dir.get_path() + '/resources/prefs.css');
     Gtk.StyleContext.add_provider_for_display(


### PR DESCRIPTION
As it turns out reloading the CSS was easy. Just call `Main.loadTheme()`.

But I'm having some trouble with the UI. The button shows up, but for some reason the click-listener does not work. Also as far as I can tell `init` in prefs.js is also never called. I pieced together that this is automatically loaded by gnome-shell and not by us, but I can't get it to work.

@jtaala I would be grateful for some pointers here. Or if you want you can just implement it yourself and I will take a look at that.