### PR TITLE
FIX: keep window previews always in view

### DIFF
--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -309,7 +309,7 @@ var StackOverlay = class StackOverlay {
         Tiling.animateWindow(this.target);
 
         // set clone parameters
-        let scale = 0.3;
+        let scale = prefs.minimap_scale;
         clone.opacity = 255*0.95;
         
         clone.set_scale(scale, scale);


### PR DESCRIPTION
Fixes #506.

So, this PR fixes window previews (when touching left/right edges) so that the preview is always in view (e.g. when touching the upper or lower parts of an edge) - see #506 for a video of this issue).  

It also change the position of the preview to be centered (vertically) on the mouse - rather then the preview showing under the mouse.

_NOTE: #507 is an alternative approach to previews - but might be too big a departure from current previewing approach (change a lot of things), so this PR is designed more to fix/address #506 instead of completely change previews like #507._

### Keeping mouse previews always in view:
https://user-images.githubusercontent.com/30424662/230694526-a99093a9-4fbb-4fff-8012-a7b968bd0589.mp4

_NOTE: I'm using a `minimap scale` size of 30% (hence my window previews might looks a little bigger than yours)._

_NOTE: this PR has been implemented in the [PaperWM-redux](https://github.com/PaperWM-redux/PaperWM) fork, which you can install if you want this, or any of [my PRs](https://github.com/paperwm/PaperWM/pulls/jtaala) that are open._