### PR TITLE
Fix 589 minimap reset bug

### DIFF
--- a/navigator.js
+++ b/navigator.js
@@ -300,7 +300,7 @@ class NavigatorClass {
             });
             this.minimaps.set(space, minimapId);
         } else {
-            typeof  minimap !== 'number' && minimap.show();
+            typeof minimap !== 'number' && minimap.show();
         }
     }
 
@@ -317,10 +317,12 @@ class NavigatorClass {
 
     destroy(space, focus) {
         this.minimaps.forEach(m => {
-            if (typeof  m === 'number')
+            if (typeof  m === 'number') {
                 Mainloop.source_remove(m);
-            else
+            }
+            else {
                 m.destroy();
+            }
         });
 
         if (Tiling.inGrab && !Tiling.inGrab.dnd) {

--- a/tiling.js
+++ b/tiling.js
@@ -2754,7 +2754,7 @@ function destroyHandler(actor) {
 function resizeHandler(metaWindow) {
     // if navigator is showing, reset/refresh it after a window has resized
     if (Navigator.navigating) {
-        Navigator.getNavigator().minimaps.forEach(m => m.reset());
+        Navigator.getNavigator().minimaps.forEach(m => typeof m !== 'number' && m.reset());
     }
 
     if (inGrab && inGrab.window === metaWindow)


### PR DESCRIPTION
Fixes #589.

Thanks @YaLTeR - was missing a type check.  Looks like a corner-case timing issue with minimap elements disappearing when resizing.

Type check added which should fix this bug.