### PR TITLE
Improvements to multi-monitor behaviour 2

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -262,7 +262,7 @@
               </object>
             </child>
             <child>
-              <object class="GtkListBoxRow" id="general_row_4">
+              <object class="GtkListBoxRow">
                 <property name="activatable">False</property>
                 <property name="focusable">False</property>
                 <property name="tooltip_text" translatable="yes">Semicolon separated values of "useful window widths" that will be cycled through. Values types can be either percentage (of available screen width), e.g. "50%" or pixel values, e.g. "500px". Mixed value types are not supported.</property>
@@ -316,7 +316,7 @@
               </object>
             </child>
             <child>
-              <object class="GtkListBoxRow" id="general_row_5">
+              <object class="GtkListBoxRow">
                 <property name="activatable">False</property>
                 <property name="focusable">False</property>
                 <property name="tooltip_text" translatable="yes">Semicolon separated values of "useful window heights" that will be cycled through. Values types can be either percentage (of available screen width), e.g. "50%" or pixel values, e.g. "500px". Mixed value types are not supported.</property>
@@ -804,6 +804,47 @@
                           <property name="column">1</property>
                           <property name="row">0</property>
                         </layout>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkListBoxRow">
+                <property name="activatable">False</property>
+                <property name="focusable">False</property>
+                <property name="tooltip_text" translatable="yes">Resets workspace names to default.</property>
+                <child>
+                  <object class="GtkGrid">
+                    <property name="focusable">False</property>
+                    <property name="margin_start">12</property>
+                    <property name="margin_end">12</property>
+                    <property name="margin_top">6</property>
+                    <property name="margin_bottom">6</property>
+                    <property name="column_spacing">32</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="focusable">False</property>
+                        <property name="hexpand">1</property>
+                        <property name="label" translatable="yes">Reset workspace names</property>
+                        <property name="xalign">0</property>
+                        <layout>
+                          <property name="column">0</property>
+                          <property name="row">0</property>
+                        </layout>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="workspace_reset_button">
+                        <property name="label">Reset</property>
+                        <layout>
+                          <property name="column">2</property>
+                          <property name="row">0</property>
+                        </layout>
+                        <style>
+                          <class name="destructive-action" />
+                        </style>
                       </object>
                     </child>
                   </object>

--- a/kludges.js
+++ b/kludges.js
@@ -359,11 +359,10 @@ function setupActions() {
 }
 
 let savedProps;
-let gsettings, wmSettings, mutterSettings;
+let gsettings, mutterSettings;
 function enable() {
     savedProps = new Map();
     gsettings = ExtensionUtils.getSettings();
-    wmSettings = new Gio.Settings({ schema_id: 'org.gnome.desktop.wm.preferences' });
     mutterSettings = new Gio.Settings({ schema_id: 'org.gnome.mutter' });
     setupSwipeTrackers();
     setupOverrides();
@@ -385,7 +384,6 @@ function disable() {
     savedProps = null;
     swipeTrackers = null;
     gsettings = null;
-    wmSettings = null;
     mutterSettings = null;
     actions = null;
 }

--- a/kludges.js
+++ b/kludges.js
@@ -205,7 +205,11 @@ function setupOverrides() {
             return !Scratch.isScratchWindow(metaWindow) && !metaWindow.skip_taskbar;
     });
 
