### PR TITLE
Use 3-finger swipe-up for gnome overview and 3-finger swipe-down for PaperWM workspace stack tiling preview

### DIFF
--- a/gestures.js
+++ b/gestures.js
@@ -160,7 +160,6 @@ function horizontalScroll(actor, event) {
 }
 
 function update(space, dx, t) {
-
     dxs.push(dx);
     dts.push(t);
 
@@ -268,7 +267,11 @@ function done(space) {
 
 
 function findTargetWindow(space, direction) {
-    let selected = space.selectedWindow.clone;
+    let selected = space.selectedWindow?.clone;
+    if (!selected) {
+        return;
+    }
+
     if (selected.x + space.targetX >= 0 &&
           selected.x + selected.width + space.targetX <= space.width) {
         return selected.meta_window;

--- a/kludges.js
+++ b/kludges.js
@@ -394,6 +394,7 @@ var swipeTrackers = [
     Main?.wm?._workspaceAnimation?._swipeTracker, // gnome 40+
     Main?.wm?._swipeTracker // gnome 38 (and below)
 ].filter(t => typeof t !== 'undefined');
+
 var signals;
 function init() {
     registerOverridePrototype(imports.ui.messageTray.MessageTray, '_updateState');

--- a/tiling.js
+++ b/tiling.js
@@ -3154,6 +3154,9 @@ function ensureViewport(meta_window, space, options={}) {
 }
 
 function updateSelection(space, metaWindow) {
+    if (!metaWindow) {
+        return;
+    }
     let clone = metaWindow.clone;
     let cloneActor = clone.cloneActor;
 


### PR DESCRIPTION
Resolves #263.

PaperWM has a [curious :smile: ](https://github.com/paperwm/PaperWM/issues/263)  animation/feature when you "3-finger" swipe up - it kind of zooms into the workspace...

This was originally meant as a visual cue to to let the user know that the workspace tiling stack (in "most-recent-used" order, no cyling) was already at the stack top (see https://github.com/paperwm/PaperWM/issues/263#issuecomment-597784774).

In practice, if you're not actually in workspace tiling (e.g. stack/sequence workspace tiling) this "zoom in" animation is rather... useless. #263 suggests using the swipe up action to show the overview (smoothly, i.e. follow fingers).

This PR does just that.  It uses 3-finger swipe-up to show the overview (smoothly, i.e. follow fingers), while 3-finger swipe-down shows the workspace stack tiling (just like now).

Note, that while in workspace preview, 3-finger swipe-down acts as it should (in that mode), and in overview it also acts as it should.

This feels quite natural and allows us to use the default 3-finger gnome action while also providing the PaperWM 3-finger swipe down action.