### PR TITLE
FIX and improve new window create/insert tween (animation)

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,3 +1,7 @@
+.background-clear {
+    background-color: rgba(0, 0, 0, 0);
+}
+
 .space-label-wrapper {
     padding: 0 10px 0 0;
     background-color: transparent;
@@ -18,10 +22,6 @@
     padding: 8px;
     border-radius: 8px;
     font-weight: 600;
-}
-
-.topbar-clear {
-    background-color: rgba(0, 0, 0, 0);
 }
 
 .topbar-transparent {

--- a/tiling.js
+++ b/tiling.js
@@ -1081,6 +1081,14 @@ var Space = class Space extends Array {
         }
     }
 
+    hideSelection() {
+        this.selection.style_class = 'background-clear';
+    }
+
+    showSelection() {
+        this.selection.style_class = 'paperwm-selection tile-preview';
+    }
+
     setSelectionActive() {
         this.selection.opacity = 255;
     }
@@ -2520,7 +2528,7 @@ var Spaces = class Spaces extends Map {
                So even if we set it again in `first-frame` that is too late
                since that happens _after_ mutter have drawn the frame.
 
-               So we kill visibily on the first the `queue-redraw`.
+               So we kill visibily on the first `queue-redraw`.
             */
             signals.connectOneShot(actor, 'queue-redraw', () =>  {
                 actor.opacity = 0;
@@ -2911,9 +2919,11 @@ function insertWindow(metaWindow, {existing}) {
 
     if (!existing) {
         actor.opacity = 0;
+        actor.visible = false;
         clone.x = clone.targetX;
         clone.y = clone.targetY;
-        clone.set_scale(0, 0);
+        clone.set_scale(0, 1);
+        space.hideSelection();
         Tweener.addTween(clone, {
             scale_x: 1,
             scale_y: 1,
@@ -2921,6 +2931,7 @@ function insertWindow(metaWindow, {existing}) {
             onStopped: () => {
                 connectSizeChanged(true);
                 space.layout();
+                space.showSelection();
             }
         });
     } else {

--- a/topbar.js
+++ b/topbar.js
@@ -749,7 +749,7 @@ function disable() {
 }
 
 function setClearStyle() {
-    Main.panel.style_class = 'topbar-clear';
+    Main.panel.style_class = 'background-clear';
 }
 
 function setTransparentStyle() {


### PR DESCRIPTION
Fixes #328.

This PR fixes and improves the new window create/insert tween.  Also resolves a noticable issue where part of current selected window is clipped during window creation.

See below for comparison between current tween and new tween:

**Note the transitions have been slowed down for demonstration purposes.  Also, I'm using a styled `selection` (pinkish colour - because I like it but also to see it better for this demonstration)**

### current transitions (slowed down so can see issues with certain applications):
https://user-images.githubusercontent.com/30424662/228228961-34250abe-7fb6-4141-a1c7-a55f23b54ec4.mp4

### new (improved) transitions (slowed down to see them better):
https://user-images.githubusercontent.com/30424662/228229082-d0088765-6cd8-499f-8c06-26dfba21952e.mp4

_NOTE: this PR has been implemented in the [PaperWM-redux](https://github.com/PaperWM-redux/PaperWM) fork, which you can install if you want this, or any of [my PRs](https://github.com/paperwm/PaperWM/pulls/jtaala) that are open._