### PR TITLE
FIX: drag 'n' drop across multiple monitors / workspaces

### DIFF
--- a/navigator.js
+++ b/navigator.js
@@ -21,26 +21,15 @@ const Signals = imports.signals;
 const display = global.display;
 
 var navigating; // exported
-let grab, dispatcher, signals;
+let grab, dispatcher;
 function enable() {
     navigating = false;
-    signals = new Utils.Signals();
-    /**
-     * Clear navigation once out of overview. Avoids an issue most seen
-     * in multimonitors where coming out of overview and quickly clicking
-     * the background actor causes a monitor swtich.
-     */
-    signals.connect(Main.overview, 'hidden', () => {
-        finishNavigation();
-    });
 }
 
 function disable() {
     navigating = false;
     grab = null;
     dispatcher = null;
-    signals.destroy();
-    signals = null;
 }
 
 function dec2bin(dec) {

--- a/navigator.js
+++ b/navigator.js
@@ -21,15 +21,26 @@ const Signals = imports.signals;
 const display = global.display;
 
 var navigating; // exported
-let grab, dispatcher;
+let grab, dispatcher, signals;
 function enable() {
     navigating = false;
+    signals = new Utils.Signals();
+    /**
+     * Clear navigation once out of overview. Avoids an issue most seen
+     * in multimonitors where coming out of overview and quickly clicking
+     * the background actor causes a monitor swtich.
+     */
+    signals.connect(Main.overview, 'hidden', () => {
+        finishNavigation();
+    });
 }
 
 function disable() {
     navigating = false;
     grab = null;
     dispatcher = null;
+    signals.destroy();
+    signals = null;
 }
 
 function dec2bin(dec) {

--- a/navigator.js
+++ b/navigator.js
@@ -21,15 +21,29 @@ const Signals = imports.signals;
 const display = global.display;
 
 var navigating; // exported
-let grab, dispatcher;
+let grab, dispatcher, signals;
 function enable() {
     navigating = false;
+
+    /**
+     * Stop navigation before before/after overview. Avoids a corner-case issue
+     * in multimonitors where workspaces can get snapped to another monitor.
+     */
+    signals = new Utils.Signals();
+    signals.connect(Main.overview, 'showing', () => {
+        finishNavigation();
+    });
+    signals.connect(Main.overview, 'hidden', () => {
+        finishNavigation();
+    });
 }
 
 function disable() {
     navigating = false;
     grab = null;
     dispatcher = null;
+    signals.destroy();
+    signals = null;
 }
 
 function dec2bin(dec) {

--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -4,6 +4,7 @@ const Settings = Extension.imports.settings;
 const Utils = Extension.imports.utils;
 const Grab = Extension.imports.grab;
 const Tiling = Extension.imports.tiling;
+const Navigator = Extension.imports.navigator;
 
 const { Clutter, Shell, Meta, St } = imports.gi;
 const Main = imports.ui.main;
@@ -175,6 +176,11 @@ var ClickOverlay = class ClickOverlay {
     }
 
     select() {
+        /**
+         * stop navigation before activating workspace. Avoids an issue most seen
+         * in multimonitors where workspaces can get snapped to another monitor.
+         */
+        Navigator.finishNavigation();
         this.deactivate();
         let space = Tiling.spaces.monitors.get(this.monitor);
         space.workspace.activate(global.get_current_time());

--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -177,7 +177,7 @@ var ClickOverlay = class ClickOverlay {
 
     select() {
         /**
-         * stop navigation before activating workspace. Avoids an issue most seen
+         * stop navigation before activating workspace. Avoids an issue
          * in multimonitors where workspaces can get snapped to another monitor.
          */
         Navigator.finishNavigation();

--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -120,26 +120,6 @@ var ClickOverlay = class ClickOverlay {
 
         this._lastPointer = [];
         this._lastPointerTimeout = null;
-        /*
-        this.signals.connect(enterMonitor, 'motion-event', (actor, event) => {
-            // Changing monitors while in workspace preview doesn't work
-            if (Tiling.inPreview)
-                return;
-            let [x, y, z] = global.get_pointer();
-            let [lX, lY] = this._lastPointer;
-            this._lastPointer = [x, y];
-            this._lastPointerTimeout = Mainloop.timeout_add(500, () => {
-                this._lastPointer = [];
-                this._lastPointerTimeout = null;
-                return false; // on return false destroys timeout
-            });
-            if (lX === undefined ||
-                    Math.sqrt((lX - x) ** 2 + (lY - y) ** 2) < 10)
-                return;
-            this.select();
-            return Clutter.EVENT_STOP;
-        });
-        */
 
         this.signals.connect(enterMonitor, 'enter-event', () => {
             if (Tiling.inPreview)

--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -106,35 +106,32 @@ var ClickOverlay = class ClickOverlay {
 
         this._lastPointer = [];
         this._lastPointerTimeout = null;
-        this.signals.connect(
-            enterMonitor, 'motion-event',
-            (actor, event) => {
-                // Changing monitors while in workspace preview doesn't work
-                if (Tiling.inPreview)
-                    return;
-                let [x, y, z] = global.get_pointer();
-                let [lX, lY] = this._lastPointer;
-                this._lastPointer = [x, y];
-                this._lastPointerTimeout = Mainloop.timeout_add(500, () => {
-                    this._lastPointer = [];
-                    this._lastPointerTimeout = null;
-                    return false; // on return false destroys timeout
-                });
-                if (lX === undefined ||
+        this.signals.connect(enterMonitor, 'motion-event', (actor, event) => {
+            // Changing monitors while in workspace preview doesn't work
+            if (Tiling.inPreview)
+                return;
+            let [x, y, z] = global.get_pointer();
+            let [lX, lY] = this._lastPointer;
+            this._lastPointer = [x, y];
+            this._lastPointerTimeout = Mainloop.timeout_add(500, () => {
+                this._lastPointer = [];
+                this._lastPointerTimeout = null;
+                return false; // on return false destroys timeout
+            });
+            if (lX === undefined ||
                     Math.sqrt((lX - x) ** 2 + (lY - y) ** 2) < 10)
-                    return;
-                this.select();
-                return Clutter.EVENT_STOP;
-            }
+                return;
+            this.select();
+            return Clutter.EVENT_STOP;
+        }
         );
 
-        this.signals.connect(
-            enterMonitor, 'button-press-event', () => {
-                if (Tiling.inPreview)
-                    return;
-                this.select();
-                return Clutter.EVENT_STOP;
-            }
+        this.signals.connect(enterMonitor, 'button-press-event', () => {
+            if (Tiling.inPreview)
+                return;
+            this.select();
+            return Clutter.EVENT_STOP;
+        }
         );
 
         this.signals.connect(Main.overview, 'showing', () => {

--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -46,6 +46,31 @@ const Layout = imports.ui.layout;
 
 let monitorActiveTimeout;
 function enable() {
+
+}
+
+function disable() {
+    removeMonitorActiveTimeout();
+}
+
+function removeMonitorActiveTimeout () {
+    Utils.timeout_remove(monitorActiveTimeout);
+    monitorActiveTimeout = null;
+}
+
+/**
+ * Checks for multiple monitors and if so, then enables multimonitor
+ * drag/drop support in PaperWM.
+ */
+function multimonitorDragDropSupport() {
+    // remove current support (will add new if multimonitors)
+    removeMonitorActiveTimeout();
+
+    // if only one monitor, return
+    if (Tiling.spaces.monitors?.size <= 1) {
+        return;
+    }
+
     /*
     We monitor mouse position to pickup when monitor changes.  This approach
     was the only one found that also works for drag-n-drop cases (note for drag
@@ -65,11 +90,6 @@ function enable() {
         }
         return true;
     });
-}
-
-function disable() {
-    Utils.timeout_remove(monitorActiveTimeout);
-    monitorActiveTimeout = null;
 }
 
 function createAppIcon(metaWindow, size) {

--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -144,6 +144,8 @@ var ClickOverlay = class ClickOverlay {
         this.right = new StackOverlay(Meta.MotionDirection.RIGHT, monitor);
 
         let enterMonitor = new Clutter.Actor({ reactive: true });
+        enterMonitor.background_color = Clutter.color_from_string('green')[1];
+        enterMonitor.opacity = 100;
         this.enterMonitor = enterMonitor;
         enterMonitor.set_position(monitor.x, monitor.y);
 
@@ -175,8 +177,15 @@ var ClickOverlay = class ClickOverlay {
         });
         */
 
+        this.signals.connect(enterMonitor, 'enter-event', () => {
+            Utils.print_stacktrace(new Error('button press'));
+            if (Tiling.inPreview)
+                return;
+            this.select();
+        });
+
         this.signals.connect(enterMonitor, 'button-press-event', () => {
-            console.log('button-pressed');
+            Utils.print_stacktrace(new Error('button press'));
             if (Tiling.inPreview)
                 return;
             this.select();
@@ -197,16 +206,25 @@ var ClickOverlay = class ClickOverlay {
     }
 
     select() {
-        let space = Tiling.spaces.monitors.get(this.monitor);
-        console.log('active worksace', space.workspace.index());
-
         this.deactivate();
+        let space = Tiling.spaces.monitors.get(this.monitor);
+
+        Utils.print_stacktrace(new Error(`activate workspace' ${space.workspace.index()}`));
+        space.workspace.activate(global.get_current_time());
+        /**
+         * calling explicit switchWorkspace here since selecting same workspace doesn't
+         * fire switch-workspace signal again.
+         */
+        /*
+        let workspaceId = space.workspace.index();
+        Tiling.spaces.switchWorkspace(null, workspaceId, workspaceId);
+        space.moveDone();
+
         if (space.selectedWindow) {
-            space.workspace.activate_with_focus(space.selectedWindow, global.get_current_time());
+            Utils.print_stacktrace(new Error(`ensureViewport on' ${space.selectedWindow.title}`));
+            Tiling.ensureViewport(space.selectedWindow, space);
         }
-        else {
-            space.workspace.activate(global.get_current_time());
-        }
+        */
     }
 
     activate() {

--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -51,7 +51,7 @@ function enable() {
     was the only one found that also works for drag-n-drop cases (note for drag
     none for signals fire when in drag phase).
     */
-    monitorActiveTimeout = Mainloop.timeout_add(100, () => {
+    monitorActiveTimeout = Mainloop.timeout_add(200, () => {
         if (Tiling.inPreview) {
             return true;
         }

--- a/tiling.js
+++ b/tiling.js
@@ -1376,7 +1376,9 @@ border-radius: ${borderWidth}px;
                 }
 
                 spaces.selectedSpace = this;
-                Navigator.getNavigator().finish();
+                Utils.later_add(Meta.LaterType.BEFORE_REDRAW, () => {
+                    Navigator.getNavigator().finish();
+                });
             });
 
         this.signals.connect(

--- a/tiling.js
+++ b/tiling.js
@@ -10,7 +10,8 @@ const Grab = Extension.imports.grab;
 const TopBar = Extension.imports.topbar;
 const Scratch = Extension.imports.scratch;
 const Easer = Extension.imports.utils.easer;
-const ClickOverlay = Extension.imports.stackoverlay.ClickOverlay;
+const StackOverlay = Extension.imports.stackoverlay;
+const ClickOverlay = StackOverlay.ClickOverlay;
 
 const { Clutter, St, Graphene, Meta, Gio, GDesktopEnums } = imports.gi;
 const Main = imports.ui.main;
@@ -1723,6 +1724,7 @@ var Spaces = class Spaces extends Map {
                 });
 
             activeSpace.monitor.clickOverlay.deactivate();
+            StackOverlay.multimonitorDragDropSupport();
         };
 
         if (this.onlyOnPrimary) {

--- a/tiling.js
+++ b/tiling.js
@@ -3321,7 +3321,7 @@ function getDefaultFocusMode() {
 
 // `MetaWindow::focus` handling
 function focus_handler(metaWindow, user_data) {
-    debug("focus:", metaWindow.title, Utils.framestr(metaWindow.get_frame_rect()));
+    console.debug("focus:", metaWindow.title, Utils.framestr(metaWindow.get_frame_rect()));
     if (Scratch.isScratchWindow(metaWindow)) {
         setAllWorkspacesInactive();
         Scratch.makeScratch(metaWindow);

--- a/tiling.js
+++ b/tiling.js
@@ -1376,9 +1376,7 @@ border-radius: ${borderWidth}px;
                 }
 
                 spaces.selectedSpace = this;
-                Utils.later_add(Meta.LaterType.BEFORE_REDRAW, () => {
-                    Navigator.finishNavigation();
-                });
+                Navigator.finishNavigation();
             });
 
         this.signals.connect(

--- a/tiling.js
+++ b/tiling.js
@@ -1377,7 +1377,7 @@ border-radius: ${borderWidth}px;
 
                 spaces.selectedSpace = this;
                 Utils.later_add(Meta.LaterType.BEFORE_REDRAW, () => {
-                    Navigator.getNavigator().finish();
+                    Navigator.finishNavigation();
                 });
             });
 

--- a/utils.js
+++ b/utils.js
@@ -21,7 +21,7 @@ function debug() {
 
 function assert(condition, message, ...dump) {
     if (!condition) {
-        throw new Error(message + "\n", dump);
+        throw new Error(`${message}\n`, dump);
     }
 }
 
@@ -29,20 +29,20 @@ function withTimer(message, fn) {
     let start = GLib.get_monotonic_time();
     let ret = fn();
     let stop = GLib.get_monotonic_time();
-    console.debug(`${message} ${((stop - start)/1000).toFixed(1)}ms`);
+    console.debug(`${message} ${((stop - start) / 1000).toFixed(1)}ms`);
 }
 
 function print_stacktrace(error) {
     let trace;
     if (!error) {
-        trace = (new Error()).stack.split("\n");
+        trace = new Error().stack.split("\n");
         // Remove _this_ frame
         trace.splice(0, 1);
     } else {
         trace = error.stack.split("\n");
     }
     // Remove some uninteresting frames
-    let filtered = trace.filter((frame) => {
+    let filtered = trace.filter(frame => {
         return frame !== "wrapper@resource:///org/gnome/gjs/modules/lang.js:178";
     });
     console.error(`JS ERROR: ${error}\n ${trace.join('\n')}`);
@@ -57,7 +57,7 @@ function prettyPrintToLog(...args) {
 }
 
 function framestr(rect) {
-    return "[ x:"+rect.x + ", y:" + rect.y + " w:" + rect.width + " h:"+rect.height + " ]";
+    return `[ x:${rect.x}, y:${rect.y} w:${rect.width} h:${rect.height} ]`;
 }
 
 /**
@@ -66,9 +66,9 @@ function framestr(rect) {
 function ppEnumValue(value, genum) {
     let entry = Object.entries(genum).find(([k, v]) => v === value);
     if (entry) {
-        return `${entry[0]} (${entry[1]})`
+        return `${entry[0]} (${entry[1]})`;
     } else {
-        return `<not-found> (${value})`
+        return `<not-found> (${value})`;
     }
 }
 
@@ -91,12 +91,12 @@ function dynamic_function_ref(handler_name, owner_obj) {
     owner_obj = owner_obj || window;
     return function() {
         owner_obj[handler_name].apply(this, arguments);
-    }
+    };
 }
 
 function isPointInsideActor(actor, x, y) {
-    return (actor.x <= x && x <= actor.x+actor.width)
-        && (actor.y <= y && y <= actor.y+actor.height);
+    return (actor.x <= x && x <= actor.x + actor.width) &&
+        (actor.y <= y && y <= actor.y + actor.height);
 }
 
 function setBackgroundImage(actor, resource_path) {
@@ -116,7 +116,7 @@ function setBackgroundImage(actor, resource_path) {
 }
 
 
-//// Debug and development utils
+// // Debug and development utils
 
 /**
  * Visualize the frame and buffer bounding boxes of a meta window
@@ -124,7 +124,7 @@ function setBackgroundImage(actor, resource_path) {
 function toggleWindowBoxes(metaWindow) {
     metaWindow = metaWindow || display.focus_window;
 
-    if(metaWindow._paperDebugBoxes) {
+    if (metaWindow._paperDebugBoxes) {
         metaWindow._paperDebugBoxes.forEach(box => {
             box.destroy();
         });
@@ -132,25 +132,25 @@ function toggleWindowBoxes(metaWindow) {
         return [];
     }
 
-    let frame = metaWindow.get_frame_rect()
-    let inputFrame = metaWindow.get_buffer_rect()
+    let frame = metaWindow.get_frame_rect();
+    let inputFrame = metaWindow.get_buffer_rect();
     let actor = metaWindow.get_compositor_private();
 
-    makeFrameBox = function({x, y, width, height}, color) {
+    makeFrameBox = function({ x, y, width, height }, color) {
         let frameBox = new St.Widget();
-        frameBox.set_position(x, y)
-        frameBox.set_size(width, height)
-        frameBox.set_style("border: 2px" + color + " solid");
+        frameBox.set_position(x, y);
+        frameBox.set_size(width, height);
+        frameBox.set_style(`border: 2px${color} solid`);
         return frameBox;
-    }
+    };
 
     let boxes = [];
 
     boxes.push(makeFrameBox(frame, "red"));
     boxes.push(makeFrameBox(inputFrame, "blue"));
 
-    if(inputFrame.x !== actor.x || inputFrame.y !== actor.y
-       || inputFrame.width !== actor.width || inputFrame.height !== actor.height) {
+    if (inputFrame.x !== actor.x || inputFrame.y !== actor.y ||
+       inputFrame.width !== actor.width || inputFrame.height !== actor.height) {
         boxes.push(makeFrameBox(actor, "yellow"));
     }
 
@@ -187,7 +187,7 @@ function toggleCloneMarks() {
         windows.forEach(unmarkCloneOf);
     } else {
         markNewClonesSignalId = display.connect_after(
-            "window-created", (_, mw) => markCloneOf(mw))
+            "window-created", (_, mw) => markCloneOf(mw));
 
         windows.forEach(markCloneOf);
     }
@@ -210,8 +210,8 @@ function getModiferState() {
 function monitorOfPoint(x, y) {
     // get_monitor_index_for_rect "helpfully" returns the primary monitor index for out of bounds rects..
     for (let monitor of Main.layoutManager.monitors) {
-        if ((monitor.x <= x && x <= monitor.x+monitor.width) &&
-            (monitor.y <= y && y <= monitor.y+monitor.height))
+        if ((monitor.x <= x && x <= monitor.x + monitor.width) &&
+            (monitor.y <= y && y <= monitor.y + monitor.height))
         {
             return monitor;
         }
@@ -235,24 +235,24 @@ function mkFmt({ nameOnly } = { nameOnly: false }) {
         const extraStr = extra.join(" | ");
         let actorId = "";
         if (nameOnly) {
-            actorId = actor.name ? actor.name : (prefix.length == 0 ? "" : "#")
+            actorId = actor.name ? actor.name : prefix.length == 0 ? "" : "#";
         } else {
             actorId = actor.toString();
         }
-        actorId = prefix+actorId
-        let spacing = actorId.length > 0 ? " " : ""
+        actorId = prefix + actorId;
+        let spacing = actorId.length > 0 ? " " : "";
         return `*${spacing}${actorId} ${extraStr}`;
     }
     return defaultFmt;
 }
 
-function printActorTree(node, fmt=mkFmt(), options={}, state=null) {
-    state = Object.assign({}, (state || {level: 0, actorPrefix: ""}))
+function printActorTree(node, fmt = mkFmt(), options = {}, state = null) {
+    state = Object.assign({}, state || { level: 0, actorPrefix: "" });
     const defaultOptions = {
         limit: 9999,
         collapseChains: true,
     };
-    options = Object.assign(defaultOptions, options)
+    options = Object.assign(defaultOptions, options);
 
     if (state.level > options.limit) {
         return;
@@ -268,13 +268,13 @@ function printActorTree(node, fmt=mkFmt(), options={}, state=null) {
               u
           ->
           a.b.s
-          a.b.t 
+          a.b.t
           a.b.c ...
             u
         */
         if (node.get_children().length > 0) {
             if (node.x === 0 && node.y === 0) {
-                state.actorPrefix += (node.name ? node.name : "#") + ".";
+                state.actorPrefix += `${node.name ? node.name : "#"}.`;
                 collapse = true;
             } else {
                 collapse = false;
@@ -290,7 +290,7 @@ function printActorTree(node, fmt=mkFmt(), options={}, state=null) {
     }
 
     for (let child of node.get_children()) {
-        printActorTree(child, fmt, options, state)
+        printActorTree(child, fmt, options, state);
     }
 }
 
@@ -320,7 +320,7 @@ var Signals = class Signals extends Map {
         return id;
     }
 
-    disconnect(object, id=null) {
+    disconnect(object, id = null) {
         let ids = this.get(object);
         if (ids) {
             if (id === null) {
@@ -375,17 +375,17 @@ function isMetaWindow(obj) {
     return obj && obj.window_type && obj.get_compositor_private;
 }
 
-function shortTrace(skip=0) {
+function shortTrace(skip = 0) {
     let trace = new Error().stack.split("\n").map(s => {
-        let words = s.split(/[@/]/)
-        let cols = s.split(":")
-        let ln = parseInt(cols[2])
+        let words = s.split(/[@/]/);
+        let cols = s.split(":");
+        let ln = parseInt(cols[2]);
         if (ln === null)
-            ln = "?"
+            ln = "?";
 
-        return [words[0], ln]
+        return [words[0], ln];
     });
-    trace = trace.filter(([f, ln]) => f !== "dynamic_function_ref").map(([f, ln]) => f === "" ? "?" : f + ":" + ln);
+    trace = trace.filter(([f, ln]) => f !== "dynamic_function_ref").map(([f, ln]) => f === "" ? "?" : `${f}:${ln}`);
     return trace.slice(skip + 1, skip + 5);
 }
 


### PR DESCRIPTION
Fixes #559 #401.

_I believe this PR should also fix #469 - noticed this issue while working on this PR, in which the workspace would get snapped onto another monitor._

This PR overcomes the drag 'n' drop issue across monitors.  PaperWM uses (invisible) `ClickOverlay`'s to detect when the mouse cursor moves to another monitor.  On this detection, the `ClickOverlay` actor is disabled.  This functionality is responsible for focus switching to another monitor's workspace.

However, when dragging and dropping something, signals are not sent (specific behaviour in gnome for drag/drop, e.g. see [gnome-shell](https://gitlab.gnome.org/GNOME/gnome-shell/-/blame/main/js/ui/dnd.js#L54).  This causes the ClickOverlay to not disable - which means there's actually still an actor layer between the dragged object and it's intended target.  This layer completely blocks drag/drop operations.

Unfortunately, due to no signals being sent, we can't detect a focus switch to another monitor during drag/drop operations via signals.

~~The approach here set's an monitor check in the mainloop that periodically checks the mouse position, gets the associated `ClickOverlay` and deactivates it (removing the obstructing layer) - allow drag/drop to now be effective.~~

The approach here uses gnome's `PointerWatcher` to more efficiently track pointer movements, including drag/drop movements across monitors.