### PR TITLE
FIX: workspace FocusMode icon can be mis-positioned (e.g. over workspace name) in stack/sequence workspace switching

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -2009,20 +2009,14 @@ var Spaces = class Spaces extends Map {
      * @param {boolean} visible 
      */
     setSpaceTopbarElementsVisible(visible=true, changeTopBarStyle=true) {
-        // set visibility on space elements (like workspace name)
-        this.forEach(s => {
-            s.setSpaceTopbarElementsVisible(visible, changeTopBarStyle);
-        });
-    }
+        // get position of topbar focus icon to replicate in spaces
+        const pos = TopBar.focusButton.apply_relative_transform_to_point(Main.panel, 
+            new Clutter.Vertex({ x: 0, y: 0 }));
 
-    /**
-     * Sets the focusIconPosition for all spaces.
-     * @param {int} x 
-     * @param {int} y 
-     */
-    setFocusIconPosition(x=0, y=0) {
+        // for each space, set/update focusModeIcon positon and set visibilities
         this.forEach(s => {
-            s.focusModeIcon.set_position(x, y);
+            s.focusModeIcon.set_position(pos.x, pos.y);
+            s.setSpaceTopbarElementsVisible(visible, changeTopBarStyle);
         });
     }
 

--- a/topbar.js
+++ b/topbar.js
@@ -667,16 +667,9 @@ function enable () {
     Main.panel.addToStatusArea('WorkspaceMenu', menu, 0, 'left');
     fixWorkspaceIndicator();
 
-    // when menu is shown or hidden, also update the space focusModeIcon positions
-    signals.connect(menu, 'show', setSpaceFocusModeIconPositions.bind(this, 100));
-    signals.connect(menu, 'hide', setSpaceFocusModeIconPositions.bind(this, 100));
-
     // setup focusButton and space focusModeIcons
     focusButton = new FocusButton();
     Main.panel.addToStatusArea('FocusButton', focusButton, 1, 'left');
-    signals.connect(focusButton, 'notify::allocation', () => {
-        setSpaceFocusModeIconPositions();
-    });
     fixFocusModeIcon();
     fixStyle();
 
@@ -814,20 +807,6 @@ function fixWorkspaceIndicator() {
 function fixFocusModeIcon() {
     prefs.show_focus_mode_icon ? focusButton.show() : focusButton.hide();
     Tiling.spaces.forEach(s => s.showFocusModeIcon());
-}
-
-/**
- * Sets the space focusModeIcon position based off the position
- * of the focusButton (mimics it).
- * @param {Number} timeout needed to allow update before querying position.
- */
-function setSpaceFocusModeIconPositions(timeout) {
-    timeout = timeout ?? 0;
-    imports.mainloop.timeout_add(timeout, () => {
-        const pos = focusButton.apply_relative_transform_to_point(Main.panel, 
-            new Clutter.Vertex({ x: 0, y: 0 }));
-        Tiling.spaces.setFocusIconPosition(pos.x, pos.y);
-    });
 }
 
 /**


### PR DESCRIPTION
This PR fixes an issue (most) noticed on previous gnome versions in my testing.  Where the FocusMode icon can be incorrectly placed when spaceElements (like workspace name, focusmode icon, etc.) are set to visible in workspace stack/sequence changes.

The position was set on TopBar init, but relied on a (flakey?) timeout in an attempt to ensure the actual topbar FocusModeIcon position was set first, then we replicate that position for the space FocusMode icons.

A better approach (which this PR implements) is to check/set correct FocusMode icon position whenever these are set visible (e.g. in workspace changes etc.), and update the space FocusMode icon position to match (also works better when changing display resolutions and other things that might cause the TopBar FocusMode icon position to change).