### PR TITLE
Fix multimonitor workspace placement on unlock, also fixes lots of other multi-monitor issues

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -177,7 +177,7 @@ rules:
   no-trailing-spaces: error
   no-undef-init: error
   no-unneeded-ternary: error
-  no-unused-expressions: error
+  #no-unused-expressions: error
   no-unused-vars:
     - error
     # Vars use a suffix _ instead of a prefix because of file-scope private vars
@@ -198,7 +198,7 @@ rules:
     - error
     - consistent: true
       multiline: true
-  # object-curly-spacing: error
+  #object-curly-spacing: error
   object-curly-spacing: 
     - error
     - always

--- a/gestures.js
+++ b/gestures.js
@@ -326,12 +326,12 @@ function updateVertical(dy, t) {
 
     let selected = Tiling.spaces.selectedSpace;
     let monitor = navigator.monitor;
-    let v = dy/(t - time);
+    let v = dy / (t - time);
     time = t;
     const StackPositions = Tiling.StackPositions;
-    if (dy > 0
-        && selected !== navigator.from
-        && (selected.actor.y - dy < StackPositions.up * monitor.height)
+    if (dy > 0 &&
+        selected !== navigator.from &&
+        (selected.actor.y - dy < StackPositions.up * monitor.height)
     ) {
         dy = 0;
         vy = 1;
@@ -341,10 +341,10 @@ function updateVertical(dy, t) {
         Easer.removeEase(selected.actor);
         Easer.addEase(selected.actor, {
             scale_x: 0.9, scale_y: 0.9, time:
-                Settings.prefs.animation_time, transition
+                Settings.prefs.animation_time, transition,
         });
-    } else if (dy < 0
-        && (selected.actor.y - dy > StackPositions.down * monitor.height)) {
+    } else if (dy < 0 &&
+        (selected.actor.y - dy > StackPositions.down * monitor.height)) {
         dy = 0;
         vy = -1;
         selected.actor.y = StackPositions.down * selected.height;

--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -133,27 +133,7 @@ var ClickOverlay = class ClickOverlay {
     select() {
         this.deactivate();
         let space = Tiling.spaces.monitors.get(this.monitor);
-        let display = global.display;
-        let mi = space.monitor.index;
-        let mru = display.get_tab_list(Meta.TabList.NORMAL,
-            space.workspace)
-            .filter(w => !w.minimized && w.get_monitor() === mi);
-
-        let stack = display.sort_windows_by_stacking(mru);
-        // Select the highest stacked window on the monitor
-        let select = stack[stack.length - 1];
-
-        // But don't change focus if a stuck window is active
-        if (display.focus_window &&
-            display.focus_window.is_on_all_workspaces())
-            select = display.focus_window;
-
-        if (select) {
-            space.workspace.activate_with_focus(
-                select, global.get_current_time());
-        } else {
-            space.workspace.activate(global.get_current_time());
-        }
+        space.workspace.activate(global.get_current_time());
     }
 
     activate() {

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -25,7 +25,8 @@
 }
 
 .topbar-transparent {
-    background-color: rgba(0, 0, 0, 0.35)
+    background-color: rgba(0, 0, 0, 0.35);
+    box-shadow: none;
 }
 
 .workspace-icon-button {

--- a/tiling.js
+++ b/tiling.js
@@ -1685,8 +1685,7 @@ var Spaces = class Spaces extends Map {
         let finish = () => {
             // update topbar workspace indicator
             TopBar.updateMonitor();
-            let panelSpace = spaces.monitors.get(TopBar.panelMonitor);
-            TopBar.updateWorkspaceIndicator(panelSpace.workspace.index());
+            TopBar.refreshWorkspaceIndicator();
 
             let activeSpace = this.get(workspaceManager.get_active_workspace());
             let mru = this.mru();

--- a/tiling.js
+++ b/tiling.js
@@ -2259,7 +2259,6 @@ var Spaces = class Spaces extends Map {
 
         newSpace = mru[to];
         this.selectedSpace = newSpace;
-        Utils.print_stacktrace();
         TopBar.updateWorkspaceIndicator(newSpace.workspace.index());
 
         mru.forEach((space, i) => {

--- a/tiling.js
+++ b/tiling.js
@@ -1756,9 +1756,6 @@ var Spaces = class Spaces extends Map {
             }
         }
 
-        // update old monitors here
-        oldMonitors = new Map(this.monitors);
-
         // Reset any removed monitors
         mru.forEach(space => {
             if (!monitors.includes(space.monitor)) {
@@ -2763,8 +2760,7 @@ function disable () {
     grabSignals.destroy();
     signals.destroy();
 
-    // save spaces map for restore (monitors are alrady stored)
-    oldSpaces = new Map(spaces);
+    oldMonitors = new Map(spaces.monitors);
     oldSpaces.forEach(space => {
         let windows = space.getWindows();
         let selected = windows.indexOf(space.selectedWindow);

--- a/tiling.js
+++ b/tiling.js
@@ -1683,7 +1683,11 @@ var Spaces = class Spaces extends Map {
         }
 
         let finish = () => {
+            // update topbar workspace indicator
             TopBar.updateMonitor();
+            let panelSpace = spaces.monitors.get(TopBar.panelMonitor);
+            TopBar.updateWorkspaceIndicator(panelSpace.workspace.index());
+
             let activeSpace = this.get(workspaceManager.get_active_workspace());
             let mru = this.mru();
             this.selectedSpace = mru[0];

--- a/tiling.js
+++ b/tiling.js
@@ -1180,7 +1180,7 @@ border-radius: ${borderWidth}px;
      * Enables or disables this space's window position bar.
      * @param {boolean} enable
      */
-    enableWindowPositionBar(enable=true) {
+    enableWindowPositionBar(enable = true) {
         if (enable) {
             [this.windowPositionBarBackdrop, this.windowPositionBar]
                 .forEach(i => this.actor.add_actor(i));
@@ -2074,8 +2074,6 @@ var Spaces = class Spaces extends Map {
         newSpace = monitorSpaces[to];
         this.selectedSpace = newSpace;
 
-        TopBar.updateWorkspaceIndicator(newSpace.workspace.index());
-
         const scale = 0.825;
         const padding_percentage = 4;
         let last = monitorSpaces.length - 1;
@@ -2229,8 +2227,6 @@ var Spaces = class Spaces extends Map {
 
         newSpace = mru[to];
         this.selectedSpace = newSpace;
-
-        TopBar.updateWorkspaceIndicator(newSpace.workspace.index());
 
         mru.forEach((space, i) => {
             let actor = space.actor;

--- a/tiling.js
+++ b/tiling.js
@@ -2066,7 +2066,7 @@ var Spaces = class Spaces extends Map {
 
         if (move && this.selectedSpace.selectedWindow) {
             const navigator = Navigator.getNavigator();
-            if (navigator._moving == null || 
+            if (navigator._moving === null ||
                 (Array.isArray(navigator._moving) && navigator._moving.length === 0)) {
                 takeWindow(this.selectedSpace.selectedWindow,
                     this.selectedSpace,
@@ -2087,7 +2087,11 @@ var Spaces = class Spaces extends Map {
 
         newSpace = monitorSpaces[to];
         this.selectedSpace = newSpace;
-        TopBar.updateWorkspaceIndicator(newSpace.workspace.index());
+
+        // if active (source space) is panelMonitor update indicator
+        if (currentSpace.monitor === TopBar.panelMonitor) {
+            TopBar.updateWorkspaceIndicator(newSpace.workspace.index());
+        }
 
         const scale = 0.825;
         const padding_percentage = 4;
@@ -2259,7 +2263,11 @@ var Spaces = class Spaces extends Map {
 
         newSpace = mru[to];
         this.selectedSpace = newSpace;
-        TopBar.updateWorkspaceIndicator(newSpace.workspace.index());
+
+        // if active (source space) is panelMonitor update indicator
+        if (space.monitor === TopBar.panelMonitor) {
+            TopBar.updateWorkspaceIndicator(newSpace.workspace.index());
+        }
 
         mru.forEach((space, i) => {
             let actor = space.actor;

--- a/tiling.js
+++ b/tiling.js
@@ -2775,6 +2775,7 @@ function disable () {
     signals.destroy();
 
     prevMonitors = new Map(spaces.monitors);
+    prevSpaces = new Map(spaces);
     prevSpaces.forEach(space => {
         let windows = space.getWindows();
         let selected = windows.indexOf(space.selectedWindow);

--- a/tiling.js
+++ b/tiling.js
@@ -1257,12 +1257,17 @@ border-radius: ${borderWidth}px;
         // if windowPositionBar shown, we want the topbar style to be transparent if visible
         if (Settings.prefs.show_window_position_bar) {
             if (changeTopBarStyle) {
-                visible ? TopBar.setTransparentStyle() : TopBar.setClearStyle();
+                visible && this.hasTopBar() ? TopBar.setTransparentStyle() : TopBar.setClearStyle();
             }
 
             // if on different monitor then override to show elements
             if (!this.hasTopBar()) {
                 visible = true;
+            }
+
+            // don't show elements on spaces with actual TopBar (unless inPreview)
+            if (this.hasTopBar() && !inPreview) {
+                visible = false;
             }
         }
 
@@ -2076,6 +2081,7 @@ var Spaces = class Spaces extends Map {
 
         newSpace = monitorSpaces[to];
         this.selectedSpace = newSpace;
+        TopBar.updateWorkspaceIndicator(newSpace.workspace.index());
 
         const scale = 0.825;
         const padding_percentage = 4;
@@ -2230,6 +2236,7 @@ var Spaces = class Spaces extends Map {
 
         newSpace = mru[to];
         this.selectedSpace = newSpace;
+        TopBar.updateWorkspaceIndicator(newSpace.workspace.index());
 
         mru.forEach((space, i) => {
             let actor = space.actor;

--- a/tiling.js
+++ b/tiling.js
@@ -1257,7 +1257,12 @@ border-radius: ${borderWidth}px;
         // if windowPositionBar shown, we want the topbar style to be transparent if visible
         if (Settings.prefs.show_window_position_bar) {
             if (changeTopBarStyle) {
-                visible && this.hasTopBar() ? TopBar.setTransparentStyle() : TopBar.setClearStyle();
+                if (visible && this.hasTopBar()) {
+                    TopBar.setTransparentStyle();
+                }
+                else {
+                    TopBar.setClearStyle();
+                }
             }
 
             // if on different monitor then override to show elements
@@ -1586,6 +1591,7 @@ var Spaces = class Spaces extends Map {
         super();
 
         this._initDone = false;
+        this._inPreviewProgress = false;
         this.clickOverlays = [];
         this.signals = new Utils.Signals();
         this.stack = [];
@@ -2113,6 +2119,11 @@ var Spaces = class Spaces extends Map {
             return;
         }
 
+        if (this._inPreviewProgress) {
+            return;
+        }
+        this._inPreviewProgress = true;
+
         inPreview = PreviewMode.STACK;
 
         // Always show the topbar when using the workspace stack
@@ -2169,8 +2180,10 @@ var Spaces = class Spaces extends Map {
             // Remove any lingering onComplete handlers from animateToSpace
             Easer.removeEase(space.actor);
 
-            if (mru[i - 1] === undefined)
+            if (mru[i - 1] === undefined) {
+                this._inPreviewProgress = false;
                 return;
+            }
             let child = space.clip;
             let sibling = mru[i - 1].clip;
             child !== sibling && cloneParent.set_child_below_sibling(child, sibling);
@@ -2188,6 +2201,9 @@ var Spaces = class Spaces extends Map {
             Easer.addEase(selected.clone, {
                 y: Main.panel.height + Settings.prefs.vertical_margin,
                 time: Settings.prefs.animation_time,
+                onComplete: () => {
+                    this._inPreviewProgress = false;
+                },
             });
         }
     }
@@ -2197,6 +2213,11 @@ var Spaces = class Spaces extends Map {
         if (inPreview === PreviewMode.SEQUENTIAL) {
             return;
         }
+
+        if (this._inPreviewProgress) {
+            return;
+        }
+        this._inPreviewProgress = true;
 
         const scale = 0.9;
         let space = this.getActiveSpace();
@@ -2231,16 +2252,21 @@ var Spaces = class Spaces extends Map {
             to = 0;
         }
 
-        if (to === from && Easer.isEasing(newSpace.actor))
+        if (to === from && Easer.isEasing(newSpace.actor)) {
+            this._inPreviewProgress = false;
             return;
+        }
 
         newSpace = mru[to];
         this.selectedSpace = newSpace;
+        Utils.print_stacktrace();
         TopBar.updateWorkspaceIndicator(newSpace.workspace.index());
 
         mru.forEach((space, i) => {
             let actor = space.actor;
-            let h, onComplete = () => {};
+            let h, onComplete = () => {
+                this._inPreviewProgress = false;
+            };
             if (to === i)
                 h = StackPositions.selected;
             else if (to + 1 === i)
@@ -2253,7 +2279,10 @@ var Spaces = class Spaces extends Map {
                 h = StackPositions.bottom;
 
             if (Math.abs(i - to) > 2) {
-                onComplete = () => space.hide();
+                onComplete = () => {
+                    space.hide();
+                    this._inPreviewProgress = false;
+                };
             } else {
                 space.show();
             }

--- a/tiling.js
+++ b/tiling.js
@@ -168,8 +168,6 @@ var Space = class Space extends Array {
         }
 
         this.setSettings(Workspace.getWorkspaceSettings(this.workspace.index()));
-        this.setMonitor(monitor, false);
-
         actor.set_pivot_point(0.5, 0);
 
         this.selectedWindow = null;
@@ -189,6 +187,9 @@ var Space = class Space extends Array {
         if (Settings.prefs.show_window_position_bar) {
             this.enableWindowPositionBar();
         }
+
+        // now set monitor for this space
+        this.setMonitor(monitor, false);
 
         if (doInit)
             this.init();
@@ -211,7 +212,6 @@ var Space = class Space extends Array {
         this.cloneContainer.x = this.targetX;
 
         // init window position bar and space topbar elements
-        this.windowPositionBarBackdrop.width = this.monitor.width;
         this.windowPositionBarBackdrop.height = TopBar.panelBox.height;
         this.setSpaceTopbarElementsVisible(false);
 
@@ -1411,6 +1411,9 @@ border-radius: ${borderWidth}px;
             this.createBackground();
             this.updateBackground();
             this.updateColor();
+
+            // update width of windowPositonBarBackdrop (to match monitor)
+            this.windowPositionBarBackdrop.width = monitor.width;
         }
 
         let background = this.background;

--- a/tiling.js
+++ b/tiling.js
@@ -2738,6 +2738,14 @@ function enable(errorNotification) {
             s.monitor.clickOverlay.show();
         });
         TopBar.fixTopBar();
+
+        // on idle update space topbar elements and name
+        Utils.later_add(Meta.LaterType.IDLE, () => {
+            spaces.forEach(s => {
+                s.setSpaceTopbarElementsVisible(false);
+                s.updateName();
+            });
+        });
     }
 
     if (Main.layoutManager._startingUp) {

--- a/tiling.js
+++ b/tiling.js
@@ -2006,7 +2006,7 @@ var Spaces = class Spaces extends Map {
 
             let selected = space.selectedWindow;
             if (selected && selected.fullscreen && space !== toSpace) {
-                selected.clone.y = Main.panel.actor.height + Settings.prefs.vertical_margin;
+                selected.clone.y = Main.panel.height + Settings.prefs.vertical_margin;
             }
         });
     }
@@ -2027,7 +2027,7 @@ var Spaces = class Spaces extends Map {
         let selected = this.selectedSpace.selectedWindow;
         if (selected && selected.fullscreen) {
             Easer.addEase(selected.clone, {
-                y: Main.panel.actor.height + Settings.prefs.vertical_margin,
+                y: Main.panel.height + Settings.prefs.vertical_margin,
                 time: Settings.prefs.animation_time,
             });
         }
@@ -2169,7 +2169,7 @@ var Spaces = class Spaces extends Map {
             child !== sibling && cloneParent.set_child_below_sibling(child, sibling);
             let selected = space.selectedWindow;
             if (selected && selected.fullscreen) {
-                selected.clone.y = Main.panel.actor.height + Settings.prefs.vertical_margin;
+                selected.clone.y = Main.panel.height + Settings.prefs.vertical_margin;
             }
         });
 
@@ -2179,7 +2179,7 @@ var Spaces = class Spaces extends Map {
         let selected = space.selectedWindow;
         if (selected && selected.fullscreen) {
             Easer.addEase(selected.clone, {
-                y: Main.panel.actor.height + Settings.prefs.vertical_margin,
+                y: Main.panel.height + Settings.prefs.vertical_margin,
                 time: Settings.prefs.animation_time,
             });
         }

--- a/topbar.js
+++ b/topbar.js
@@ -728,9 +728,6 @@ function fixTopBar() {
     else if (normal && fullscreen) {
         panelBox.hide();
     }
-    else if (Tiling.inPreview) {
-        panelBox.hide();
-    }
     else {
         panelBox.scale_y = 1;
         panelBox.show();

--- a/topbar.js
+++ b/topbar.js
@@ -756,10 +756,8 @@ function fixFocusModeIcon() {
 */
 function updateWorkspaceIndicator(index) {
     let spaces = Tiling.spaces;
-    let space = spaces && spaces.spaceOf(workspaceManager.get_workspace_by_index(index));
-    let onMonitor = space && space.monitor === panelMonitor;
-    let nav = Navigator.navigator;
-    if (onMonitor || (Tiling.inPreview && nav && nav.from.monitor === panelMonitor)) {
+    let space = spaces?.spaceOf(workspaceManager.get_workspace_by_index(index));
+    if (space && space.monitor === panelMonitor) {
         setWorkspaceName(space.name);
 
         // also update focus mode

--- a/topbar.js
+++ b/topbar.js
@@ -764,6 +764,14 @@ function updateWorkspaceIndicator(index) {
     }
 }
 
+/**
+ * Refreshes topbar workspace indicator.
+ */
+function refreshWorkspaceIndicator() {
+    let panelSpace = Tiling.spaces.monitors.get(panelMonitor);
+    updateWorkspaceIndicator(panelSpace.workspace.index());
+}
+
 function setWorkspaceName (name) {
     menu && menu.setName(name);
 }

--- a/topbar.js
+++ b/topbar.js
@@ -731,6 +731,9 @@ function fixTopBar() {
     else if (normal && fullscreen) {
         panelBox.hide();
     }
+    else if (Tiling.inPreview) {
+        panelBox.hide();
+    }
     else {
         panelBox.scale_y = 1;
         panelBox.show();

--- a/topbar.js
+++ b/topbar.js
@@ -770,6 +770,7 @@ function setWorkspaceName (name) {
 
 function updateMonitor() {
     let primaryMonitor = Main.layoutManager.primaryMonitor;
+
     // if panelMonitor has changed, then update layouts on workspaces
     if (panelMonitor !== primaryMonitor) {
         Utils.later_add(Meta.LaterType.IDLE, () => {
@@ -782,5 +783,7 @@ function updateMonitor() {
             fixStyle();
         });
     }
+
+    // update topbar monitor
     panelMonitor = primaryMonitor;
 }


### PR DESCRIPTION
Fixes #565, #497.
May also fix #469, #391 (note I won't close these until we confirm this fixes these issues, which is may not...).

This PR fixes several multi-monitor issues, namely it:
- saves monitor/workspace layout and restores on unlock;
- fixes an issue where after unlock (on multi-monitor) the space topbar icons aren't showing;
- fixes an issue where the workspace name/number was incorrect on login with multi-monitors (previously it corrected itself once the mouse moved);
- fixes an issue where, for mismatched sized monitors, the `windowPositionBarBackdrop element is incorrectly sized (too short or too long);
- fixes an issue where the workspace indicator would be half-overwritten when stack workspace switching;
- ~~improves workspace switching (paperwm workspace stack switching) by hiding the topbar during switching view;~~.  So, I actually prefer NOT showing the topbar during PaperWM workplace switching - however, I recognise it's a bit of a change and I'm sure some users might like having it always shown.  In any case, I've restored it.  Later on I might add user preference option for this.