### PR TITLE
Allow enabling the extension in Gnome 44

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ We hang out on [zulip](https://paperwm.zulipchat.com).
 
 Clone the repo and check out the branch supporting the Gnome Shell version you're running.
 
+- 44 (experimental, not officially supported yet, please report bugs): https://github.com/paperwm/PaperWM/tree/develop
 - 43 (experimental, please report bugs): https://github.com/paperwm/PaperWM/tree/develop
 - 42: https://github.com/paperwm/PaperWM/tree/gnome-42
 - 40: https://github.com/paperwm/PaperWM/tree/gnome-40

--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,7 @@
   "description": "Tiling window manager with a twist",
   "url": "https://github.com/paperwm/PaperWM",
   "settings-schema": "org.gnome.Shell.Extensions.PaperWM",
-  "shell-version": [ "42", "43" ],
+  "shell-version": [ "42", "43", "44" ],
   "version": "43.0",
   "session-modes":  [ "unlock-dialog", "user" ]
 }


### PR DESCRIPTION
This allows enabling the extension in Gnome 44 (even if there might be errors)

Do we also want to increase the version number of PaperWM to "44.0"? We can also wait until we officially support Gnome 44.