### PR TITLE
FIX: workspace label can be mis-positioned in stack/sequence workspace switching

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -2019,12 +2019,14 @@ var Spaces = class Spaces extends Map {
      * Updates workspace topbar icon positions.
      */
     updateSpaceIconPositions() {
-         // get position of topbar focus icon to replicate in spaces
-         const pos = TopBar.focusButton.apply_relative_transform_to_point(Main.panel, 
-            new Clutter.Vertex({ x: 0, y: 0 }));
+        // get positions of topbar elements to replicate positions in spaces
+        const vertex = new Clutter.Vertex({ x: 0, y: 0 });
+        const labelPosition = TopBar.menu.label.apply_relative_transform_to_point(Main.panel, vertex);
+        const focusPosition = TopBar.focusButton.apply_relative_transform_to_point(Main.panel, vertex);
 
         this.forEach(s => {
-            s.focusModeIcon.set_position(pos.x, pos.y);
+            s.workspaceLabel.set_position(labelPosition.x, labelPosition.y);
+            s.focusModeIcon.set_position(focusPosition.x, focusPosition.y);
         });
     }
 


### PR DESCRIPTION
Similar to #541, workspace labels can be mis-positioned under certain conditions, such as when/if you add more workspaces after PaperWM has been started.  I've also noticed this on new install of PaperWM.

To reproduce the issue:

- have PaperWM enabled and working;
- remove workspaces (e.g. in `settings` -> `multitasking`)
- add workspaces;
- switch workspaces via the stack or sequence workspaces switching (e.g. `super+pagedown/pageup`);
- note that the workspace label is mispositoned in the newly added spaces (in workspace switching mode);

Similar causes to #541, so this PR refactors and combines the reposition code into one (for both workspace labels and the focus mode icon).  Is much cleaner and robust.

Also fixes and now shows the spaces workspace label, bar, etc. when user "peek" at workspaces with the 3-finger swipe downwards.
