### PR TITLE
Improve compatibility with previous gnome versions in `develop` branch

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -242,7 +242,15 @@ function keystrToKeycombo(keystr) {
         keystr = keystr.replace('Above_Tab', 'a');
         aboveTab = true;
     }
-    let [ok, key, mask] = Gtk.accelerator_parse(keystr);
+    
+    let ok, key, mask;
+    let result = Gtk.accelerator_parse(keystr);
+    if (result.length === 3) {
+        [ok, key, mask] = result;
+    }
+    else {
+        [key, mask] = result;
+    }
 
     if (aboveTab)
         key = META_KEY_ABOVE_TAB;


### PR DESCRIPTION
This PR relates to #539.

#539 implemented a previous-gnome version backwards compatible change for keybind clash detection.

Closes #533.

Gnome 44 changed `Gtk.accelerator_parse` result, that originally broke keybind clash detection.  The result of `Gtk.accelerator_parse` differs in Gnome 44 and previous gnome versions.  To make matters worse, there is some confusion about when this change occurred, e.g. [GJS porting guide](https://gjs.guide/extensions/upgrading/gnome-shell-40.html#gtk-accelerator-parse) suggests this change occurred in Gnome 40, however actually testing in Fedora 37 (and purportedly in other Gnome 43, 42) versions, this change wasn't Gnome 43, 42, 41, or 40... but is in Gnome 44.

In any case, this change implements a fix that will work in all gnome versions (or more specifically, will work correclty with the different `Gtk.accelerator_parse` results.  In essence, it checks the output and correctly assigns the result elements (regardless of gnome version).

This PR is largely aimed at users that want to use (and test) the current `develop` branch with older gnome versions.  Ideally, we would like to have `develop` branch compatible with previous gnome versions.  This PR at least fixes one issue and brings us closer to that ideal.