### PR TITLE
FIX: hold notifications when current window is fullscreen (Notifications are then shown when the window is un-fullscreened)

### DIFF
--- a/kludges.js
+++ b/kludges.js
@@ -553,10 +553,10 @@ function enable() {
                     this.emit('queue-changed');
 
                 let hasNotifications = Main.sessionMode.hasNotifications;
-
                 if (this._notificationState == State.HIDDEN) {
+                    let selectedFullscreen = global.display.focus_window?.fullscreen ?? false;
                     let nextNotification = this._notificationQueue[0] || null;
-                    if (hasNotifications && nextNotification) {
+                    if (!selectedFullscreen && hasNotifications && nextNotification) {
                         // Monkeypatch here
                         let limited = this._busy;
                         let showNextNotification = (!limited || nextNotification.forFeedback || nextNotification.urgency == Urgency.CRITICAL);


### PR DESCRIPTION
Fixes #221.

This PR hold notifications when the currently selected window is  fullscreened.  Notifications are then shown when the window is un-fullscreened.

This aligns more with Gnome default behaviour (but a bit better since any missed notifications will be shown when exiting fullscreen).

Plus, fullscreen movies are nicer without notifications always showing...