### PR TITLE
Fix swipe gesture trackers and workspace switching / double workspace animation (no longer need `Vertical overview` extension to workaround)

### DIFF
--- a/kludges.js
+++ b/kludges.js
@@ -374,10 +374,10 @@ function restoreMethod(obj, name) {
 
 var signals;
 var swipeTrackers = [
-    Main.overview?._swipeTracker,
-    Main.overview?._overview?._controls?._workspacesDisplay?._swipeTracker,
-    Main.wm?._swipeTracker,
-    Main.wm._workspaceAnimation?._swipeTracker
+    Main?.overview?._swipeTracker,
+    Main?.overview?._overview?._controls?._workspacesDisplay?._swipeTracker,
+    Main?.wm?._swipeTracker,
+    Main?.wm?._workspaceAnimation?._swipeTracker
 ].filter(t => t !== undefined);
 function init() {
     registerOverridePrototype(imports.ui.messageTray.MessageTray, '_updateState');

--- a/kludges.js
+++ b/kludges.js
@@ -375,8 +375,9 @@ function restoreMethod(obj, name) {
 var signals;
 var swipeTrackers = [
     Main.overview?._swipeTracker,
-    Main.wm._workspaceAnimation?._swipeTracker,
-    Main.overview?._overview?._controls?._workspacesDisplay?._swipeTracker
+    Main.overview?._overview?._controls?._workspacesDisplay?._swipeTracker,
+    Main.wm?._swipeTracker,
+    Main.wm._workspaceAnimation?._swipeTracker
 ].filter(t => t !== undefined);
 function init() {
     registerOverridePrototype(imports.ui.messageTray.MessageTray, '_updateState');
@@ -567,8 +568,6 @@ function enable() {
                 this._notificationExpired = false;
             };
     }
-
-
 }
 
 function disable() {

--- a/kludges.js
+++ b/kludges.js
@@ -458,10 +458,16 @@ function enable() {
     });
     actions.forEach(a => global.stage.remove_action(a))
 
-
-    signals.connect(settings, 'changed::override-hot-corner',
-                    disableHotcorners);
+    signals.connect(settings, 'changed::override-hot-corner', disableHotcorners);
     disableHotcorners();
+
+    /**
+     * Swipetrackers are reset by gnome during overview, once exits overview
+     * ensure swipe trackers are reset.
+     */
+    signals.connect(Main.overview, 'hidden', () => {
+        swipeTrackers.forEach(t => t.enabled = false);
+    });
 
     function scratchInOverview() {
         let onlyScratch = settings.get_boolean('only-scratch-in-overview');
@@ -472,10 +478,8 @@ function enable() {
             disableOverride(Workspace.Workspace.prototype, '_isOverviewWindow');
         }
     }
-    signals.connect(settings, 'changed::only-scratch-in-overview',
-                    scratchInOverview);
-    signals.connect(settings, 'changed::disable-scratch-in-overview',
-                    scratchInOverview);
+    signals.connect(settings, 'changed::only-scratch-in-overview',scratchInOverview);
+    signals.connect(settings, 'changed::disable-scratch-in-overview', scratchInOverview);
     scratchInOverview();
 
 
@@ -499,7 +503,6 @@ function enable() {
             switchData.inProgress = false;
 
             switchData.container = new Clutter.Actor();
-
         };
 
     Workspace.Workspace.prototype._realRecalculateWindowPositions = _realRecalculateWindowPositions;

--- a/kludges.js
+++ b/kludges.js
@@ -372,13 +372,18 @@ function restoreMethod(obj, name) {
         obj[name] = method;
 }
 
-var signals;
+/**
+ * Swipetrackers that should be disabled.  Locations of swipetrackers may
+ * move from gnome version to gnome version.  Next to the swipe tracker locations
+ * below are the gnome versions when they were first (or last) seen.
+ */
 var swipeTrackers = [
-    Main?.overview?._swipeTracker,
-    Main?.overview?._overview?._controls?._workspacesDisplay?._swipeTracker,
-    Main?.wm?._swipeTracker,
-    Main?.wm?._workspaceAnimation?._swipeTracker
-].filter(t => t !== undefined);
+    Main?.overview?._swipeTracker, // gnome 40+
+    Main?.overview?._overview?._controls?._workspacesDisplay?._swipeTracker, // gnome 40+
+    Main?.wm?._workspaceAnimation?._swipeTracker, // gnome 40+
+    Main?.wm?._swipeTracker // gnome 38 (and below)
+].filter(t => typeof t !== 'undefined');
+var signals;
 function init() {
     registerOverridePrototype(imports.ui.messageTray.MessageTray, '_updateState');
     registerOverridePrototype(WindowManager.WindowManager, '_prepareWorkspaceSwitch');
@@ -478,7 +483,7 @@ function enable() {
             disableOverride(Workspace.Workspace.prototype, '_isOverviewWindow');
         }
     }
-    signals.connect(settings, 'changed::only-scratch-in-overview',scratchInOverview);
+    signals.connect(settings, 'changed::only-scratch-in-overview', scratchInOverview);
     signals.connect(settings, 'changed::disable-scratch-in-overview', scratchInOverview);
     scratchInOverview();
 

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -14,7 +14,7 @@
 }
 
 .focus-button-tooltip {
-    background-color: rgba(0, 0, 0, 0.7);
+    background-color: rgba(0, 0, 0, 0.8);
     padding: 8px;
     border-radius: 8px;
     font-weight: 600;

--- a/tiling.js
+++ b/tiling.js
@@ -41,6 +41,7 @@ var TopBar = Extension.imports.topbar;
 var Navigator = Extension.imports.navigator;
 var ClickOverlay = Extension.imports.stackoverlay.ClickOverlay;
 var Settings = Extension.imports.settings;
+var Kludges = Extension.imports.kludges;
 var Me = Extension.imports.tiling;
 
 var prefs = Settings.prefs;
@@ -276,7 +277,11 @@ var Space = class Space extends Array {
                              utils.dynamic_function_ref("remove_handler", Me));
         this.signals.connect(Main.overview, 'showing',
                              this.startAnimate.bind(this));
-        this.signals.connect(Main.overview, 'hidden', this.moveDone.bind(this));
+        this.signals.connect(Main.overview, 'hidden', () => {
+            // after overview hidden, swipetrackers are reset by gnome, ensure are disabled here
+            Kludges.swipeTrackers.forEach(t => t.enabled = false);
+            this.moveDone();
+        });
 
         const Convenience = Extension.imports.convenience;
         const settings = Convenience.getSettings();

--- a/tiling.js
+++ b/tiling.js
@@ -41,7 +41,6 @@ var TopBar = Extension.imports.topbar;
 var Navigator = Extension.imports.navigator;
 var ClickOverlay = Extension.imports.stackoverlay.ClickOverlay;
 var Settings = Extension.imports.settings;
-var Kludges = Extension.imports.kludges;
 var Me = Extension.imports.tiling;
 
 var prefs = Settings.prefs;
@@ -277,11 +276,7 @@ var Space = class Space extends Array {
                              utils.dynamic_function_ref("remove_handler", Me));
         this.signals.connect(Main.overview, 'showing',
                              this.startAnimate.bind(this));
-        this.signals.connect(Main.overview, 'hidden', () => {
-            // after overview hidden, swipetrackers are reset by gnome, ensure are disabled here
-            Kludges.swipeTrackers.forEach(t => t.enabled = false);
-            this.moveDone();
-        });
+        this.signals.connect(Main.overview, 'hidden', this.moveDone.bind(this));
 
         const Convenience = Extension.imports.convenience;
         const settings = Convenience.getSettings();

--- a/topbar.js
+++ b/topbar.js
@@ -201,11 +201,12 @@ class ColorEntry {
  */
 var FocusIcon = Utils.registerClass(
 class FocusIcon extends St.Icon {
-    _init(properties = {}, tooltip_x_point=0) {
+    _init(properties = {}, tooltip_parent, tooltip_x_point=0) {
         super._init(properties);
         this.reactive = true;
 
         // allow custom x position for tooltip
+        this.tooltip_parent = tooltip_parent ?? this;
         this.tooltip_x_point = tooltip_x_point;
 
         // read in focus icons from resources folder
@@ -236,12 +237,12 @@ class FocusIcon extends St.Icon {
         const tt = new St.Label({style_class: 'focus-button-tooltip'});
         tt.hide();
         global.stage.add_child(tt);
-        this.connect('enter-event', icon => {
+        this.tooltip_parent.connect('enter-event', icon => {
             this._updateTooltipPosition(this.tooltip_x_point);
             this._updateTooltipText();
             tt.show();
         });
-        this.connect('leave-event', (icon, event) => {
+        this.tooltip_parent.connect('leave-event', (icon, event) => {
             if (!this.has_pointer) {
                 tt.hide();
             }
@@ -311,7 +312,7 @@ class FocusButton extends PanelMenu.Button {
         
         this._icon = new FocusIcon({
             style_class: 'system-status-icon focus-mode-button'
-        }, -10);
+        }, this, -10);
         
         this.setFocusMode();
         this.add_child(this._icon);


### PR DESCRIPTION
Fixes #413.

This PR fixes/updates swipe gesture tracking disabling in PaperWM, and implements a fix for gnome resetting this swipe gesture tracking after showing overview.

PaperWM disables the **default** swipe gesture tracking for workspace switching (only applicable to Wayland), and instead uses it's own one.  However, gnome was resetting the default switching trackers after going into overview mode, resulting in it breaking the paperwm swipe tracking, and the weird double-switching animation bug.  Changes in this PR ensure default swipe tracking gestures for workspace switching remains disabled.

Previously, a way to alleviate this issue was by using the [Vertical overview](https://extensions.gnome.org/extension/4144/vertical-overview/) extension.  However, this was just working around the issue.  Since the extension enforces vertical workspaces, 3-finger swipe gestures (which usually switches to next horizontal workspace) are not applicable in vertical workspaces.

This PR alleviates the need to use the `Vertical overview` extension to avoid the aforementioned issue.

This makes it a bit easier for new users who are often confused (annoyed?) by the 3-finger window tiling swipe gesture breaking and the workspace switching with the "double workspace" animation that results.

~~Although [this comment](https://github.com/paperwm/PaperWM/issues/413#issuecomment-1320324268) suggests it's still currently needed to avoid an issue in multiple-monitor setups (where windows may not appear on the correct monitor when in overview mode).  However, that issue still seems to occur even with vertical overview for me (when I'm using multiple monitors).~~  Apologies!  I misread that comment - it's saying that issue still likely occurs even with vertical overview extension (which it looks like it does).

_NOTE: this PR has been implemented in the [PaperWM-redux](https://github.com/PaperWM-redux/PaperWM) fork, which you can install if you want this, or any of [my PRs](https://github.com/paperwm/PaperWM/pulls/jtaala) that are open._