### PR TITLE
Fix conflicting keybindings on Gnome 42

### DIFF
--- a/keybindings.js
+++ b/keybindings.js
@@ -574,8 +574,32 @@ function overrideAction(mutterName, action) {
     actionIdMap[id] = action;
 }
 
+/**
+ * Disables known keybind clashes with default gnome operations.
+ */
+function disableKnownClashes() {
+    // disable specific actions known to cause issues
+    const mutterbinds = convenience.getSettings('org.gnome.mutter.keybindings');
+    [
+        'toggle-tiled-left', 'toggle-tiled-right'
+    ].forEach(key => {
+        try {
+            mutterbinds.set_value(key, new GLib.Variant('as', []));
+        } catch (e) {}
+    });
+
+    const wmbinds = convenience.getSettings('org.gnome.desktop.wm.keybindings');
+    [
+        'switch-group', 'switch-group-backward',
+        'switch-to-workspace-left', 'switch-to-workspace-right',
+    ].forEach(key => {
+        try {
+            wmbinds.set_value(key, new GLib.Variant('as', []));
+        } catch (e) {}
+    });
+}
+
 function resolveConflicts() {
-    resetConflicts();
     for (let conflict of Settings.findConflicts()) {
         let {name, conflicts} = conflict;
         let action = byMutterName(name);
@@ -710,6 +734,7 @@ function resetConflicts() {
 }
 
 function enable() {
+    disableKnownClashes();
     let schemas = [...Settings.conflictSettings,
                    convenience.getSettings(KEYBINDINGS_KEY)];
     schemas.forEach(schema => {

--- a/settings.js
+++ b/settings.js
@@ -242,7 +242,7 @@ function keystrToKeycombo(keystr) {
         keystr = keystr.replace('Above_Tab', 'a');
         aboveTab = true;
     }
-    let [ok, key, mask] = Gtk.accelerator_parse(keystr);
+    let [key, mask] = Gtk.accelerator_parse(keystr);
 
     if (aboveTab)
         key = META_KEY_ABOVE_TAB;


### PR DESCRIPTION
Revert the one commit that fixed conflicting keybindings on Gnome 44 from #515

Fixes #536

Notes regarding testing: You need to relogin after you enable conflicting keybindings. They don't seem to be picked up without relogin if you reset your keybindings in the Gnome settings.