### PR TITLE
Behaviour_change: when selecting transient windows, do NOT drag view back to tiled parent

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -3299,7 +3299,7 @@ function focus_handler(metaWindow, user_data) {
         return;
     }
 
-    // If metaWindow is a transient window, deselect visual focus indicators and return
+    // If metaWindow is a transient window, return (after deselecting tiled focus indicators)
     if (isTransient(metaWindow)) {
         setAllWorkspacesInactive();
         return;

--- a/tiling.js
+++ b/tiling.js
@@ -3299,14 +3299,14 @@ function focus_handler(metaWindow, user_data) {
         return;
     }
 
+    // If metaWindow is a transient window, deselect visual focus indicators and return
+    if (isTransient(metaWindow)) {
+        setAllWorkspacesInactive();
+        return;
+    }
+
     let space = spaces.spaceOfWindow(metaWindow);
     space.monitor.clickOverlay.show();
-
-    // If metaWindow is a transient window ensure the parent window instead
-    let transient = metaWindow.get_transient_for();
-    if (transient) {
-        metaWindow = transient;
-    }
 
     /**
        Find the closest neighbours. Remove any dead windows in the process to


### PR DESCRIPTION
This PR fixes/changes a behaviour when selecting a transient window (a transient window is a floating window linked to a parent window that has focus (from the parent) while it's open, e.g. a extensions settings window that's open from `Extensions` application.

The current behaviour is that when a transient window is selected, it's parent is always brought into view.  This "forcing parent into view" feels harsh, and often causes frustration since I just want to move the transient window without focus being dragged back to the parent every time.

This PR changes this behaviour so that selected transient does just that... and doesn't drag the parent back into view.  This feels much more natural and expected to me.

A a few videos can demonstrate this difference in behaviour.

> Note: the flickering in the video is caused by my recording software, it's not seen in gnome or PaperWM.

### current behaviour - force parent back into view:
https://github.com/paperwm/PaperWM/assets/30424662/665d763f-ad1f-493e-a7fa-4e1ddbef8b0f

### behaviour of this PR - do NOT force parent back into view:
https://github.com/paperwm/PaperWM/assets/30424662/635b2928-4810-4c88-ab10-449734b70159