### PR TITLE
Fixes: keybind clash detection also correctly detects `grave` against mutter `Above_Tab`. Fix keybind replace.

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,8 +432,6 @@ There's a few Gnome Shell settings which works poorly with PaperWM. Namely
   spanning all monitors
 - `edge-tiling`: We don't support the native half tiled windows
 - `attach-modal-dialogs`: Attached modal dialogs can cause visual glitching
-- `toggle-tiled-left`: Default GNOME keyboard shortcut `super+left` collides with a default PaperWM shortcut. We disable the GNOME shortcut
-- `toggle-tiled-right`: Default GNOME keyboard shortcut `super+right` collides with a default PaperWM shortcut. We disable the GNOME shortcut
 
 To use the recommended settings run
 [`set-recommended-gnome-shell-settings.sh`](https://github.com/paperwm/PaperWM/blob/master/set-recommended-gnome-shell-settings.sh). A "restore previous settings" script is generated so the original settings is not lost.

--- a/settings.js
+++ b/settings.js
@@ -237,9 +237,9 @@ function printWorkspaceSettings() {
 function keystrToKeycombo(keystr) {
     // Above_Tab is a fake keysymbol provided by mutter
     let aboveTab = false;
-    if (keystr.match(/Above_Tab/)) {
+    if (keystr.match(/Above_Tab/) || keystr.match(/grave/)) {
         // Gtk bails out if provided with an unknown keysymbol
-        keystr = keystr.replace('Above_Tab', 'A');
+        keystr = keystr.replace('Above_Tab', 'a');
         aboveTab = true;
     }
     let [ok, key, mask] = Gtk.accelerator_parse(keystr);


### PR DESCRIPTION
This PR fixes several keybind detection issues (one introduced in Gnome 44 support branch).

Keybind detection has been broken for a while - this became apparent in Gnome 44.  Branch `fixes-gnome-44-support` found and fixed the root cause of PaperWM not correctly identifying clashes with system keybinds (so that it can override them while PaperWM is active.

### FIX 1: mutter `Above_Tab` check against `grave`
Mutter uses `Above_Tab` in keybinds, while PaperWM and gnome can also use `grave`, to describe the same button.  This fix normalises these references in PaperWM keybind clashes so that clashes involving PaperWM vs. system keybinds involving `grave` are detected correctly (and overridden where needed).

### FIX 2: `Above_Tab` internal reference inadvertedly changed to uppercase in `fixes-gnome-44-support` branch
Not sure how (or why), but I changed the internal reference used by PaperWM to uppercase.  This inadvertedly broke PaperWM keybind detection (in the PaperWM settings) involving `Above_Tab`.