### PR TITLE
FIX: "taking" windows (e.g. by Super+T or by Ctrl+Super+`) now keeps that window selected/activated on target workspace

### DIFF
--- a/keybindings.js
+++ b/keybindings.js
@@ -113,12 +113,10 @@ function init() {
     }, {settings});
 
     registerNavigatorAction('previous-workspace', Tiling.selectPreviousSpace);
-    registerNavigatorAction('previous-workspace-backward',
-                            Tiling.selectPreviousSpaceBackwards);
+    registerNavigatorAction('previous-workspace-backward', Tiling.selectPreviousSpaceBackwards);
 
     registerNavigatorAction('move-previous-workspace', Tiling.movePreviousSpace);
-    registerNavigatorAction('move-previous-workspace-backward',
-                            Tiling.movePreviousSpaceBackwards);
+    registerNavigatorAction('move-previous-workspace-backward', Tiling.movePreviousSpaceBackwards);
 
     registerNavigatorAction('switch-down-workspace', Tiling.selectDownSpace);
     registerNavigatorAction('switch-up-workspace', Tiling.selectUpSpace);

--- a/tiling.js
+++ b/tiling.js
@@ -3849,7 +3849,6 @@ function takeWindow(metaWindow, space, {navigator}) {
 
             // activate last metaWindow after taken windows inserted
             Meta.later_add(Meta.LaterType.IDLE, () => {
-                ensureViewport(metaWindow);
                 Main.activateWindow(metaWindow);
             });
         });

--- a/tiling.js
+++ b/tiling.js
@@ -3850,6 +3850,7 @@ function takeWindow(metaWindow, space, {navigator}) {
             // activate last metaWindow after taken windows inserted
             Meta.later_add(Meta.LaterType.IDLE, () => {
                 ensureViewport(metaWindow);
+                Main.activateWindow(metaWindow);
             });
         });
     }


### PR DESCRIPTION
This PR fixes #534.

An annoyance I've had for some time is that when you "take" a window to drop it on another workspace (e.g. by `Super+T` or by `` Ctrl+Super+` ``, e.g. the  `Move the active window to the previously active workspace` keybind)), it's not selected/activated after dropping it.

This PR causes the last "taken" window to be selected/activated after dropping it on another workspace.  This is much more intuitive/expected and allows users to quickly "undo" that drop (e.g. move it quickly back to where it was simply pressing `` Ctrl+Super+` `` again).
