### PR TITLE
Fixes: add Gnome 44 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ PaperWM is an experimental [Gnome Shell](https://wiki.gnome.org/Projects/GnomeSh
 
 Supports Gnome Shell from 3.28 to 44 on X11 and wayland.
 
->**Note:** while PaperWM can be installed on a wide range of Gnome versions, fixes and new features, in general, aren't backported to prevous Gnome Shell versions.
+>**Note:** while PaperWM can be installed on a wide range of Gnome versions, new features aren't generally backported to prevous Gnome Shell versions.  Fixes may be backported on request (please submit a [new issue](https://github.com/paperwm/PaperWM/issues/new/choose) if you've identified a recent fix that should be backported and you can help with testing).
 
 While technically an [extension](https://wiki.gnome.org/Projects/GnomeShell/Extensions) it's to a large extent built on top of the Gnome desktop rather than merely extending it.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ We hang out on [zulip](https://paperwm.zulipchat.com).
 Clone the repo and check out the branch supporting the Gnome Shell version you're running.
 
 - 44 (targeted for current support, please report bugs): https://github.com/paperwm/PaperWM/tree/develop
-- 43 (targeted for current support, please report bugs): https://github.com/paperwm/PaperWM/tree/develop
+- 43: https://github.com/paperwm/PaperWM/tree/gnome-43
 - 42: https://github.com/paperwm/PaperWM/tree/gnome-42
 - 40: https://github.com/paperwm/PaperWM/tree/gnome-40
 - 3.28-3.38: https://github.com/paperwm/PaperWM/tree/gnome-3.38

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ We hang out on [zulip](https://paperwm.zulipchat.com).
 
 Clone the repo and check out the branch supporting the Gnome Shell version you're running.
 
-- 44 (targeted for current support, please report bugs): https://github.com/paperwm/PaperWM/tree/develop
+- 44 (targeted for current support): https://github.com/paperwm/PaperWM/tree/develop
 - 43: https://github.com/paperwm/PaperWM/tree/gnome-43
 - 42: https://github.com/paperwm/PaperWM/tree/gnome-42
 - 40: https://github.com/paperwm/PaperWM/tree/gnome-40

--- a/README.md
+++ b/README.md
@@ -432,6 +432,8 @@ There's a few Gnome Shell settings which works poorly with PaperWM. Namely
   spanning all monitors
 - `edge-tiling`: We don't support the native half tiled windows
 - `attach-modal-dialogs`: Attached modal dialogs can cause visual glitching
+- `toggle-tiled-left`: Default GNOME keyboard shortcut `super+left` collides with a default PaperWM shortcut. We disable the GNOME shortcut
+- `toggle-tiled-right`: Default GNOME keyboard shortcut `super+right` collides with a default PaperWM shortcut. We disable the GNOME shortcut
 
 To use the recommended settings run
 [`set-recommended-gnome-shell-settings.sh`](https://github.com/paperwm/PaperWM/blob/master/set-recommended-gnome-shell-settings.sh). A "restore previous settings" script is generated so the original settings is not lost.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 PaperWM is an experimental [Gnome Shell](https://wiki.gnome.org/Projects/GnomeShell) extension providing scrollable tiling of windows and per monitor workspaces. It's inspired by paper notebooks and tiling window managers.
 
-Supports Gnome Shell from 3.28 to 43 on X11 and wayland.
+Supports Gnome Shell from 3.28 to 44 on X11 and wayland.
+
+>**Note:** while PaperWM can be installed on a wide range of Gnome versions, fixes and new features, in general, aren't backported to prevous Gnome Shell versions.
 
 While technically an [extension](https://wiki.gnome.org/Projects/GnomeShell/Extensions) it's to a large extent built on top of the Gnome desktop rather than merely extending it.
 
@@ -14,8 +16,8 @@ We hang out on [zulip](https://paperwm.zulipchat.com).
 
 Clone the repo and check out the branch supporting the Gnome Shell version you're running.
 
-- 44 (experimental, not officially supported yet, please report bugs): https://github.com/paperwm/PaperWM/tree/develop
-- 43 (experimental, please report bugs): https://github.com/paperwm/PaperWM/tree/develop
+- 44 (targeted for current support, please report bugs): https://github.com/paperwm/PaperWM/tree/develop
+- 43 (targeted for current support, please report bugs): https://github.com/paperwm/PaperWM/tree/develop
 - 42: https://github.com/paperwm/PaperWM/tree/gnome-42
 - 40: https://github.com/paperwm/PaperWM/tree/gnome-40
 - 3.28-3.38: https://github.com/paperwm/PaperWM/tree/gnome-3.38

--- a/grab.js
+++ b/grab.js
@@ -58,6 +58,10 @@ var MoveGrab = class MoveGrab {
 
         this.initialSpace = space || Tiling.spaces.spaceOfWindow(metaWindow);
         this.zoneActors = new Set();
+
+        // save whether this was tiled window at start of grab
+        this.wasTiled = !(this.initialSpace.isFloating(metaWindow) ||
+            Scratch.isScratchWindow(metaWindow));
     }
 
     begin({center} = {}) {
@@ -500,7 +504,7 @@ var MoveGrab = class MoveGrab {
          * until we "click out".  We do this here if needed.
          */
         Meta.later_add(Meta.LaterType.BEFORE_REDRAW, () => {
-            if (!global.display.end_grab_op) {
+            if (!global.display.end_grab_op && this.wasTiled) {
                 // move to current cursort position
                 let [x, y, _mods] = global.get_pointer();
                 getVirtualPointer().notify_absolute_motion(

--- a/grab.js
+++ b/grab.js
@@ -18,12 +18,12 @@ var Utils = Extension.imports.utils;
 var Tweener = Utils.tweener;
 var Navigator = Extension.imports.navigator;
 
+var virtualPointer;
 
 function isInRect(x, y, r) {
     return r.x <= x && x < r.x + r.width &&
         r.y <= y && y < r.y + r.height;
 }
-
 
 function monitorAtPoint(gx, gy) {
     for (let monitor of Main.layoutManager.monitors) {
@@ -31,6 +31,22 @@ function monitorAtPoint(gx, gy) {
             return monitor;
     }
     return null;
+}
+
+/**
+ * Returns a virtual pointer (i.e. mouse) device that can be used to
+ * "clickout" of a drag operation when `grab_end_op` is unavailable
+ * (i.e. as of Gnome 44 where `grab_end_op` was removed).
+ * @returns Clutter.VirtualInputDevice
+ */
+function getVirtualPointer() {
+    if (!virtualPointer) {
+        virtualPointer = Clutter.get_default_backend()
+            .get_default_seat()
+            .create_virtual_device(Clutter.InputDeviceType.POINTER_DEVICE);
+    }
+
+    return virtualPointer;
 }
 
 var MoveGrab = class MoveGrab {
@@ -476,6 +492,20 @@ var MoveGrab = class MoveGrab {
         }
 
         global.display.set_cursor(Meta.Cursor.DEFAULT);
+
+        /**
+         * Gnome 44 removed the ability to manually end_grab_op.
+         * Previously we would end the grab_op before doing
+         * PaperWM grabs.  In 44, we can't do this so the grab op
+         * may still be in progress, which is okay, but won't be ended
+         * until we "click out".  We do this here if needed.
+         */
+        if (!global.display.end_grab_op) {
+            getVirtualPointer().notify_button(Clutter.get_current_event_time(),
+                Clutter.BUTTON_PRIMARY, Clutter.ButtonState.PRESSED);
+            getVirtualPointer().notify_button(Clutter.get_current_event_time(),
+                Clutter.BUTTON_PRIMARY, Clutter.ButtonState.RELEASED);
+        }
     }
 
     activateDndTarget(zone, first) {

--- a/grab.js
+++ b/grab.js
@@ -476,6 +476,17 @@ var MoveGrab = class MoveGrab {
         }
 
         global.display.set_cursor(Meta.Cursor.DEFAULT);
+
+        /**
+         * Gnome 44 removed the ability to manually end_grab_op.
+         * Previously we would end the grab_op before doing
+         * PaperWM grabs.  In 44, we can't do this so the grab op
+         * may still be in progress, which is okay, but won't be ended
+         * until we "click out".  We do this here if needed.
+         */
+        if (!global.display.end_grab_op) {
+            imports.gi.Atspi.generate_mouse_event(0,0,'b1c');
+        }
     }
 
     activateDndTarget(zone, first) {

--- a/grab.js
+++ b/grab.js
@@ -50,8 +50,11 @@ var MoveGrab = class MoveGrab {
         this.center = center;
         if (this.grabbed)
             return;
+
         this.grabbed = true
-        global.display?.end_grab_op(global.get_current_time());
+        
+        global.display.end_grab_op?.(global.get_current_time());
+        
         global.display.set_cursor(Meta.Cursor.MOVE_OR_RESIZE_WINDOW);
         this.dispatcher = new Navigator.getActionDispatcher(Clutter.GrabState.POINTER)
         this.actor = this.dispatcher.actor

--- a/grab.js
+++ b/grab.js
@@ -475,30 +475,10 @@ var MoveGrab = class MoveGrab {
         // and layout will work correctly etc.
         this.window = null;
 
-
         this.initialSpace.layout();
         // ensure window is properly activated after layout/ensureViewport tweens
-        Mainloop.timeout_add(0, () => {
+        Meta.later_add(Meta.LaterType.IDLE, () => {
             Main.activateWindow(metaWindow);
-
-            // if floating or scratch, then exit (no need to click-out)
-            if (this.initialSpace.isFloating(metaWindow) ||
-                Scratch.isScratchWindow(metaWindow)) {
-                return;
-            }
-            /**
-             * Gnome 44 removed the ability to manually end_grab_op.
-             * Previously we would end the grab_op before doing
-             * PaperWM grabs.  In 44, we can't do this so the grab op
-             * may still be in progress, which is okay, but won't be ended
-             * until we "click out".  We do this here if needed.
-             */
-            if (!global.display.end_grab_op) {
-                getVirtualPointer().notify_button(Clutter.get_current_event_time(),
-                    Clutter.BUTTON_PRIMARY, Clutter.ButtonState.PRESSED);
-                getVirtualPointer().notify_button(Clutter.get_current_event_time(),
-                    Clutter.BUTTON_PRIMARY, Clutter.ButtonState.RELEASED);
-            }
         });
 
         // // Make sure the window is on the correct workspace.
@@ -511,6 +491,28 @@ var MoveGrab = class MoveGrab {
         }
 
         global.display.set_cursor(Meta.Cursor.DEFAULT);
+
+        /**
+         * Gnome 44 removed the ability to manually end_grab_op.
+         * Previously we would end the grab_op before doing
+         * PaperWM grabs.  In 44, we can't do this so the grab op
+         * may still be in progress, which is okay, but won't be ended
+         * until we "click out".  We do this here if needed.
+         */
+        Meta.later_add(Meta.LaterType.BEFORE_REDRAW, () => {
+            if (!global.display.end_grab_op) {
+                // move to current cursort position
+                let [x, y, _mods] = global.get_pointer();
+                getVirtualPointer().notify_absolute_motion(
+                    Clutter.get_current_event_time(),
+                    x, y);
+
+                getVirtualPointer().notify_button(Clutter.get_current_event_time(),
+                    Clutter.BUTTON_PRIMARY, Clutter.ButtonState.PRESSED);
+                getVirtualPointer().notify_button(Clutter.get_current_event_time(),
+                    Clutter.BUTTON_PRIMARY, Clutter.ButtonState.RELEASED);
+            }
+        });
     }
 
     activateDndTarget(zone, first) {

--- a/grab.js
+++ b/grab.js
@@ -480,6 +480,25 @@ var MoveGrab = class MoveGrab {
         // ensure window is properly activated after layout/ensureViewport tweens
         Mainloop.timeout_add(0, () => {
             Main.activateWindow(metaWindow);
+
+            // if floating or scratch, then exit (no need to click-out)
+            if (this.initialSpace.isFloating(metaWindow) ||
+                Scratch.isScratchWindow(metaWindow)) {
+                return;
+            }
+            /**
+             * Gnome 44 removed the ability to manually end_grab_op.
+             * Previously we would end the grab_op before doing
+             * PaperWM grabs.  In 44, we can't do this so the grab op
+             * may still be in progress, which is okay, but won't be ended
+             * until we "click out".  We do this here if needed.
+             */
+            if (!global.display.end_grab_op) {
+                getVirtualPointer().notify_button(Clutter.get_current_event_time(),
+                    Clutter.BUTTON_PRIMARY, Clutter.ButtonState.PRESSED);
+                getVirtualPointer().notify_button(Clutter.get_current_event_time(),
+                    Clutter.BUTTON_PRIMARY, Clutter.ButtonState.RELEASED);
+            }
         });
 
         // // Make sure the window is on the correct workspace.
@@ -492,20 +511,6 @@ var MoveGrab = class MoveGrab {
         }
 
         global.display.set_cursor(Meta.Cursor.DEFAULT);
-
-        /**
-         * Gnome 44 removed the ability to manually end_grab_op.
-         * Previously we would end the grab_op before doing
-         * PaperWM grabs.  In 44, we can't do this so the grab op
-         * may still be in progress, which is okay, but won't be ended
-         * until we "click out".  We do this here if needed.
-         */
-        if (!global.display.end_grab_op) {
-            getVirtualPointer().notify_button(Clutter.get_current_event_time(),
-                Clutter.BUTTON_PRIMARY, Clutter.ButtonState.PRESSED);
-            getVirtualPointer().notify_button(Clutter.get_current_event_time(),
-                Clutter.BUTTON_PRIMARY, Clutter.ButtonState.RELEASED);
-        }
     }
 
     activateDndTarget(zone, first) {

--- a/grab.js
+++ b/grab.js
@@ -503,7 +503,7 @@ var MoveGrab = class MoveGrab {
          * may still be in progress, which is okay, but won't be ended
          * until we "click out".  We do this here if needed.
          */
-        Meta.later_add(Meta.LaterType.BEFORE_REDRAW, () => {
+        Meta.later_add(Meta.LaterType.IDLE, () => {
             if (!global.display.end_grab_op && this.wasTiled) {
                 // move to current cursort position
                 let [x, y, _mods] = global.get_pointer();

--- a/grab.js
+++ b/grab.js
@@ -476,17 +476,6 @@ var MoveGrab = class MoveGrab {
         }
 
         global.display.set_cursor(Meta.Cursor.DEFAULT);
-
-        /**
-         * Gnome 44 removed the ability to manually end_grab_op.
-         * Previously we would end the grab_op before doing
-         * PaperWM grabs.  In 44, we can't do this so the grab op
-         * may still be in progress, which is okay, but won't be ended
-         * until we "click out".  We do this here if needed.
-         */
-        if (!global.display.end_grab_op) {
-            imports.gi.Atspi.generate_mouse_event(0,0,'b1c');
-        }
     }
 
     activateDndTarget(zone, first) {

--- a/grab.js
+++ b/grab.js
@@ -393,7 +393,7 @@ var MoveGrab = class MoveGrab {
             time: prefs.animation_time,
             scale_x: 1,
             scale_y: 1,
-            opacity: clone.__oldOpacity || 255
+            opacity: clone?.__oldOpacity ?? 255,
         };
 
         if (this.dnd) {

--- a/keybindings.js
+++ b/keybindings.js
@@ -575,32 +575,8 @@ function overrideAction(mutterName, action) {
     actionIdMap[id] = action;
 }
 
-/**
- * Disables known keybind clashes with default gnome operations.
- */
-function disableKnownClashes() {
-    // disable specific actions known to cause issues
-    const mutterbinds = convenience.getSettings('org.gnome.mutter.keybindings');
-    [
-        'toggle-tiled-left', 'toggle-tiled-right'
-    ].forEach(key => {
-        try {
-            mutterbinds.set_value(key, new GLib.Variant('as', []));
-        } catch (e) {}
-    });
-
-    const wmbinds = convenience.getSettings('org.gnome.desktop.wm.keybindings');
-    [
-        'switch-group', 'switch-group-backward',
-        'switch-to-workspace-left', 'switch-to-workspace-right',
-    ].forEach(key => {
-        try {
-            wmbinds.set_value(key, new GLib.Variant('as', []));
-        } catch (e) {}
-    });
-}
-
 function resolveConflicts() {
+    resetConflicts();
     for (let conflict of Settings.findConflicts()) {
         let {name, conflicts} = conflict;
         let action = byMutterName(name);
@@ -734,7 +710,6 @@ function resetConflicts() {
 }
 
 function enable() {
-    disableKnownClashes();
     let schemas = [...Settings.conflictSettings,
                    convenience.getSettings(KEYBINDINGS_KEY)];
     schemas.forEach(schema => {

--- a/kludges.js
+++ b/kludges.js
@@ -43,20 +43,16 @@ function overrideHotCorners() {
     }
 }
 
+// polyfill for 3.28 (`get_monitor_scale` first appeared in 3.31.92). 
 if (!global.display.get_monitor_scale) {
-    // `get_monitor_scale` first appeared in 3.31.92. Polyfill a fallback for 3.28
     global.display.constructor.prototype.get_monitor_scale = () => 1.0;
 }
 
+// polyfill for 3.28 (`get_monitor_neighbor_index`)
 if (!global.display.get_monitor_neighbor_index) {
-    // `get_monitor_neighbor_index` polyfill a fallback for 3.28
     global.display.constructor.prototype.get_monitor_neighbor_index = function(...args) {
         return global.screen.get_monitor_neighbor_index(...args);
     }
-}
-
-if (!global.display.set_cursor) {
-    global.display.constructor.prototype.set_cursor = global.screen.set_cursor.bind(global.screen);
 }
 
 // polyfill for 3.28
@@ -64,8 +60,8 @@ if (!Meta.DisplayDirection && Meta.ScreenDirection) {
     Meta.DisplayDirection = Meta.ScreenDirection;
 }
 
+// polyfill for 3.28
 if (!St.Settings) {
-    // `St.Settings` doesn't exist in 3.28 - polyfill:
     let Gtk = imports.gi.Gtk;
     let gtkSettings = Gtk.Settings.get_default();
     let polyfillSettings = new (class PolyfillStSettings {
@@ -82,14 +78,14 @@ if (!St.Settings) {
     };
 }
 
+// polyfill for 3.28
 if (!Clutter.Actor.prototype.set) {
-    // `set` doesn't exist in 3.28 - polyfill:
     Clutter.Actor.prototype.set = function(params) {
         Object.assign(this, params);
     }
 }
 
-// Polyfill gnome-3.34 transition API, taken from gnome-shell/js/ui/environment.js
+// polyfill 3.34 transition API, taken from gnome-shell/js/ui/environment.js
 if (version[0] >= 3 && version[1] < 34) {
     function _makeEaseCallback(params, cleanup) {
         let onComplete = params.onComplete;
@@ -179,7 +175,12 @@ if (version[0] >= 3 && version[1] < 34) {
     };
 }
 
-// Polyfill
+// polyfill
+if (!global.display.set_cursor) {
+    global.display.constructor.prototype.set_cursor = global.screen.set_cursor.bind(global.screen);
+}
+
+// polyfill
 if (!Clutter.Actor.prototype.raise) {
     Clutter.Actor.prototype.raise = function raise(above) {
         const parent = this.get_parent();
@@ -189,12 +190,14 @@ if (!Clutter.Actor.prototype.raise) {
     }
 }
 
+// polyfill
 if (!Clutter.Actor.prototype.raise_top) {
   Clutter.Actor.prototype.raise_top = function raise_top() {
         this.raise(null);
     }
 }
 
+// polyfill
 if (!Clutter.Actor.prototype.reparent) {
     Clutter.Actor.prototype.reparent = function reparent(newParent) {
         const parent = this.get_parent();
@@ -205,9 +208,17 @@ if (!Clutter.Actor.prototype.reparent) {
     }
 }
 
-if (! Clutter.Vertex) {
+// polyfill
+if (!Clutter.Vertex) {
     const {Graphene} = imports.gi;
     Clutter.Vertex = Graphene.Point3D;
+}
+
+// polyfill for 44
+if (!Meta.later_add && global.compositor?.get_laters()) {
+    Meta.later_add = function(...args) {
+        global.compositor.get_laters().add(...args);
+    }
 }
 
 // Workspace.Workspace._realRecalculateWindowPositions

--- a/metadata.json
+++ b/metadata.json
@@ -5,6 +5,6 @@
   "url": "https://github.com/paperwm/PaperWM",
   "settings-schema": "org.gnome.Shell.Extensions.PaperWM",
   "shell-version": [ "42", "43", "44" ],
-  "version": "43.0",
+  "version": "44.0",
   "session-modes":  [ "unlock-dialog", "user" ]
 }

--- a/navigator.js
+++ b/navigator.js
@@ -87,7 +87,6 @@ function getModLock(mods) {
         grab = Main.pushModal(this.actor)
         // We expect at least a keyboard grab here
         if ((grab.get_seat_state() & Clutter.GrabState.KEYBOARD) === 0) {
-            Main.popModal(grabHandle);
             log("Failed to grab modal");
             throw new Error('Could not grab modal')
         }

--- a/set-recommended-gnome-shell-settings.sh
+++ b/set-recommended-gnome-shell-settings.sh
@@ -51,7 +51,9 @@ set-with-backup org.gnome.shell.overrides edge-tiling false
 # Attached modal dialogs isn't handled very well
 set-with-backup org.gnome.shell.overrides attach-modal-dialogs false
 
-
+# Gnome 44 tiling left/right shortcuts collide with PaperWM shortcuts (super + left/right)
+set-with-backup org.gnome.mutter.keybindings toggle-tiled-left "[]"
+set-with-backup org.gnome.mutter.keybindings toggle-tiled-right "[]"
 
 echo
 echo "Run $RESTORE_SETTINGS_SCRIPT to revert changes"

--- a/set-recommended-gnome-shell-settings.sh
+++ b/set-recommended-gnome-shell-settings.sh
@@ -51,9 +51,5 @@ set-with-backup org.gnome.shell.overrides edge-tiling false
 # Attached modal dialogs isn't handled very well
 set-with-backup org.gnome.shell.overrides attach-modal-dialogs false
 
-# Gnome 44 tiling left/right shortcuts collide with PaperWM shortcuts (super + left/right)
-set-with-backup org.gnome.mutter.keybindings toggle-tiled-left "[]"
-set-with-backup org.gnome.mutter.keybindings toggle-tiled-right "[]"
-
 echo
 echo "Run $RESTORE_SETTINGS_SCRIPT to revert changes"

--- a/settings.js
+++ b/settings.js
@@ -242,7 +242,7 @@ function keystrToKeycombo(keystr) {
         keystr = keystr.replace('Above_Tab', 'A');
         aboveTab = true;
     }
-    let [key, mask] = Gtk.accelerator_parse(keystr);
+    let [accel, key, mask] = Gtk.accelerator_parse(keystr);
 
     if (aboveTab)
         key = META_KEY_ABOVE_TAB;

--- a/settings.js
+++ b/settings.js
@@ -242,7 +242,7 @@ function keystrToKeycombo(keystr) {
         keystr = keystr.replace('Above_Tab', 'A');
         aboveTab = true;
     }
-    let [accel, key, mask] = Gtk.accelerator_parse(keystr);
+    let [ok, key, mask] = Gtk.accelerator_parse(keystr);
 
     if (aboveTab)
         key = META_KEY_ABOVE_TAB;

--- a/tiling.js
+++ b/tiling.js
@@ -3376,6 +3376,7 @@ function toggleMaximizeHorizontally(metaWindow) {
 }
 
 function resizeHInc(metaWindow) {
+    metaWindow = metaWindow || display.focus_window;
     let frame = metaWindow.get_frame_rect();
     let monitor = Main.layoutManager.monitors[metaWindow.get_monitor()];
     let space = spaces.spaceOfWindow(metaWindow);
@@ -3396,6 +3397,7 @@ function resizeHInc(metaWindow) {
 }
 
 function resizeHDec(metaWindow) {
+    metaWindow = metaWindow || display.focus_window;
     let frame = metaWindow.get_frame_rect();
     let monitor = Main.layoutManager.monitors[metaWindow.get_monitor()];
     let space = spaces.spaceOfWindow(metaWindow);
@@ -3417,6 +3419,7 @@ function resizeHDec(metaWindow) {
 }
 
 function resizeWInc(metaWindow) {
+    metaWindow = metaWindow || display.focus_window;
     let frame = metaWindow.get_frame_rect();
     let monitor = Main.layoutManager.monitors[metaWindow.get_monitor()];
     let space = spaces.spaceOfWindow(metaWindow);
@@ -3437,6 +3440,7 @@ function resizeWInc(metaWindow) {
 }
 
 function resizeWDec(metaWindow) {
+    metaWindow = metaWindow || display.focus_window;
     let frame = metaWindow.get_frame_rect();
     let monitor = Main.layoutManager.monitors[metaWindow.get_monitor()];
     let space = spaces.spaceOfWindow(metaWindow);

--- a/tiling.js
+++ b/tiling.js
@@ -1399,8 +1399,12 @@ border-radius: ${borderWidth}px;
                 if (windowAtPoint) {
                     ensureViewport(windowAtPoint, this);
                     spaces.selectedSpace = this
-                    inGrab = new Extension.imports.grab.MoveGrab(windowAtPoint, Meta.GrabOp.MOVING, this);
-                    inGrab.begin();
+                    /**
+                     * disabled to address gnome-44 grab issues. Simple selection of window
+                     * should not execute a MoveGrab (avoid getting stuck in grab state).
+                     */
+                    //inGrab = new Extension.imports.grab.MoveGrab(windowAtPoint, Meta.GrabOp.MOVING, this);
+                    //inGrab.begin();
                 } else if (inPreview) {
                     spaces.selectedSpace = this;
                     Navigator.getNavigator().finish();
@@ -1666,11 +1670,12 @@ var Spaces = class Spaces extends Map {
 
         this.signals.connect(display, 'window-created',
                         this.window_created.bind(this));
+        
         this.signals.connect(display, 'grab-op-begin',
                         (display, mw, type) => grabBegin(mw, type));
         this.signals.connect(display, 'grab-op-end',
                         (display, mw, type) => grabEnd(mw, type));
-
+        
         this.signals.connect(Main.layoutManager, 'monitors-changed', this.monitorsChanged.bind(this));
 
         this.signals.connect(global.window_manager, 'switch-workspace',

--- a/tiling.js
+++ b/tiling.js
@@ -3318,8 +3318,10 @@ function showWindow(metaWindow) {
     let actor = metaWindow.get_compositor_private();
     if (!actor)
         return false;
-    metaWindow.clone.cloneActor.hide();
-    metaWindow.clone.cloneActor.source = null;
+    if (metaWindow.clone?.cloneActor) {
+        metaWindow.clone.cloneActor.hide();
+        metaWindow.clone.cloneActor.source = null;
+    }
     actor.show();
     return true;
 }
@@ -3328,8 +3330,10 @@ function animateWindow(metaWindow) {
     let actor = metaWindow.get_compositor_private();
     if (!actor)
         return false;
-    metaWindow.clone.cloneActor.show();
-    metaWindow.clone.cloneActor.source = actor;
+    if (metaWindow.clone?.cloneActor) {
+        metaWindow.clone.cloneActor.show();
+        metaWindow.clone.cloneActor.source = actor;
+    }
     actor.hide();
     return true;
 }

--- a/tiling.js
+++ b/tiling.js
@@ -1387,28 +1387,24 @@ border-radius: ${borderWidth}px;
 
         this.actor.insert_child_below(this.background, null);
 
-        this.signals.connect(
-            this.background, 'button-press-event',
+        this.signals.connect(this.background, 'button-press-event',
             (actor, event) => {
                 if (inGrab) {
                     return;
                 }
+
+                /**
+                 * if user clicks on window, then ensureViewport on that window before exiting
+                 */
                 let [gx, gy, $] = global.get_pointer();
                 let [ok, x, y] = this.actor.transform_stage_point(gx, gy);
                 let windowAtPoint = !Gestures.gliding && this.getWindowAtPoint(x, y);
                 if (windowAtPoint) {
                     ensureViewport(windowAtPoint, this);
-                    spaces.selectedSpace = this
-                    /**
-                     * disabled to address gnome-44 grab issues. Simple selection of window
-                     * should not execute a MoveGrab (avoid getting stuck in grab state).
-                     */
-                    //inGrab = new Extension.imports.grab.MoveGrab(windowAtPoint, Meta.GrabOp.MOVING, this);
-                    //inGrab.begin();
-                } else if (inPreview) {
-                    spaces.selectedSpace = this;
-                    Navigator.getNavigator().finish();
                 }
+
+                spaces.selectedSpace = this;
+                Navigator.getNavigator().finish();
             });
 
         this.signals.connect(
@@ -1502,7 +1498,6 @@ border-radius: ${borderWidth}px;
        layout of oldSpace if present.
     */
     addAll(oldSpace) {
-
         // On gnome-shell-restarts the windows are moved into the viewport, but
         // they're moved minimally and the stacking is not changed, so the tiling
         // order is preserved (sans full-width windows..)
@@ -2159,7 +2154,6 @@ var Spaces = class Spaces extends Map {
         const padding_percentage = 4;
         let last = monitorSpaces.length - 1;
         monitorSpaces.forEach((space, i) => {
-
             let padding = (space.height * scale / 100) * padding_percentage;
             let center = (space.height - (space.height * scale)) / 2;
             let space_y;

--- a/tiling.js
+++ b/tiling.js
@@ -32,6 +32,13 @@ var Gdk = imports.gi.Gdk;
 var workspaceManager = global.workspace_manager;
 var display = global.display;
 
+// Polyfill for Gnome 44
+if (!Meta.later_add) {
+    Meta.later_add = function(...args) {
+        global.compositor.get_laters().add(...args);
+    }
+}
+
 /** @type {Spaces} */
 var spaces;
 

--- a/tiling.js
+++ b/tiling.js
@@ -3145,6 +3145,7 @@ function grabBegin(metaWindow, type) {
             })
             break;
         case Meta.GrabOp.MOVING:
+        case Meta.GrabOp.MOVING_UNCONSTRAINED: // introduced in Gnome 44
             inGrab = new Extension.imports.grab.MoveGrab(metaWindow, type);
 
             if (utils.getModiferState() & Clutter.ModifierType.CONTROL_MASK) {

--- a/tiling.js
+++ b/tiling.js
@@ -32,13 +32,6 @@ var Gdk = imports.gi.Gdk;
 var workspaceManager = global.workspace_manager;
 var display = global.display;
 
-// Polyfill for Gnome 44
-if (!Meta.later_add) {
-    Meta.later_add = function(...args) {
-        global.compositor.get_laters().add(...args);
-    }
-}
-
 /** @type {Spaces} */
 var spaces;
 

--- a/utils.js
+++ b/utils.js
@@ -270,7 +270,6 @@ function toggleCloneMarks() {
     }
 }
 
-
 function sum(array) {
     return array.reduce((a, b) => a + b, 0);
 }
@@ -285,18 +284,9 @@ function zip(...as) {
 }
 
 function warpPointer(x, y) {
-    // 3.36 added support for warping in wayland
-    if (Meta.is_wayland_compositor() && Clutter.Backend.prototype.get_default_seat) {
-        let backend = Clutter.get_default_backend();
-        let seat = backend.get_default_seat();
-        seat.warp_pointer(x, y);
-        return;
-    } else {
-        let display = Gdk.Display.get_default();
-        let deviceManager = display.get_device_manager();
-        let pointer = deviceManager.get_client_pointer();
-        pointer.warp(Gdk.Screen.get_default(), x, y)
-    }
+    let backend = Clutter.get_default_backend();
+    let seat = backend.get_default_seat();
+    seat.warp_pointer(x, y);
 }
 
 /**


### PR DESCRIPTION
This PR fixes reported issues in Gnome 44: fixes #494, fixes #495, closes #490, fixes #523. 

Note: these are compatibility fixes to support Gnome 44 in develop branch (i.e. Gnome 43 should still work fine with these changes).

Gnome 44 has a new (improved?) mechanism for grabs (e.g. grabbing and moving windows), and no longer uses `end_grab_op`.

This PR also adds a polyfill to support Gnome 44's removal of `Meta.later_add` (which is replaced with `global.compositor.get_laters().add(...)`.  

Note: [GJS porting guide](https://gjs.guide/extensions/upgrading/gnome-shell-44.html#meta-later-add-and-meta-later-remove) suggests using `Meta.Laters.add` but in testing the latest Gnome 44 (and what was released in Fedora 38), this was not present.  The implemented approach is used heavily in the latest/official [gnome-shell source code](https://gitlab.gnome.org/search?search=global.compositor.get_laters()&nav_source=navbar&project_id=546&group_id=8&search_code=true&repository_ref=main) (which is why I moved to using that).

~~Note<sup>2</sup>: for the first fix (`end_grab_op`) - it still not quite perfect, it seems to require a second click to activate a window (after moving a window) - but at least it doesn't completely/irreversibly lose mouse click control. 
 Will look at this and see how to improve here.~~  _**fix now implemented for this**_  :heavy_check_mark: 