### PR TITLE
Updated README.md and combined gnome versions targeted for current support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Clone the repo and check out the branch supporting the Gnome Shell version you'r
 - 3.28-3.38: https://github.com/paperwm/PaperWM/tree/gnome-3.38
 
 
-Then run the [`install.sh`](https://github.com/paperwm/PaperWM/blob/master/install.sh) script
+Then run the [`install.sh`](https://github.com/paperwm/PaperWM/blob/develop/install.sh) script
 from the repository. The installer will create a link to the repo in
 `$XDG_DATA_HOME/gnome-shell/extensions/`. It will then ask if you want to apply
 the recommended settings (see [Recommended
@@ -432,7 +432,7 @@ There's a few Gnome Shell settings which works poorly with PaperWM. Namely
 - `attach-modal-dialogs`: Attached modal dialogs can cause visual glitching
 
 To use the recommended settings run
-[`set-recommended-gnome-shell-settings.sh`](https://github.com/paperwm/PaperWM/blob/master/set-recommended-gnome-shell-settings.sh). A "restore previous settings" script is generated so the original settings is not lost.
+[`set-recommended-gnome-shell-settings.sh`](https://github.com/paperwm/PaperWM/blob/develop/set-recommended-gnome-shell-settings.sh). A "restore previous settings" script is generated so the original settings is not lost.
 
 
 ## Recommended extensions ##

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ PaperWM is an experimental [Gnome Shell](https://wiki.gnome.org/Projects/GnomeSh
 
 Supports Gnome Shell from 3.28 to 44 on X11 and wayland.
 
->**Note:** while PaperWM can be installed on a wide range of Gnome versions, new features aren't generally backported to prevous Gnome Shell versions.  Fixes may be backported on request (please submit a [new issue](https://github.com/paperwm/PaperWM/issues/new/choose) if you've identified a recent fix that should be backported and you can help with testing).
+>**Note:** while PaperWM can be installed on a wide range of Gnome versions, new features aren't generally backported to versions NOT targeted for current support (see [Installation](#installation) section).  Fixes may be backported on request (please submit a [new issue](https://github.com/paperwm/PaperWM/issues/new/choose) if you've identified a recent fix that should be backported and you can help with testing).
 
 While technically an [extension](https://wiki.gnome.org/Projects/GnomeShell/Extensions) it's to a large extent built on top of the Gnome desktop rather than merely extending it.
 
@@ -16,10 +16,8 @@ We hang out on [zulip](https://paperwm.zulipchat.com).
 
 Clone the repo and check out the branch supporting the Gnome Shell version you're running.
 
-- 44 (targeted for current support): https://github.com/paperwm/PaperWM/tree/develop
-- 43: https://github.com/paperwm/PaperWM/tree/gnome-43
-- 42: https://github.com/paperwm/PaperWM/tree/gnome-42
-- 40: https://github.com/paperwm/PaperWM/tree/gnome-40
+- 42-44 (targeted for current support): https://github.com/paperwm/PaperWM/tree/develop
+- 40-41: https://github.com/paperwm/PaperWM/tree/gnome-40
 - 3.28-3.38: https://github.com/paperwm/PaperWM/tree/gnome-3.38
 
 


### PR DESCRIPTION
After some extended testing of the `develop` branch in both gnome 43 and gnome 42, we've updated README.md to state that gnome versions 42-44 should use `develop` branch.

This should simplify things for users of recent versions of Gnome, and make things easier to support (i.e. easier to support and focus testing on one branch rather than 3).

This PR updates `README.md` to reflect this.