-    // always show workspaces thumbnails if more than one workspace
+    /**
+     * Always show workspace thumbnails in overview if more than one workspace.
+     * See original function at:
+     * https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/gnome-44/js/ui/workspaceThumbnail.js#L690
+     */
     registerOverridePrototype(ThumbnailsBox, '_updateShouldShow',
         function () {
             const { nWorkspaces } = global.workspace_manager;

--- a/kludges.js
+++ b/kludges.js
@@ -16,6 +16,7 @@ const Main = imports.ui.main;
 const Workspace = imports.ui.workspace;
 const WindowManager = imports.ui.windowManager;
 const WorkspaceAnimation = imports.ui.workspaceAnimation;
+const ThumbnailsBox = imports.ui.workspaceThumbnail.ThumbnailsBox;
 const Mainloop = imports.mainloop;
 const Params = imports.misc.params;
 
@@ -203,6 +204,19 @@ function setupOverrides() {
         if (gsettings.get_boolean('disable-scratch-in-overview'))
             return !Scratch.isScratchWindow(metaWindow) && !metaWindow.skip_taskbar;
     });
+
+    // always show workspaces thumbnails if more than one workspace
+    registerOverridePrototype(ThumbnailsBox, '_updateShouldShow',
+        function () {
+            const { nWorkspaces } = global.workspace_manager;
+            const shouldShow = nWorkspaces > 1;
+
+            if (this._shouldShow === shouldShow)
+                return;
+
+            this._shouldShow = shouldShow;
+            this.notify('should-show');
+        });
 }
 
 /**

--- a/prefs.js
+++ b/prefs.js
@@ -232,8 +232,6 @@ var SettingsWidget = class SettingsWidget {
 
         const workspaceCombo = this.builder.get_object('workspace_combo_text');
         const workspaceStack = this.builder.get_object('workspace_stack');
-
-        this.workspaceNames = wmSettings.get_strv('workspace-names');
         const nWorkspaces = Workspace.getWorkspaceList().get_strv('list').length;
 
         // Note: For some reason we can't set the visible child of the workspace
@@ -448,11 +446,10 @@ var SettingsWidget = class SettingsWidget {
     }
 
     getWorkspaceName(settings, index) {
-        let name = settings.get_string('name');
-        if (name === '')
-            name = this.workspaceNames[index];
-        if (name === undefined)
+        let name = settings.get_string('name') ?? `Workspace ${index + 1}`;
+        if (!name || name === '') {
             name = `Workspace ${index + 1}`;
+        }
         return name;
     }
 };

--- a/prefs.js
+++ b/prefs.js
@@ -446,11 +446,7 @@ var SettingsWidget = class SettingsWidget {
     }
 
     getWorkspaceName(settings, index) {
-        let name = settings.get_string('name') ?? `Workspace ${index + 1}`;
-        if (!name || name === '') {
-            name = `Workspace ${index + 1}`;
-        }
-        return name;
+        return Workspace.getWorkspaceName(settings, index);
     }
 };
 

--- a/tiling.js
+++ b/tiling.js
@@ -1111,8 +1111,7 @@ var Space = class Space extends Array {
         }
         this.updateName();
         this.updateShowTopBar();
-        this.signals.connect(this.settings, 'changed::name',
-            this.updateName.bind(this));
+        this.signals.connect(this.settings, 'changed::name', this.updateName.bind(this));
         this.signals.connect(gsettings, 'changed::use-workspace-name',
             this.updateName.bind(this));
         this.signals.connect(this.settings, 'changed::color',
@@ -1216,9 +1215,7 @@ border-radius: ${borderWidth}px;
         } else {
             this.workspaceLabel.hide();
         }
-        let name = this.settings.get_string('name');
-        if (name === '')
-            name = Meta.prefs_get_workspace_name(this.index);
+        let name = Workspace.getWorkspaceName(this.settings, this.index);
         Meta.prefs_change_workspace_name(this.index, name);
         this.workspaceLabel.text = name;
         this.name = name;
@@ -1360,6 +1357,7 @@ border-radius: ${borderWidth}px;
      * @param {boolean} show
      */
     showWorkspaceIndicator(show = true) {
+        this.updateName();
         if (show && Settings.prefs.show_workspace_indicator) {
             Utils.actor_raise(this.workspaceIndicator);
             this.workspaceIndicator.show();

--- a/tiling.js
+++ b/tiling.js
@@ -1726,7 +1726,6 @@ var Spaces = class Spaces extends Map {
      */
     monitorsChanged() {
         this.onlyOnPrimary = this.overrideSettings.get_boolean('workspaces-only-on-primary');
-        saveState.update();
         this.monitors = new Map();
         this.activeSpace.getWindows().forEach(w => {
             animateWindow(w);

--- a/tiling.js
+++ b/tiling.js
@@ -1726,7 +1726,7 @@ var Spaces = class Spaces extends Map {
      */
     monitorsChanged() {
         this.onlyOnPrimary = this.overrideSettings.get_boolean('workspaces-only-on-primary');
-
+        saveState.update();
         this.monitors = new Map();
         this.activeSpace.getWindows().forEach(w => {
             animateWindow(w);
@@ -2951,7 +2951,7 @@ let SaveState = class SaveState {
         /**
          * For monitors, since these are upgraded with "connector" field,
          * which we delete on disable. Beefore we delete this field, we want
-         * a copy on connector (and maybe index) to restore space to monitor.
+         * a copy on connector (and index) to restore space to monitor.
          */
         if (spaces?.monitors) {
             for (let [monitor, space] of spaces.monitors) {
@@ -2962,7 +2962,9 @@ let SaveState = class SaveState {
         // store space targetx values
         this.prevTargetX = new Map();
         spaces.forEach(s => {
-            this.prevTargetX.set(s.index, s.targetX);
+            if (s.getWindows().length > 0 && s.targetX !== 0) {
+                this.prevTargetX.set(s.index, s.targetX);
+            }
         });
 
         // save spaces (for window restore)

--- a/workspace.js
+++ b/workspace.js
@@ -35,6 +35,13 @@ function getSchemaSource() {
     return schemaSource;
 }
 
+function getWorkspaceName(settings, index) {
+    let name = settings.get_string('name') ?? `Workspace ${index + 1}`;
+    if (!name || name === '') {
+        name = `Workspace ${index + 1}`;
+    }
+    return name;
+}
 
 function getWorkspaceList() {
     return workspaceList;


### PR DESCRIPTION
This PR is a continuation of #577 and #582.

It adds:
 - a workspace names "Reset" button to PaperWM workspace settings.  There were several issues with dynamic workspaces in previous versions of PaperWM.  These issues resulted in spawning multiple identical workspaces names.  This reset button can help in such situations by setting workspace names to their defaults;
 - now even with dynamic workspaces, always show overview workspace thumbnails if more than one workspace.