### PR TITLE
Also print if on wayland or Xorg in gather-system-info.sh

### DIFF
--- a/gather-system-info.sh
+++ b/gather-system-info.sh
@@ -20,6 +20,13 @@ fi
 
 gnome-shell --version
 
+echo -n "Display server: "
+if [ "${XDG_SESSION_TYPE}" = "wayland" ]; then
+    echo "Wayland"
+else
+    echo "Xorg"
+fi
+
 echo -n "PaperWM branch/tag: "
 git symbolic-ref --short -q HEAD || git name-rev --tags --name-only --no-undefined "$(git rev-parse HEAD)"
 echo -n "PaperWM commit: "

--- a/gather-system-info.sh
+++ b/gather-system-info.sh
@@ -67,20 +67,17 @@ show_gnome_extensions() {
         # compare enabled extensions to installed extensions
         # because some uninstalled extensions could still be enabled because of
         # stale gsettings
-        local enabled=$(_enabled_extensions)
-        local installed=$(_installed_extensions)
-
-        for ext in $enabled; do
-            if [[ "${installed}" =~ "${ext}" ]]; then
+        for ext in $(_enabled_extensions); do
+            if is_extension_installed "$ext"; then
                 echo "- $ext"
             fi
         done
     fi
 }
 
-_installed_extensions() {
-    ls ~/.local/share/gnome-shell/extensions/
-    ls /usr/share/gnome-shell/extensions/
+is_extension_installed() {
+    local ext=$1
+    [[ -d "$HOME/.local/share/gnome-shell/extensions/$ext" ]] || [[ -d "/usr/share/gnome-shell/extensions/$ext" ]]
 }
 
 _enabled_extensions() {
@@ -89,7 +86,7 @@ _enabled_extensions() {
     # $matches contains lines with the extension uuid and lines with ", "
     mapfile -t matches < <(_global_rematch "$s" "'([^']*)'")
     for match in "${matches[@]}"; do
-        if [[ "$match" =~ "^," ]]; then
+        if [[ "$match" =~ ^,\s* ]]; then
             continue
         fi
         echo "$match"

--- a/gather-system-info.sh
+++ b/gather-system-info.sh
@@ -9,36 +9,99 @@
 # - awk
 
 REPO="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-cd "${REPO}"
 
-echo "Please include this information in your bug report on GitHub!"
+main() {
+    cd "${REPO}"
 
-echo -n "Distribution: "
-if [ -f /etc/os-release ]; then
-    source /etc/os-release && echo "${NAME}"
-fi
+    echo "Please include this information in your bug report on GitHub!"
 
-gnome-shell --version
+    show_distribution
+    show_gnome_version
+    show_display_server
+    show_paperwm_version
+    show_gnome_extensions
+}
 
-echo -n "Display server: "
-if [ "${XDG_SESSION_TYPE}" = "wayland" ]; then
-    echo "Wayland"
-else
-    echo "Xorg"
-fi
-
-echo -n "PaperWM branch/tag: "
-git symbolic-ref --short -q HEAD || git name-rev --tags --name-only --no-undefined "$(git rev-parse HEAD)"
-echo -n "PaperWM commit: "
-git rev-parse HEAD
-
-echo "Enabled extensions:"
-# make a markdown list out of gnome-extensions list
-gnome-extensions list --enabled | {
-    if command -v awk >/dev/null; then
-        awk '{print "- " $0}'
-    else
-        cat
+show_distribution() {
+    echo -n "Distribution: "
+    if [ -f /etc/os-release ]; then
+        source /etc/os-release && echo "${NAME}"
     fi
 }
 
+show_gnome_version() {
+    gnome-shell --version
+}
+
+show_display_server() {
+    echo -n "Display server: "
+    if [ "${XDG_SESSION_TYPE}" = "wayland" ]; then
+        echo "Wayland"
+    else
+        echo "Xorg"
+    fi
+}
+
+show_paperwm_version() {
+    echo -n "PaperWM branch/tag: "
+    git symbolic-ref --short -q HEAD || git name-rev --tags --name-only --no-undefined "$(git rev-parse HEAD)"
+    echo -n "PaperWM commit: "
+    git rev-parse HEAD
+
+}
+
+show_gnome_extensions() {
+    echo "Enabled extensions:"
+    # make a markdown list out of gnome-extensions list
+    # use gnome-extensions if it exists and falls back to bash on older gnome
+    # versions
+    if command -v gnome-extensions >/dev/null; then
+        gnome-extensions list --enabled | {
+            if command -v awk >/dev/null; then
+                awk '{print "- " $0}'
+            else
+                cat
+            fi
+        }
+    else
+        # compare enabled extensions to installed extensions
+        # because some uninstalled extensions could still be enabled because of
+        # stale gsettings
+        local enabled=$(_enabled_extensions)
+        local installed=$(_installed_extensions)
+
+        for ext in $enabled; do
+            if [[ "${installed}" =~ "${ext}" ]]; then
+                echo "- $ext"
+            fi
+        done
+    fi
+}
+
+_installed_extensions() {
+    ls ~/.local/share/gnome-shell/extensions/
+    ls /usr/share/gnome-shell/extensions/
+}
+
+_enabled_extensions() {
+    local s matches
+    s=$(gsettings get org.gnome.shell enabled-extensions)
+    # $matches contains lines with the extension uuid and lines with ", "
+    mapfile -t matches < <(_global_rematch "$s" "'([^']*)'")
+    for match in "${matches[@]}"; do
+        if [[ "$match" =~ "^," ]]; then
+            continue
+        fi
+        echo "$match"
+    done
+}
+
+_global_rematch() {
+    local s=$1 regex=$2
+    while [[ $s =~ $regex ]]; do
+        echo "${BASH_REMATCH[1]}"
+        s=${s#*"${BASH_REMATCH[1]}"}
+    done
+}
+
+main "$@"


### PR DESCRIPTION
This will also print a line:

```
Display server: Wayland
```

or

```
Display server: Xorg
```

depending on what the user is using.

---

Also regarding gnome 3.38 and the `gnome-extensions` command not being available: I found two fallbacks we could use:

1. `ls ~/.local/share/gnome-shell/extensions/` (lists also extensions that might not be enabled)
2. `gsettings get org.gnome.shell enabled-extensions` (list also system extensions)

I think I would prefer option 2. And maybe we would also want to print all extensions anyway and not just user extensions (as distro specific extensions are currently not visible).