### PR TITLE
fix: Warp pointer to a proportional location in the other monitor

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -249,11 +249,12 @@ function warpPointerToMonitor(monitor, center = false) {
         return;
     }
 
-    let normX = x - currMonitor.x;
-    let normY = y - currMonitor.y;
+    let proportionalX = (x - currMonitor.x) / currMonitor.width;
+    let proportionalY = (y - currMonitor.y) / currMonitor.height;
     warpPointer(
-        monitor.x + normX,
-        monitor.y + normY);
+        monitor.x + Math.floor(proportionalX * monitor.width),
+        monitor.y + Math.floor(proportionalY * monitor.height)
+    );
 }
 
 /**


### PR DESCRIPTION
When switching focus between monitors using the /Switch to the {left,right,above,below} monitor/ keybindings, the pointer may be left in a weird location when screens are of different sizes.

Consider two monitors, side by side:
- Monitor 1: 2560x1080, top/leftmost pixel placed at virtual location 0, 0
- Monitor 2: 1920x1080, top/leftmost pixel placed at virtual location 2560, 0

```
      +-----------------------------+-----------------+
      |                             |                 |
      |                             |                 |
      |  MONITOR 1             .    |  MONITOR 2      |
      |                             |                 |
      |                             |                 |
      +-----------------------------+-----------------+

      ^                             ^                 ^
      |                             |                 |
    x: 0                          x: 2560           x: 4479
```

When the pointer is at the monitor 1 at any (virtual) position left of 1920 (say 2000, 500 -- marked as a dot above), the original code would try to place the cursor at 4560, 500 -- thats past the virtual screen last horizontal pixel.

As a result, the pointer would be left somewhere near x=2559. This would result in the cursor remaining in the monitor 1 and the focus being lost, requiring mouse movements to make the focus fall back to some active window.

This commit changes the code to compute a /proportional position/ in the original monitor (2000/2560 = 78%) and then moving the pointer that same proportional position in the target monitor (78% * 1920 = 1487 pixels left of 2560 = 4047).