### PR TITLE
Full module dependency review and clean-up of exports

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,21 +10,21 @@ const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
 const Shell = imports.gi.Shell;
 
-var Tracker = Shell.WindowTracker.get_default();
-var CouldNotLaunch = Symbol();
+let Tracker = Shell.WindowTracker.get_default();
+let CouldNotLaunch = Symbol();
 
 // Lookup table for custom handlers, keys being the app id
 var customHandlers, customSpawnHandlers;
 function enable() {
-    customHandlers = {'org.gnome.Terminal.desktop': newGnomeTerminal};
+    customHandlers = { 'org.gnome.Terminal.desktop': newGnomeTerminal };
     customSpawnHandlers = {
-        'com.gexperts.Tilix.desktop': mkCommandLineSpawner('tilix --working-directory %d')
+        'com.gexperts.Tilix.desktop': mkCommandLineSpawner('tilix --working-directory %d'),
     };
 
     function spawnWithFallback(fallback, ...args) {
         try {
             return trySpawnWindow(...args);
-        } catch(e) {
+        } catch (e) {
             return fallback();
         }
     }

--- a/extension.js
+++ b/extension.js
@@ -192,7 +192,7 @@ function enableUserConfig() {
 /**
  * Reloads user.css styles (if user.css present in ~/.config/paperwm).
  */
-var userStylesheet;
+let userStylesheet;
 function enableUserStylesheet() {
     userStylesheet = getConfigDir().get_child("user.css");
     if (userStylesheet.query_exists(null)) {

--- a/extension.js
+++ b/extension.js
@@ -43,10 +43,12 @@ const modules = [
 ];
 
 /**
-  Tell the modules to run init, enable or disable
+  Tell the modules to run enable or disable.
  */
-function run(method) {
-    for (let name of modules) {
+function run(method, reverse = false) {
+    // reverse order an array (useful for controlling execution order)
+    let arr = reverse ? [...modules].reverse() : modules;
+    for (let name of arr) {
         // Bail if there's an error in our own modules
         if (!safeCall(name, method))
             return false;
@@ -100,7 +102,7 @@ function prepareForDisable() {
 function disable() {
     console.log('#PaperWM disabled');
     prepareForDisable();
-    run('disable');
+    run('disable', true);
 
     disableUserStylesheet();
     safeCall('user', 'disable');

--- a/extension.js
+++ b/extension.js
@@ -39,7 +39,7 @@ const Main = imports.ui.main;
  */
 const modules = [
     'settings', 'keybindings', 'gestures', 'navigator', 'workspace', 'tiling', 'scratch',
-    'liveAltTab', 'stackoverlay', 'topbar', 'app', 'kludges',
+    'liveAltTab', 'stackoverlay', 'topbar', 'kludges', 'app',
 ];
 
 /**

--- a/extension.js
+++ b/extension.js
@@ -38,8 +38,10 @@ const Main = imports.ui.main;
           - settings.js should not depend on other paperwm modules;
  */
 const modules = [
-    'settings', 'keybindings', 'gestures', 'navigator', 'workspace', 'tiling', 'scratch',
-    'liveAltTab', 'stackoverlay', 'topbar', 'kludges', 'app',
+    'settings',
+    'gestures', 'keybindings', 'liveAltTab', 'navigator', 'stackoverlay', 'scratch',
+    'workspace', 'tiling', 'topbar', // these have `enable` dependency order
+    'kludges', 'app', // these have `enable` dependency order
 ];
 
 /**

--- a/gestures.js
+++ b/gestures.js
@@ -17,17 +17,17 @@ const DIRECTIONS = {
     Vertical: false,
 };
 
-var vy;
-var time;
-var vState;
-var navigator;
-var direction = undefined;
-var gliding = false;
-var signals;
+let vy;
+let time;
+let vState;
+let navigator;
+let direction = undefined;
+let signals;
 // 1 is natural scrolling, -1 is unnatural
-var natural = 1;
+let natural = 1;
+var gliding = false; //exported
 
-var touchpadSettings;
+let touchpadSettings;
 function enable() {
     signals = new Utils.Signals();
     // Touchpad swipes only works in Wayland
@@ -317,7 +317,7 @@ function findTargetWindow(space, direction) {
         return next.meta_window;
 }
 
-var transition = 'easeOutQuad';
+let transition = 'easeOutQuad';
 function updateVertical(dy, t) {
     // if here then initiate workspace stack (for tiling inPreview show)
     if (!Tiling.inPreview) {
@@ -369,7 +369,7 @@ function updateVertical(dy, t) {
     }
 }
 
-var endVerticalTimeout;
+let endVerticalTimeout;
 function endVertical() {
     let test = vy > 0 ?
         () => vy < 0 :

--- a/gestures.js
+++ b/gestures.js
@@ -374,10 +374,12 @@ function endVertical() {
     let test = vy > 0 ? () => vy < 0 : () => vy > 0;
     let glide = () => {
         if (vState < Clutter.TouchpadGesturePhase.END) {
+            endVerticalTimeout = null;
             return false;
         }
 
         if (!Number.isFinite(vy)) {
+            endVerticalTimeout = null;
             return false;
         }
 
@@ -385,10 +387,12 @@ function endVertical() {
         let y = selected.actor.y;
         if (selected === navigator.from && y <= 0.1 * selected.height) {
             navigator.finish();
+            endVerticalTimeout = null;
             return false;
         }
 
         if (test()) {
+            endVerticalTimeout = null;
             return false;
         }
 

--- a/gestures.js
+++ b/gestures.js
@@ -73,7 +73,7 @@ function enable() {
                     return Clutter.EVENT_PROPAGATE;
                 }
 
-                let dir_y = -dy*natural*Settings.prefs.swipe_sensitivity[1];
+                let dir_y = -dy * natural * Settings.prefs.swipe_sensitivity[1];
                 // if not Tiling.inPreview and swipe is UP => propagate event to overview
                 if (!Tiling.inPreview && dir_y > 0) {
                     swipeTrackersEnable();
@@ -102,7 +102,7 @@ function enable() {
                 endVertical();
                 return Clutter.EVENT_STOP;
             }
-        };
+        }
         return Clutter.EVENT_PROPAGATE;
     });
 }
@@ -137,7 +137,7 @@ function horizontalScroll(actor, event) {
             Easer.removeEase(this.cloneContainer);
             direction = DIRECTIONS.Horizontal;
         }
-        return update(this, -dx*natural*Settings.prefs.swipe_sensitivity[0], event.get_time());
+        return update(this, -dx * natural * Settings.prefs.swipe_sensitivity[0], event.get_time());
     case Clutter.TouchpadGesturePhase.CANCEL:
     case Clutter.TouchpadGesturePhase.END:
         this.hState = phase;
@@ -163,10 +163,10 @@ function update(space, dx, t) {
         space.vx = v;
     }
 
-    let accel = Settings.prefs.swipe_friction[0]/16; // px/ms^2
+    let accel = Settings.prefs.swipe_friction[0] / 16; // px/ms^2
     accel = space.vx > 0 ? -accel : accel;
-    let duration = -space.vx/accel;
-    let d = space.vx*duration + .5*accel*duration**2;
+    let duration = -space.vx / accel;
+    let d = space.vx * duration + .5 * accel * duration ** 2;
     let target = Math.round(space.targetX - d);
 
     space.targetX = target;
@@ -304,11 +304,11 @@ function findTargetWindow(space, direction) {
     let next = windows[1].clone;
     let r1, r2;
     if (direction) { // ->
-        r1 = Math.abs(closest.targetX + closest.width + space.targetX)/closest.width;
-        r2 = Math.abs(next.targetX + space.targetX - space.width)/next.width;
+        r1 = Math.abs(closest.targetX + closest.width + space.targetX) / closest.width;
+        r2 = Math.abs(next.targetX + space.targetX - space.width) / next.width;
     } else {
-        r1 = Math.abs(closest.targetX + space.targetX - space.width)/closest.width;
-        r2 = Math.abs(next.targetX + next.width + space.targetX)/next.width;
+        r1 = Math.abs(closest.targetX + space.targetX - space.width) / closest.width;
+        r2 = Math.abs(next.targetX + next.width + space.targetX) / next.width;
     }
     // Choose the window the most visible width (as a ratio)
     if (r1 > r2)
@@ -353,7 +353,7 @@ function updateVertical(dy, t) {
         Easer.removeEase(selected.actor);
         Easer.addEase(selected.actor, {
             scale_x: 0.9, scale_y: 0.9, time:
-                Settings.prefs.animation_time, transition
+                Settings.prefs.animation_time, transition,
         });
     } else if (Number.isFinite(v)) {
         vy = v;
@@ -362,7 +362,7 @@ function updateVertical(dy, t) {
     selected.actor.y -= dy;
     if (selected === navigator.from) {
         let scale = 0.90;
-        let s = 1 - (1 - scale)*(selected.actor.y/(0.1*monitor.height));
+        let s = 1 - (1 - scale) * (selected.actor.y / (0.1 * monitor.height));
         s = Math.max(s, scale);
         Easer.removeEase(selected.actor);
         selected.actor.set_scale(s, s);
@@ -371,13 +371,11 @@ function updateVertical(dy, t) {
 
 let endVerticalTimeout;
 function endVertical() {
-    let test = vy > 0 ?
-        () => vy < 0 :
-        () => vy > 0;
-
+    let test = vy > 0 ? () => vy < 0 : () => vy > 0;
     let glide = () => {
-        if (vState < Clutter.TouchpadGesturePhase.END)
+        if (vState < Clutter.TouchpadGesturePhase.END) {
             return false;
+        }
 
         if (!Number.isFinite(vy)) {
             return false;
@@ -385,7 +383,7 @@ function endVertical() {
 
         let selected = Tiling.spaces.selectedSpace;
         let y = selected.actor.y;
-        if (selected === navigator.from && y <= 0.1*selected.height) {
+        if (selected === navigator.from && y <= 0.1 * selected.height) {
             navigator.finish();
             return false;
         }
@@ -394,12 +392,12 @@ function endVertical() {
             return false;
         }
 
-        let dy = vy*16;
+        let dy = vy * 16;
         let v = vy;
         let accel = Settings.prefs.swipe_friction[1];
         accel = v > 0 ? -accel : accel;
         updateVertical(dy, time + 16);
-        vy = vy + accel;
+        vy += accel;
         return true; // repeat
     };
 

--- a/grab.js
+++ b/grab.js
@@ -11,7 +11,6 @@ const { Meta, Clutter, St, Graphene } = imports.gi;
 const Main = imports.ui.main;
 const Mainloop = imports.mainloop;
 
-var virtualPointer;
 
 function isInRect(x, y, r) {
     return r.x <= x && x < r.x + r.width &&
@@ -31,7 +30,8 @@ function monitorAtPoint(gx, gy) {
  * "clickout" of a drag operation when `grab_end_op` is unavailable
  * (i.e. as of Gnome 44 where `grab_end_op` was removed).
  * @returns Clutter.VirtualInputDevice
- */
+*/
+let virtualPointer;
 function getVirtualPointer() {
     if (!virtualPointer) {
         virtualPointer = Clutter.get_default_backend()

--- a/keybindings.js
+++ b/keybindings.js
@@ -16,7 +16,7 @@ const Main = imports.ui.main;
 const display = global.display;
 
 
-var KEYBINDINGS_KEY = 'org.gnome.shell.extensions.paperwm.keybindings';
+let KEYBINDINGS_KEY = 'org.gnome.shell.extensions.paperwm.keybindings';
 
 function registerPaperAction(actionName, handler, flags) {
     let settings = ExtensionUtils.getSettings(KEYBINDINGS_KEY);
@@ -49,7 +49,7 @@ function registerMinimapAction(name, handler) {
 }
 
 
-var signals, actions, nameMap, actionIdMap, keycomboMap, overrides;
+let signals, actions, nameMap, actionIdMap, keycomboMap, overrides;
 function setupActions() {
     signals = new Utils.Signals();
     actions = [];

--- a/kludges.js
+++ b/kludges.js
@@ -304,7 +304,7 @@ function restoreRuntimeDisables() {
  * move from gnome version to gnome version.  Next to the swipe tracker locations
  * below are the gnome versions when they were first (or last) seen.
  */
-let swipeTrackers;
+var swipeTrackers; // exported
 function setupSwipeTrackers() {
     swipeTrackers = [
         Main?.overview?._swipeTracker, // gnome 40+

--- a/kludges.js
+++ b/kludges.js
@@ -31,9 +31,6 @@ function getOriginalPosition() {
     return [x, y];
 }
 
-var savedProps;
-savedProps = savedProps || new Map();
-
 function registerOverrideProp(obj, name, override) {
     if (!obj)
         return;
@@ -307,7 +304,7 @@ function restoreRuntimeDisables() {
  * move from gnome version to gnome version.  Next to the swipe tracker locations
  * below are the gnome versions when they were first (or last) seen.
  */
-var swipeTrackers;
+let swipeTrackers;
 function setupSwipeTrackers() {
     swipeTrackers = [
         Main?.overview?._swipeTracker, // gnome 40+
@@ -317,7 +314,7 @@ function setupSwipeTrackers() {
     ].filter(t => typeof t !== 'undefined');
 }
 
-var signals;
+let signals;
 function setupSignals() {
     signals = new Utils.Signals();
 
@@ -345,7 +342,7 @@ function setupSignals() {
     scratchInOverview();
 }
 
-var actions;
+let actions;
 function setupActions() {
     /*
      * Some actions work rather poorly.
@@ -361,8 +358,10 @@ function setupActions() {
     actions.forEach(a => global.stage.remove_action(a));
 }
 
-var gsettings, wmSettings, mutterSettings;
+let savedProps;
+let gsettings, wmSettings, mutterSettings;
 function enable() {
+    savedProps = new Map();
     gsettings = ExtensionUtils.getSettings();
     wmSettings = new Gio.Settings({schema_id: 'org.gnome.desktop.wm.preferences'});
     mutterSettings = new Gio.Settings({schema_id: 'org.gnome.mutter'});
@@ -378,10 +377,12 @@ function disable() {
     disableOverrides();
     restoreRuntimeDisables();
     actions.forEach(a => global.stage.add_action(a));
+    actions = null;
 
     signals.destroy();
     signals = null;
 
+    savedProps = null;
     swipeTrackers = null;
     gsettings.run_dispose();
     gsettings = null;

--- a/liveAltTab.js
+++ b/liveAltTab.js
@@ -162,7 +162,7 @@ function liveAltTab(meta_window, space, {display, screen, binding}) {
     tabPopup.show(binding.is_reversed(), binding.get_name(), binding.get_mask());
 }
 
-var switcherSettings;
+let switcherSettings;
 function enable() {
     switcherSettings = new Gio.Settings({
         schema_id: 'org.gnome.shell.window-switcher',

--- a/navigator.js
+++ b/navigator.js
@@ -203,6 +203,7 @@ class ActionDispatcher {
             this._resetNoModsTimeout();
             this._doActionTimeout = Mainloop.timeout_add(0, () => {
                 action.handler(metaWindow, space);
+                this._doActionTimeout = null;
                 return false; // on return false destroys timeout
             });
         }
@@ -224,8 +225,8 @@ class ActionDispatcher {
 
     destroy() {
         Utils.timeout_remove(this._noModsTimeoutId);
-        Utils.timeout_remove(this._doActionTimeout);
         this._noModsTimeoutId = null;
+        Utils.timeout_remove(this._doActionTimeout);
         this._doActionTimeout = null;
 
         try {

--- a/navigator.js
+++ b/navigator.js
@@ -20,14 +20,17 @@ const Signals = imports.signals;
 
 const display = global.display;
 
-var workspaceManager = global.workspace_manager;
+var navigating; // exported
+let grab, dispatcher;
+function enable() {
+    navigating = false;
+}
 
-var scale = 0.9;
-var navigating = false;
-var grab = null;
-
-/** @type {ActionDispatcher} */
-var dispatcher = null
+function disable() {
+    navigating = false;
+    grab = null;
+    dispatcher = null;
+}
 
 function dec2bin(dec) {
     return (dec >>> 0).toString(2);
@@ -242,8 +245,8 @@ class ActionDispatcher {
     }
 }
 
-var index = 0;
-var navigator;
+let index = 0;
+var navigator; // exported
 class NavigatorClass {
     constructor() {
         Utils.debug("#navigator", "nav created");

--- a/scratch.js
+++ b/scratch.js
@@ -216,8 +216,9 @@ function showWindows() {
     ws.forEach(Tiling.showWindow)
 }
 
-var originalBuildMenu = WindowMenu.WindowMenu.prototype._buildMenu;
+let originalBuildMenu;
 function enable() {
+    originalBuildMenu = WindowMenu.WindowMenu.prototype._buildMenu;
     float = Symbol();
     scratchFrame = Symbol();
     WindowMenu.WindowMenu.prototype._buildMenu =
@@ -235,6 +236,7 @@ function enable() {
 
 function disable() {
     WindowMenu.WindowMenu.prototype._buildMenu = originalBuildMenu;
+    originalBuildMenu = null;
     float = null;
     scratchFrame = null;
 }

--- a/settings.js
+++ b/settings.js
@@ -6,10 +6,11 @@ const { Gio, Gtk } = imports.gi;
     settings.js shouldn't depend on other modules (e.g with `imports` for other modules
     at the top).
  */
-var KEYBINDINGS_KEY = 'org.gnome.shell.extensions.paperwm.keybindings';
+
+let KEYBINDINGS_KEY = 'org.gnome.shell.extensions.paperwm.keybindings';
 
 // This is the value mutter uses for the keyvalue of above_tab
-var META_KEY_ABOVE_TAB = 0x2f7259c9;
+let META_KEY_ABOVE_TAB = 0x2f7259c9;
 
 function setState($, key) {
     let value = gsettings.get_value(key);
@@ -17,7 +18,7 @@ function setState($, key) {
     prefs[name] = value.deep_unpack();
 }
 
-var conflictSettings;
+var conflictSettings; // exported
 function getConflictSettings() {
     if (!conflictSettings) {
         // Schemas that may contain conflicting keybindings

--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -89,10 +89,11 @@ var ClickOverlay = class ClickOverlay {
                 this._lastPointer = [x, y];
                 this._lastPointerTimeout = Mainloop.timeout_add(500, () => {
                     this._lastPointer = [];
+                    this._lastPointerTimeout = null;
                     return false; // on return false destroys timeout
                 });
                 if (lX === undefined ||
-                    Math.sqrt((lX - x)**2 + (lY - y)**2) < 10)
+                    Math.sqrt((lX - x) ** 2 + (lY - y) ** 2) < 10)
                     return;
                 this.select();
                 return Clutter.EVENT_STOP;
@@ -243,6 +244,7 @@ var StackOverlay = class StackOverlay {
                 if (x <= 2 || x >= this.monitor.width - 2) {
                     this.triggerPreview.bind(this)();
                 }
+                this.triggerPreviewTimeout = null;
                 return false; // on return false destroys timeout
             });
         });
@@ -271,6 +273,7 @@ var StackOverlay = class StackOverlay {
             delete this._previewId;
             this.removePreview();
             this.showPreview();
+            this._previewId = null;
             return false; // on return false destroys timeout
         });
 
@@ -278,6 +281,7 @@ var StackOverlay = class StackOverlay {
         /*
         this._removeId = Mainloop.timeout_add_seconds(2, () => {
             this.removePreview();
+            this._removeId = null;
             return false; // on return false destroys timeout
         });
         */
@@ -348,7 +352,7 @@ var StackOverlay = class StackOverlay {
             this.pressureBarrier.destroy();
             this.barrier = null;
         }
-        this._removeBarrierTimeoutId = 0;
+        this._removeBarrierTimeoutId = null;
     }
 
     updateBarrier(force) {
@@ -364,11 +368,12 @@ var StackOverlay = class StackOverlay {
         this.pressureBarrier.connect('trigger', () => {
             this.pressureBarrier._reset();
             this.pressureBarrier._isTriggered = false;
-            if (this._removeBarrierTimeoutId > 0) {
+            if (this._removeBarrierTimeoutId) {
                 Mainloop.source_remove(this._removeBarrierTimeoutId);
             }
             this._removeBarrierTimeoutId = Mainloop.timeout_add(100, () => {
                 this.removeBarrier();
+                this._removeBarrierTimeoutId = null;
                 return false;
             });
             overlay.show();
@@ -466,6 +471,8 @@ var StackOverlay = class StackOverlay {
     }
 
     destroy() {
+        Utils.timeout_remove(this._removeBarrierTimeoutId);
+        this._removeBarrierTimeoutId = null;
         Utils.timeout_remove(this.triggerPreviewTimeout);
         this.triggerPreviewTimeout = null;
 

--- a/tiling.js
+++ b/tiling.js
@@ -25,6 +25,7 @@ const display = global.display;
 var spaces; // export
 
 let borderWidth = 8;
+
 // Mutter prevints windows from being placed further off the screen than 75 pixels.
 var stack_margin = 75; // export
 
@@ -1557,6 +1558,7 @@ border-radius: ${borderWidth}px;
 
 Signals.addSignalMethods(Space.prototype);
 
+// static object
 var StackPositions = {
     top: 0.01,
     up: 0.035,
@@ -2671,7 +2673,9 @@ let signals, backgroundGroup, grabSignals;
 let gsettings, backgroundSettings, interfaceSettings;
 let oldSpaces, oldMonitors;
 let startupTimeoutId;
+var inGrab;
 function enable(errorNotification) {
+    inGrab = false;
     gsettings = ExtensionUtils.getSettings();
     backgroundSettings = new Gio.Settings({
         schema_id: 'org.gnome.desktop.background',
@@ -2777,6 +2781,7 @@ function disable () {
 
     spaces.destroy();
     gsettings.run_dispose();
+    inGrab = null;
     gsettings = null;
     backgroundGroup = null;
     backgroundSettings = null;
@@ -3173,7 +3178,6 @@ function move_to(space, metaWindow, { x, y, force, instant }) {
     space.fixOverlays(metaWindow);
 }
 
-var inGrab = false;
 function grabBegin(metaWindow, type) {
     switch (type) {
     case Meta.GrabOp.COMPOSITOR:

--- a/tiling.js
+++ b/tiling.js
@@ -2698,14 +2698,11 @@ function enable(errorNotification) {
     let timerId;
     let onWindowGapChanged = () => {
         setVerticalMargin();
-        if (timerId) {
-            Mainloop.source_remove(timerId);
-        }
+        Utils.timeout_remove(timerId);
         timerId = Mainloop.timeout_add(500, () => {
             spaces.mru().forEach(space => {
                 space.layout();
             });
-            timerId = null;
             return false; // on return false destroys timeout
         });
     };

--- a/tiling.js
+++ b/tiling.js
@@ -562,10 +562,6 @@ var Space = class Space extends Array {
         let x = this.visibleX(metaWindow);
         let workArea = this.workArea();
         let min = workArea.x;
-
-        let left = min - x
-        let right = x + clone.width
-
         return min <= x && x + clone.width < min + workArea.width;
     }
 

--- a/topbar.js
+++ b/topbar.js
@@ -16,14 +16,14 @@ const { panelMenu, popupMenu } = imports.ui;
 const Main = imports.ui.main;
 const Path = Extension.dir.get_path();
 
-var panelBox = Main.layoutManager.panelBox;
-var panelMonitor;
+const workspaceManager = global.workspace_manager;
+const display = global.display;
 
-var workspaceManager = global.workspace_manager;
-var display = global.display;
+var panelBox = Main.layoutManager.panelBox; // exported
+var panelMonitor; // exported
 
 // From https://developer.gnome.org/hig-book/unstable/design-color.html.en
-var colors = [
+let colors = [
     '#9DB8D2', '#7590AE', '#4B6983', '#314E6C',
     '#EAE8E3', '#BAB5AB', '#807D74', '#565248',
     '#C5D2C8', '#83A67F', '#5D7555', '#445632',
@@ -586,11 +586,8 @@ var WorkspaceMenu = GObject.registerClass(
         }
     });
 
-var menu;
-var focusButton;
-var orginalActivitiesText;
-var screenSignals, signals;
-let gsettings;
+var menu, focusButton; // exported
+let orginalActivitiesText, screenSignals, signals, gsettings;
 function enable () {
     gsettings = ExtensionUtils.getSettings();
     let label = Main.panel.statusArea.activities.first_child;

--- a/utils.js
+++ b/utils.js
@@ -3,6 +3,7 @@ const Extension = ExtensionUtils.getCurrentExtension();
 const Lib = Extension.imports.lib;
 const { GLib, Clutter, Meta, St, GdkPixbuf, Cogl } = imports.gi;
 const Main = imports.ui.main;
+const Mainloop = imports.mainloop;
 const display = global.display;
 
 var version = imports.misc.config.PACKAGE_VERSION.split('.').map(Number);
@@ -426,11 +427,7 @@ function later_add(...args) {
 function timeout_remove(...timeouts) {
     timeouts.forEach(t => {
         if (t) {
-            try {
-                Mainloop.source_remove(t);
-            } catch (e) {
-                console.log('hehehe');
-            }
+            Mainloop.source_remove(t);
         }
     });
 }

--- a/utils.js
+++ b/utils.js
@@ -3,13 +3,12 @@ const Extension = ExtensionUtils.getCurrentExtension();
 const Lib = Extension.imports.lib;
 const { GLib, Clutter, Meta, St, GdkPixbuf, Cogl } = imports.gi;
 const Main = imports.ui.main;
-const Mainloop = imports.mainloop;
 const display = global.display;
 
 var version = imports.misc.config.PACKAGE_VERSION.split('.').map(Number);
 
-var debug_all = false; // Turn off by default
-var debug_filter = { '#paperwm': true, '#stacktrace': true };
+let debug_all = false; // Turn off by default
+let debug_filter = { '#paperwm': true, '#stacktrace': true };
 function debug() {
     let keyword = arguments[0];
     let filter = debug_filter[keyword];
@@ -160,7 +159,7 @@ function toggleWindowBoxes(metaWindow) {
     return boxes;
 }
 
-var markNewClonesSignalId = null;
+let markNewClonesSignalId = null;
 function toggleCloneMarks() {
     // NB: doesn't clean up signal on disable
 
@@ -422,10 +421,16 @@ function later_add(...args) {
 }
 
 /**
- * Convenience method for removing a timeout source from Mainloop.
+ * Convenience method for removing timeout source(s) from Mainloop.
  */
-function timeout_remove(timeoutId) {
-    if (timeoutId) {
-        Mainloop.source_remove(timeoutId);
-    }
+function timeout_remove(...timeouts) {
+    timeouts.forEach(t => {
+        if (t) {
+            try {
+                Mainloop.source_remove(t);
+            } catch (e) {
+                console.log('hehehe');
+            }
+        }
+    });
 }

--- a/virtTiling.js
+++ b/virtTiling.js
@@ -11,7 +11,7 @@ let prefs = {
     minimum_margin: 3,
 };
 
-var virtStage = null;
+let virtStage = null;
 
 function repl() {
     if (virtStage) {


### PR DESCRIPTION
This PR is the result of a full module dependency review of PaperWM.

It adds explicit comments on which modules have an `enable` dependency which dictates the execution order of `enable`/`disable` in `extensions.js`.

It also clean up which properties are exported to other modules (in gnome extensions `var` properties are exported, while `let`, `const, etc. are not).  We now explicitly state which properties are exported, which makes paperwm modules much easier to maintain (i.e. we see what's actually needed by other modules).

This is part of an effort to clean-up & productionise paperwm.