### PR TITLE
REGRESSION FIX: Gnome 44 backported keybind fixes broke Gnome 43 (and earlier) keybind clash detection

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -242,7 +242,15 @@ function keystrToKeycombo(keystr) {
         keystr = keystr.replace('Above_Tab', 'a');
         aboveTab = true;
     }
-    let [key, mask] = Gtk.accelerator_parse(keystr);
+
+    let ok, key, mask;
+    let result = Gtk.accelerator_parse(keystr);
+    if (result.length === 3) {
+        [ok, key, mask] = result;
+    }
+    else {
+        [key, mask] = result;
+    }
 
     if (aboveTab)
         key = META_KEY_ABOVE_TAB;

--- a/settings.js
+++ b/settings.js
@@ -242,7 +242,7 @@ function keystrToKeycombo(keystr) {
         keystr = keystr.replace('Above_Tab', 'a');
         aboveTab = true;
     }
-    let [ok, key, mask] = Gtk.accelerator_parse(keystr);
+    let [key, mask] = Gtk.accelerator_parse(keystr);
 
     if (aboveTab)
         key = META_KEY_ABOVE_TAB;


### PR DESCRIPTION
See #537 #538 PR's which reverts changes that were backported to Gnome 43/42.  This PR is a replacement for these individual reverts PRs.

This PR implements a fix which first checks the number elements returned from Gtk.accelerator_parse (whether 2 or 3) and assigns them correctly.  This is a much better/robust fix that means that this should now work regardless of what gnome version is used.

Fixes #533, #536.

The issue was caused by Gtk.accelerator_parse result changing in Gnome 44.  There is confusion about when this change occurred, e.g. [GJS porting guide](https://gjs.guide/extensions/upgrading/gnome-shell-40.html#gtk-accelerator-parse) suggests this change occurred in Gnome 40, however actually testing in Fedora 37 (and purportedly in other Gnome 43, 42) versions it's still returning 2 elements instead of 3.

This PR addresses both cases.