### PR TITLE
Replaces #364: removes the left and right tiling restriction that caused no margin to be shown

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -2883,12 +2883,6 @@ function ensuredX(meta_window, space) {
     let max = min + workArea.width;
     if (meta_window.fullscreen) {
         x = 0;
-    } else if (index == 0 && x <= min) {
-        // Always align the first window to the display's left edge
-        x = min;
-    } else if (index == space.length-1 && x + frame.width >= max) {
-        // Always align the first window to the display's right edge
-        x = max - frame.width;
     } else if (frame.width > workArea.width*0.9 - 2*(prefs.horizontal_margin + prefs.window_gap)) {
         // Consider the window to be wide and center it
         x = min + Math.round((workArea.width - frame.width)/2);


### PR DESCRIPTION
Closes #364.

This PR was created since @basdelfos develop branch/fork isn't available anymore :-(

Please see #364 for details of this.  It has been a long time coming.  Given the merging of #471 (an improved way to see the window position), and also the merging of #473, having no margin on the left/right tiling edge no longer provides the original benefit (of seeing when you're at an tiling edge).

This simply removes the cases where no left/right margin would be shown - which also cleans-up/simplifies this area of code (thanks @smichel17 ). 

Note: we will close #467 as it was originally a way to set this separately.  However we will be closing that in favour of this one.

