### PR TITLE
Remove Gnome tiling left/right shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,8 @@ There's a few Gnome Shell settings which works poorly with PaperWM. Namely
   spanning all monitors
 - `edge-tiling`: We don't support the native half tiled windows
 - `attach-modal-dialogs`: Attached modal dialogs can cause visual glitching
+- `toggle-tiled-left`: Default GNOME keyboard shortcut `super+left` collides with a default PaperWM shortcut. We disable the GNOME shortcut
+- `toggle-tiled-right`: Default GNOME keyboard shortcut `super+right` collides with a default PaperWM shortcut. We disable the GNOME shortcut
 
 To use the recommended settings run
 [`set-recommended-gnome-shell-settings.sh`](https://github.com/paperwm/PaperWM/blob/master/set-recommended-gnome-shell-settings.sh). A "restore previous settings" script is generated so the original settings is not lost.

--- a/set-recommended-gnome-shell-settings.sh
+++ b/set-recommended-gnome-shell-settings.sh
@@ -51,7 +51,9 @@ set-with-backup org.gnome.shell.overrides edge-tiling false
 # Attached modal dialogs isn't handled very well
 set-with-backup org.gnome.shell.overrides attach-modal-dialogs false
 
-
+# Gnome 44 tiling left/right shortcuts collide with PaperWM shortcuts (super + left/right)
+set-with-backup org.gnome.mutter.keybindings toggle-tiled-left "[]"
+set-with-backup org.gnome.mutter.keybindings toggle-tiled-right "[]"
 
 echo
 echo "Run $RESTORE_SETTINGS_SCRIPT to revert changes"


### PR DESCRIPTION
Based on the discussion in #516 I added gnome 44 shortcut removal using the same `set-with-backup` bash function used for setting other recommended gnome-shell settings. I haven't researched if there are any unwanted consequences of disabling these shortcuts like this, but it seems to work fine for me. It would be great if someone else with this issue could also test this before merging. Also, the backup `restore-gnome-shell-settings-YYYY-MM-DD.sh` file was successfully created with the original values stored inside.