### PR TITLE
FIX: issue 136 (super+esc confusion when user is in navigator)

### DIFF
--- a/navigator.js
+++ b/navigator.js
@@ -159,6 +159,7 @@ function getModLock(mods) {
         // https://github.com/paperwm/PaperWM/issues/70
         if (keysym == Clutter.KEY_Escape) {
             this._destroy = true;
+            getNavigator().accept();
             getNavigator().destroy();
             return Clutter.EVENT_STOP;
         }
@@ -171,7 +172,7 @@ function getModLock(mods) {
     _keyReleaseEvent(actor, event) {
         let keysym = event.get_key_symbol();
         if (this._destroy) {
-            // dismissDispatcher(Clutter.GrabState.KEYBOARD)
+            dismissDispatcher(Clutter.GrabState.KEYBOARD)
         }
 
         if (this._modifierMask) {
@@ -221,7 +222,7 @@ function getModLock(mods) {
 
     _finish(timestamp) {
         let nav = getNavigator();
-        getNavigator().accept();
+        nav.accept();
         !this._destroy && nav.destroy();
         dismissDispatcher(Clutter.GrabState.KEYBOARD)
     }


### PR DESCRIPTION
This PR fixes #136 (see this issue for the behaviour that this PR fixes).  More specifically, it:

- fixes escape key action during window navigator (PaperWM no longer reverts to the origin window if user presses escape during navigator;
- after escape key press (during navigator), dismisses keyboard grab state (which allows subsequent `super+escape` action to proceed (by default this toggles scratch layer);

In essence this fixes issue #136 to act as it should.