### PR TITLE
Restored explicit sort in overview layout: needed as relying on addWindow doesn't take in to account window moves (after add)

### DIFF
--- a/kludges.js
+++ b/kludges.js
@@ -429,8 +429,8 @@ function computeLayout40(windows, layoutParams) {
     let idealRowWidth = totalWidth / numRows;
 
     let sortedWindows = windows.slice();
-    // addWindow should have made sure we're already sorted.
-    // sortedWindows.sort(sortWindows);
+    // sorting needs to be done here to address moved windows
+    sortedWindows.sort(sortWindows);
 
     let windowIdx = 0;
     for (let i = 0; i < numRows; i++) {


### PR DESCRIPTION
Restores explicit sort method for overview layout calculations.  

Sorting is needed since relying only on `addWindow` sorting doesn't take into account moving windows around (e.g. move window positions after adding window to space).