### PR TITLE
FIX: for multimonitor setups where the non-primary monitor topbar initially shows focus mode icon position incorrectly

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -2009,14 +2009,22 @@ var Spaces = class Spaces extends Map {
      * @param {boolean} visible 
      */
     setSpaceTopbarElementsVisible(visible=true, changeTopBarStyle=true) {
-        // get position of topbar focus icon to replicate in spaces
-        const pos = TopBar.focusButton.apply_relative_transform_to_point(Main.panel, 
+        this.updateSpaceIconPositions();
+        this.forEach(s => {
+            s.setSpaceTopbarElementsVisible(visible, changeTopBarStyle);
+        });
+    }
+
+    /**
+     * Updates workspace topbar icon positions.
+     */
+    updateSpaceIconPositions() {
+         // get position of topbar focus icon to replicate in spaces
+         const pos = TopBar.focusButton.apply_relative_transform_to_point(Main.panel, 
             new Clutter.Vertex({ x: 0, y: 0 }));
 
-        // for each space, set/update focusModeIcon positon and set visibilities
         this.forEach(s => {
             s.focusModeIcon.set_position(pos.x, pos.y);
-            s.setSpaceTopbarElementsVisible(visible, changeTopBarStyle);
         });
     }
 

--- a/topbar.js
+++ b/topbar.js
@@ -670,7 +670,12 @@ function enable () {
     // setup focusButton and space focusModeIcons
     focusButton = new FocusButton();
     Main.panel.addToStatusArea('FocusButton', focusButton, 1, 'left');
+    // on allocation update spaces focusIcon position (e.g. initial position)
+    signals.connectOneShot(focusButton, 'notify::allocation', () => {
+        Tiling.spaces.updateSpaceIconPositions();
+    });
     fixFocusModeIcon();
+
     fixStyle();
 
     screenSignals.push(


### PR DESCRIPTION
This PR fixes a small issue introduced in #541 for multi-monitor setups, where the non-primary monitor topbar initially (is corrected after workspace switch) incorrectly positions the space FocusMode Icon.