### PR TITLE
Create issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Version (please complete the following information):**
+- Gnome version: [e.g. 43.3, you can see this in Settings > About]
+- PaperWM version: [e.g. branch gnome-40, tag 38.2, if you are using develop please include the commit]
+ - Distribution: [e.g. Ubuntu 22.04, Arch Linux (optional)]
+- Any other installed gnome extensions: [if you think they are related to the issue]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,11 +23,21 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
-**Version (please complete the following information):**
-- Gnome version: [e.g. 43.3, you can see this in Settings > About]
-- PaperWM version: [e.g. branch gnome-40, tag 38.2, if you are using develop please include the commit]
- - Distribution: [e.g. Ubuntu 22.04, Arch Linux (optional)]
-- Any other installed gnome extensions: [if you think they are related to the issue]
+**System information:**
+Please execute `./gather-system-info.sh` in you PaperWM clone and paste the output below.
+
+```
+Example:
+Distribution: Arch Linux
+GNOME Shell 43.3
+PaperWM branch/tag: develop
+PaperWM commit: 223ff883bca9bf20dbf066eceda891cb6e8be931
+Enabled extensions:
+- paperwm@hedning:matrix.org
+- switcher@landau.fi
+- dash-to-panel@jderose9.github.com
+- appindicatorsupport@rgcjonas.gmail.com
+```
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Zulip Chat
+    url: https://paperwm.zulipchat.com/
+    about: Talk to us on Zulip.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/gather-system-info.sh
+++ b/gather-system-info.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Gather and print version information about the system.
+#
+# Expects the following commands to be available:
+# - git
+# - gnome-shell
+# - gnome-extensions
+# Optionally:
+# - awk
+
+REPO="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd "${REPO}"
+
+echo "Please include this information in your bug report on GitHub!"
+
+echo -n "Distribution: "
+if [ -f /etc/os-release ]; then
+    source /etc/os-release && echo "${NAME}"
+fi
+
+gnome-shell --version
+
+echo -n "PaperWM branch/tag: "
+git symbolic-ref --short -q HEAD || git name-rev --tags --name-only --no-undefined "$(git rev-parse HEAD)"
+echo -n "PaperWM commit: "
+git rev-parse HEAD
+
+echo "Enabled extensions:"
+# make a markdown list out of gnome-extensions list
+gnome-extensions list --enabled | {
+    if command -v awk >/dev/null; then
+        awk '{print "- " $0}'
+    else
+        cat
+    fi
+}
+


### PR DESCRIPTION
Add two issue templates: bugs and feature requests.

See it in action here: https://github.com/Lythenas/PaperWM/issues/new/choose

Also added a script to make it easier to gather the system information that might be useful to us:
```
$ ./gather-debug-info.sh
# Please include this information in your bug report on GitHub!
Distribution: Arch Linux
GNOME Shell 43.3
PaperWM branch/tag: develop
PaperWM commit: 223ff883bca9bf20dbf066eceda891cb6e8be931
Enabled extensions:
- paperwm@hedning:matrix.org
- switcher@landau.fi
- dash-to-panel@jderose9.github.com
- appindicatorsupport@rgcjonas.gmail.com
```

For bug reports we could also use an issue for (which is a beta feature):
- more information here: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository
- IMO good example here: https://github.com/doomemacs/doomemacs/issues/new/choose

But I think for our purposes this is sufficient for now.

Also I still allowed to start with an empty issue template.