### PR TITLE
Extension UUID name change to avoid path issues (remove `:` from `paperwm@hedning:matrix.org`)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -33,7 +33,7 @@ GNOME Shell 43.3
 PaperWM branch/tag: develop
 PaperWM commit: 223ff883bca9bf20dbf066eceda891cb6e8be931
 Enabled extensions:
-- paperwm@hedning:matrix.org
+- paperwm@hedning.matrix.org
 - switcher@landau.fi
 - dash-to-panel@jderose9.github.com
 - appindicatorsupport@rgcjonas.gmail.com

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ When the tiling is active <kbd>Super</kbd><kbd>Shift</kbd><kbd>Tab</kbd> selects
 
 A default user configuration, `user.js`, is created in `~/.config/paperwm/` with three functions `init`, `enable` and `disable`. `init` will run only once on startup, `enable` and `disable` will be run whenever extensions are being told to disable and enable themselves. Eg. when locking the screen with <kbd>Super</kbd><kbd>L</kbd>.
 
-You can also supply a custom `user.css` in `~/.config/paperwm/`. This user stylesheet can override the default styles of paperwm (e.g. from `~/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org/user.css` or `/usr/share/gnome-shell/extensions/paperwm@hedning:matrix.org/user.css`), gnome or even other extensions. The same rules as for CSS in the browser apply (i.e. CSS rules are additive). To reload the `user.css` (and all other loaded CSS files) you can run `Main.loadTheme()` in looking glass (i.e. <kbd>Alt</kbd><kbd>F2</kbd> `lg` <kbd>Return</kbd>). Note that `user.css` needs to already be loaded for this to work. So after initially creating the file you might need to restart gnome once.
+You can also supply a custom `user.css` in `~/.config/paperwm/`. This user stylesheet can override the default styles of paperwm (e.g. from `~/.local/share/gnome-shell/extensions/paperwm@hedning.matrix.org/user.css` or `/usr/share/gnome-shell/extensions/paperwm@hedning.matrix.org/user.css`), gnome or even other extensions. The same rules as for CSS in the browser apply (i.e. CSS rules are additive). To reload the `user.css` (and all other loaded CSS files) you can run `Main.loadTheme()` in looking glass (i.e. <kbd>Alt</kbd><kbd>F2</kbd> `lg` <kbd>Return</kbd>). Note that `user.css` needs to already be loaded for this to work. So after initially creating the file you might need to restart gnome once.
 
 We also made an emacs package, [gnome-shell-mode](https://github.com/paperwm/gnome-shell-mode), to make hacking on the config and writing extensions a more pleasant experience. To support this out of the box we also install a `metadata.json` so gnome-shell-mode will pick up the correct file context, giving you completion and interactive evaluation ala. looking glass straight in emacs.
 
@@ -178,7 +178,7 @@ Pressing <kbd>Super</kbd><kbd>Insert</kbd> will assign the active window to a gl
 #### Using dconf-editor to modify settings
 
 ```shell
-GSETTINGS_SCHEMA_DIR=$HOME/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org/schemas dconf-editor /org/gnome/shell/extensions/paperwm/
+GSETTINGS_SCHEMA_DIR=$HOME/.local/share/gnome-shell/extensions/paperwm@hedning.matrix.org/schemas dconf-editor /org/gnome/shell/extensions/paperwm/
 ```
 
 ### Setting window specific properities

--- a/app.js
+++ b/app.js
@@ -4,9 +4,9 @@
 
 var Extension;
 if (imports.misc.extensionUtils.extensions) {
-    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning:matrix.org"];
+    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning.matrix.org"];
 } else {
-    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning:matrix.org");
+    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning.matrix.org");
 }
 
 var GLib = imports.gi.GLib

--- a/examples/layouts.js
+++ b/examples/layouts.js
@@ -1,8 +1,8 @@
 var Extension;
 if (imports.misc.extensionUtils.extensions) {
-    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning:matrix.org"];
+    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning.matrix.org"];
 } else {
-    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning:matrix.org");
+    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning.matrix.org");
 }
 var Keybindings = Extension.imports.keybindings;
 var Main = imports.ui.main;

--- a/gestures.js
+++ b/gestures.js
@@ -1,8 +1,8 @@
 var Extension;
 if (imports.misc.extensionUtils.extensions) {
-    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning:matrix.org"];
+    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning.matrix.org"];
 } else {
-    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning:matrix.org");
+    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning.matrix.org");
 }
 
 var gliding = false;

--- a/grab.js
+++ b/grab.js
@@ -1,8 +1,8 @@
 var Extension;
 if (imports.misc.extensionUtils.extensions) {
-    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning:matrix.org"];
+    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning.matrix.org"];
 } else {
-    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning:matrix.org");
+    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning.matrix.org");
 }
 
 var Meta = imports.gi.Meta;

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 REPO="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-UUID=paperwm@hedning:matrix.org
+UUID=paperwm@hedning.matrix.org
 EXT_DIR=${XDG_DATA_HOME:-$HOME/.local/share}/gnome-shell/extensions
 mkdir -p "$EXT_DIR"
 ln -sn "$REPO" "$EXT_DIR"/"$UUID"

--- a/keybindings.js
+++ b/keybindings.js
@@ -1,8 +1,8 @@
 var Extension;
 if (imports.misc.extensionUtils.extensions) {
-    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning:matrix.org"];
+    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning.matrix.org"];
 } else {
-    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning:matrix.org");
+    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning.matrix.org");
 }
 
 var Me = Extension.imports.keybindings;

--- a/kludges.js
+++ b/kludges.js
@@ -7,9 +7,9 @@
 
 var Extension;
 if (imports.misc.extensionUtils.extensions) {
-    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning:matrix.org"];
+    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning.matrix.org"];
 } else {
-    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning:matrix.org");
+    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning.matrix.org");
 }
 
 var Meta = imports.gi.Meta;

--- a/liveAltTab.js
+++ b/liveAltTab.js
@@ -1,8 +1,8 @@
 var Extension;
 if (imports.misc.extensionUtils.extensions) {
-    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning:matrix.org"];
+    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning.matrix.org"];
 } else {
-    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning:matrix.org");
+    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning.matrix.org");
 }
 
 var Clutter = imports.gi.Clutter;

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "uuid": "paperwm@hedning:matrix.org",
+  "uuid": "paperwm@hedning.matrix.org",
   "name": "PaperWM",
   "description": "Tiling window manager with a twist",
   "url": "https://github.com/paperwm/PaperWM",

--- a/minimap.js
+++ b/minimap.js
@@ -1,8 +1,8 @@
 var Extension;
 if (imports.misc.extensionUtils.extensions) {
-    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning:matrix.org"];
+    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning.matrix.org"];
 } else {
-    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning:matrix.org");
+    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning.matrix.org");
 }
 
 var Clutter = imports.gi.Clutter;

--- a/navigator.js
+++ b/navigator.js
@@ -7,9 +7,9 @@
 
 var Extension;
 if (imports.misc.extensionUtils.extensions) {
-    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning:matrix.org"];
+    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning.matrix.org"];
 } else {
-    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning:matrix.org");
+    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning.matrix.org");
 }
 
 var Meta = imports.gi.Meta;

--- a/scratch.js
+++ b/scratch.js
@@ -1,8 +1,8 @@
 var Extension;
 if (imports.misc.extensionUtils.extensions) {
-    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning:matrix.org"];
+    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning.matrix.org"];
 } else {
-    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning:matrix.org");
+    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning.matrix.org");
 }
 
 var Meta = imports.gi.Meta;

--- a/settings.js
+++ b/settings.js
@@ -5,11 +5,11 @@
  */
 var Extension;
 if (imports.misc.extensionUtils.extensions) {
-    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning:matrix.org"];
+    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning.matrix.org"];
 } else {
     // Cannot relaiably test for imports.ui in the preference ui
     try {
-        Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning:matrix.org");
+        Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning.matrix.org");
     } catch(e) {
         Extension = imports.misc.extensionUtils.getCurrentExtension();
     }

--- a/shell.sh
+++ b/shell.sh
@@ -41,7 +41,7 @@ esac
 
 
 dconf reset -f /  # Reset settings
-dconf write /org/gnome/shell/enabled-extensions "['paperwm@hedning:matrix.org']"
+dconf write /org/gnome/shell/enabled-extensions "['paperwm@hedning.matrix.org']"
 
 gnome-shell $args
 

--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -1,8 +1,8 @@
 var Extension;
 if (imports.misc.extensionUtils.extensions) {
-    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning:matrix.org"];
+    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning.matrix.org"];
 } else {
-    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning:matrix.org");
+    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning.matrix.org");
 }
 
 var Tiling = Extension.imports.tiling;

--- a/tiling.js
+++ b/tiling.js
@@ -1,8 +1,8 @@
 var Extension;
 if (imports.misc.extensionUtils.extensions) {
-    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning:matrix.org"];
+    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning.matrix.org"];
 } else {
-    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning:matrix.org");
+    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning.matrix.org");
 }
 
 var GLib = imports.gi.GLib;

--- a/topbar.js
+++ b/topbar.js
@@ -4,9 +4,9 @@
 
 var Extension;
 if (imports.misc.extensionUtils.extensions) {
-    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning:matrix.org"];
+    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning.matrix.org"];
 } else {
-    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning:matrix.org");
+    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning.matrix.org");
 }
 
 var Meta = imports.gi.Meta;

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -6,7 +6,7 @@ REPO="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 if [[ -L "$REPO" ]]; then
    REPO=`readlink --canonicalize "$REPO"`
 fi
-UUID=paperwm@hedning:matrix.org
+UUID=paperwm@hedning.matrix.org
 if type gnome-extensions > /dev/null; then
     gnome-extensions disable "$UUID"
 else

--- a/utils.js
+++ b/utils.js
@@ -1,8 +1,8 @@
 var Extension;
 if (imports.misc.extensionUtils.extensions) {
-    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning:matrix.org"];
+    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning.matrix.org"];
 } else {
-    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning:matrix.org");
+    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning.matrix.org");
 }
 var { Gdk, GLib, Clutter, Meta, GObject } = imports.gi;
 

--- a/virtTiling.js
+++ b/virtTiling.js
@@ -1,8 +1,8 @@
 var Extension;
 if (imports.misc.extensionUtils.extensions) {
-    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning:matrix.org"];
+    Extension = imports.misc.extensionUtils.extensions["paperwm@hedning.matrix.org"];
 } else {
-    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning:matrix.org");
+    Extension = imports.ui.main.extensionManager.lookup("paperwm@hedning.matrix.org");
 }
 
 var Clutter = imports.gi.Clutter


### PR DESCRIPTION
Fixes #322.   Also mentioned in [#376](https://github.com/paperwm/PaperWM/issues/376#issuecomment-815561175).

As noted in #322, having a colon `:` in the extension uuid/name can cause issues with using gsettings(?) to change settings.

To avoid this, and any potential future issues with having a non-standard(?) extension uuid, this PR changes it to a more standard (note the `.` instead of a `:`) `paperwm@hedning.matrix.org`.

The only issue I can see, if that users would need to run `./install.sh` again and logout/login... but if not now, when? :stuck_out_tongue_winking_eye: 