### PR TITLE
FIX: after mouse grab/move-window end operation, ensure window is correctly activated

### DIFF
--- a/grab.js
+++ b/grab.js
@@ -9,6 +9,7 @@ var Meta = imports.gi.Meta;
 var Clutter = imports.gi.Clutter;
 var St = imports.gi.St;
 var Main = imports.ui.main;
+var Mainloop = imports.mainloop;
 
 var Tiling = Extension.imports.tiling;
 var Scratch = Extension.imports.scratch;
@@ -110,8 +111,8 @@ var MoveGrab = class MoveGrab {
         this.dnd = true;
         Utils.debug("#grab", "begin DnD")
         Navigator.getNavigator()
-                 .minimaps.forEach(m => typeof(m) === 'number' ?
-                                   Mainloop.source_remove(m) : m.hide());
+            .minimaps.forEach(m => typeof (m) === 'number' ?
+                Mainloop.source_remove(m) : m.hide());
         global.display.set_cursor(Meta.Cursor.MOVE_OR_RESIZE_WINDOW);
         let metaWindow = this.window;
         let actor = metaWindow.get_compositor_private();
@@ -455,7 +456,12 @@ var MoveGrab = class MoveGrab {
         // and layout will work correctly etc.
         this.window = null;
 
+
         this.initialSpace.layout();
+        // ensure window is properly activated after layout/ensureViewport tweens
+        Mainloop.timeout_add(0, () => {
+            Main.activateWindow(metaWindow);
+        });
 
         // // Make sure the window is on the correct workspace.
         // // If the window is transient this will take care of its parent too.

--- a/tiling.js
+++ b/tiling.js
@@ -18,6 +18,7 @@ var Main = imports.ui.main;
 /** @type {import("@gi-types/shell")} */
 var Shell = imports.gi.Shell;
 var Gio = imports.gi.Gio;
+var Mainloop = imports.mainloop;
 var Signals = imports.signals;
 var utils = Extension.imports.utils;
 var debug = utils.debug;
@@ -277,7 +278,7 @@ var Space = class Space extends Array {
         this.signals.connect(Main.overview, 'showing',
                              this.startAnimate.bind(this));
         this.signals.connect(Main.overview, 'hidden', this.moveDone.bind(this));
-
+        
         const Convenience = Extension.imports.convenience;
         const settings = Convenience.getSettings();
         this.signals.connect(
@@ -1682,7 +1683,7 @@ var Spaces = class Spaces extends Map {
          * Ensures correct window layout with multi-monitors, and if windows already exist on init, 
          * (e.g. resetting gnome-shell) then will ensure selectedWindow is activated.
          */
-        imports.mainloop.timeout_add(200, () => {
+        Mainloop.timeout_add(200, () => {
             const space = spaces.getActiveSpace();
             if (space.selectedWindow) {
                 space.layout(false);
@@ -1749,7 +1750,7 @@ var Spaces = class Spaces extends Map {
             });
             this.spaceContainer.show();
 
-            imports.mainloop.timeout_add(
+            Mainloop.timeout_add(
                 20, () => { this._monitorsChanging = false; });
 
             activeSpace.monitor.clickOverlay.deactivate();
@@ -2688,7 +2689,7 @@ function enable(errorNotification) {
         TopBar.fixTopBar()
 
         // run a final layout for multi-monitor topbar and window position indicator init
-        imports.mainloop.timeout_add(200, () => spaces.forEach(s => s.layout(false)));
+        Mainloop.timeout_add(200, () => spaces.forEach(s => s.layout(false)));
     }
 
     if (Main.layoutManager._startingUp) {
@@ -2699,7 +2700,7 @@ function enable(errorNotification) {
     } else {
         // NOTE: this needs to happen after kludges.enable() have run, so we do
         // it in a timeout
-        imports.mainloop.timeout_add(0, initWorkspaces);
+        Mainloop.timeout_add(0, initWorkspaces);
     }
 }
 


### PR DESCRIPTION
This PR fixes an observed issue when grabbing a window and moving it (e.g. while holding down `alt` and click-hold a window to move it with the mouse).

Currently the selected window is not selected/activated after the grab-end operation.  In an unselected window state, select left/right window keybinds don't work, nor can shortcuts can't be passed to the selected window.

This PR ensures the window is correctly activated after grab-end operations.

_NOTE: this PR has been implemented in the [PaperWM-redux](https://github.com/PaperWM-redux/PaperWM) fork, which you can install if you want this, or any of [my PRs](https://github.com/paperwm/PaperWM/pulls/jtaala) that are open._