### PR TITLE
Fix error in makeScratch

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -745,6 +745,7 @@ var Space = class Space extends Array {
         if (this.selectedWindow) {
             ensureViewport(this.selectedWindow, this);
         } else {
+            // can also be undefined here, will set to null explicitly
             this.selectedWindow = null;
         }
 

--- a/tiling.js
+++ b/tiling.js
@@ -715,14 +715,13 @@ var Space = class Space extends Array {
 
         this.signals.disconnect(metaWindow);
 
-        let selected = this.selectedWindow;
-        if (selected === metaWindow) {
+        if (this.selectedWindow === metaWindow) {
             // Select a new window using the stack ordering;
             let windows = this.getWindows();
             let i = windows.indexOf(metaWindow);
             let neighbours = [windows[i - 1], windows[i + 1]].filter(w => w);
             let stack = sortWindows(this, neighbours);
-            selected = stack[stack.length - 1];
+            this.selectedWindow = stack[stack.length - 1];
         }
 
         let column = this[index];
@@ -743,8 +742,8 @@ var Space = class Space extends Array {
             actor.remove_clip();
 
         this.layout();
-        if (selected) {
-            ensureViewport(selected, this);
+        if (this.selectedWindow) {
+            ensureViewport(this.selectedWindow, this);
         } else {
             this.selectedWindow = null;
         }


### PR DESCRIPTION
This fixes the below error(s). The errors are (somtimes) caused when you move a window to the scratch layer.

The following worked mostly consistently to reproduce this:

- Empty workspace
- Press `<Super>`
- Open gnome-terminal (i.e. "Terminal") by typing "Terminal" and pressing enter
- Press `<Super>`
- Open a second gnome-terminal by typing "Terminal" and pressing `<Ctrl>+<Enter>`
- Move the terminal to the scratch layer by pressing `<Ctrl>+<Super>+<Escape>`
- See error in `journalctl -ef _COMM=gnome-shell`

This error didn't cause big actual errors (besides the error message). And usually PaperWM still behaved completely normally. But sometimes the workspace kind of broke.

<details>
<summary>Errors</summary>

```
JS ERROR: TypeError: this[index] is undefined
moveDone@/home/ms/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org/tiling.js:1016:13
_makeEaseCallback/<@resource:///org/gnome/shell/ui/environment.js:153:13
_easeActor@resource:///org/gnome/shell/ui/environment.js:242:17
init/Clutter.Actor.prototype.ease@resource:///org/gnome/shell/ui/environment.js:365:19
addTween@/home/ms/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org/utils.js:461:15
layoutColumnSimple@/home/ms/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org/tiling.js:444:29
layout@/home/ms/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org/tiling.js:524:26
removeWindow@/home/ms/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org/tiling.js:745:14
remove_handler@/home/ms/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org/tiling.js:2852:11
dynamic_function_ref/<@/home/ms/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org/utils.js:104:33
makeScratch@/home/ms/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org/scratch.js:77:16
toggle@/home/ms/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org/scratch.js:139:20
dynamic_function_ref/<@/home/ms/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org/utils.js:104:33
asKeyHandler/<@/home/ms/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org/keybindings.js:271:20
```

```
moveDone@/home/ms/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org/tiling.js:1021:22
_makeEaseCallback/<@resource:///org/gnome/shell/ui/environment.js:153:13
_easeActor@resource:///org/gnome/shell/ui/environment.js:242:17
init/Clutter.Actor.prototype.ease@resource:///org/gnome/shell/ui/environment.js:365:19
addTween@/home/ms/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org/utils.js:461:15
layout@/home/ms/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org/tiling.js:558:21
removeWindow@/home/ms/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org/tiling.js:745:14
remove_handler@/home/ms/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org/tiling.js:2784:11
dynamic_function_ref/<@/home/ms/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org/utils.js:104:33
makeScratch@/home/ms/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org/scratch.js:77:16
toggle@/home/ms/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org/scratch.js:139:20
dynamic_function_ref/<@/home/ms/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org/utils.js:104:33
asKeyHandler/<@/home/ms/.local/share/gnome-shell/extensions/paperwm@hedning:matrix.org/keybindings.js:271:20
```

The errors are slightly different, second one does not call `layoutColumnSimple`, but both ultimately end in the same place.

</details>

Notes on the implementation: `ensureViewport()` set `this.selectedWindow` correctly and `this.layout()` needs this to be set correctly. Invoking layout after it also should not cause an other issues because the window was removed and therefore `ensureViewport` wouldn't move the viewport anyway.

TODO: Still need to test on multimonitor and what happens when moving a window to another monitor.

