### PR TITLE
Fix scratch windows in overview (currently not showing and not respecting settings)

### DIFF
--- a/patches.js
+++ b/patches.js
@@ -11,13 +11,12 @@ const Utils = Extension.imports.utils;
 const Tiling = Extension.imports.tiling;
 const Scratch = Extension.imports.scratch;
 
-const { Meta, Gio, Clutter, Shell } = imports.gi;
+const { Meta, Gio, Shell } = imports.gi;
 const Main = imports.ui.main;
 const Workspace = imports.ui.workspace;
 const WorkspaceThumbnail = imports.ui.workspaceThumbnail;
 const WorkspaceAnimation = imports.ui.workspaceAnimation;
 const WindowManager = imports.ui.windowManager;
-const Mainloop = imports.mainloop;
 const Params = imports.misc.params;
 
 function registerOverrideProp(obj, name, override) {
@@ -103,9 +102,7 @@ function setupOverrides() {
 
     registerOverridePrototype(WorkspaceAnimation.WorkspaceAnimationController, '_prepareWorkspaceSwitch',
         function (workspaceIndices) {
-            const saved = getSavedPrototype(
-                WorkspaceAnimation.WorkspaceAnimationController,
-                '_prepareWorkspaceSwitch');
+            const saved = getSavedPrototype(WorkspaceAnimation.WorkspaceAnimationController, '_prepareWorkspaceSwitch');
             // hide selection during workspace switch
             Tiling.spaces.forEach(s => s.hideSelection());
             saved.call(this, workspaceIndices);
@@ -113,9 +110,7 @@ function setupOverrides() {
 
     registerOverridePrototype(WorkspaceAnimation.WorkspaceAnimationController, '_finishWorkspaceSwitch',
         function (switchData) {
-            const saved = getSavedPrototype(
-                WorkspaceAnimation.WorkspaceAnimationController,
-                '_finishWorkspaceSwitch');
+            const saved = getSavedPrototype(WorkspaceAnimation.WorkspaceAnimationController, '_finishWorkspaceSwitch');
             // ensure selection is shown after workspaces swtching
             Tiling.spaces.forEach(s => s.showSelection());
             saved.call(this, switchData);
@@ -134,14 +129,14 @@ function setupOverrides() {
     registerOverridePrototype(Workspace.UnalignedLayoutStrategy, '_sortRow', row => row);
     registerOverridePrototype(Workspace.UnalignedLayoutStrategy, 'computeLayout', computeLayout40);
     registerOverridePrototype(Workspace.Workspace, '_isOverviewWindow', win => {
-        const metaWindow = win.meta_window ?? win;
-        if (!metaWindow) {
-            return !win.skip_taskbar;
-        }
+        win = win.meta_window ?? win; // should be metawindow, but get if not
+        // upstream (gnome value result - whta it would have done)
+        const saved = getSavedPrototype(Workspace.Workspace, '_isOverviewWindow');
+        const upstreamValue = saved?.call(this, win) ?? !win.skip_taskbar;
 
-        if (Scratch.isScratchWindow(metaWindow)) {
+        if (Scratch.isScratchWindow(win)) {
             if (gsettings.get_boolean('only-scratch-in-overview')) {
-                return true;
+                return upstreamValue;
             }
 
             if (gsettings.get_boolean('disable-scratch-in-overview')) {
@@ -153,12 +148,23 @@ function setupOverrides() {
         if (gsettings.get_boolean('only-scratch-in-overview')) {
             return false;
         }
-        else {
-            return true;
-        }
+
+        return upstreamValue;
     });
 
+    const checkScratch = (metaWindow, metaWorkspace) => {
+        if (Scratch.isScratchWindow(metaWindow)) {
+            // check workspace match
+            return metaWorkspace === metaWindow?.get_workspace();
+        }
+
+        return false;
+    };
     registerOverridePrototype(Workspace.Workspace, '_isMyWindow', function(window) {
+        if (checkScratch(window, this.metaWorkspace)) {
+            return true;
+        }
+
         const space = Tiling.spaces.spaceOf(this.metaWorkspace);
         const onSpace = space.indexOf(window) >= 0;
         const onMonitor = this._monitor === space.monitor;
@@ -166,6 +172,10 @@ function setupOverrides() {
     });
     registerOverridePrototype(WorkspaceThumbnail.WorkspaceThumbnail, '_isMyWindow', function(actor) {
         const window = actor.meta_window;
+        if (checkScratch(actor, this.metaWorkspace)) {
+            return true;
+        }
+
         const space = Tiling.spaces.spaceOf(this.metaWorkspace);
         const onSpace = space.indexOf(window) >= 0;
         const onMonitor = this.monitorIndex === space.monitor.index;
@@ -299,23 +309,6 @@ function setupSwipeTrackers() {
     ].filter(t => typeof t !== 'undefined');
 }
 
-let signals;
-function setupSignals() {
-    signals = new Utils.Signals();
-    let scratchInOverview = () => {
-        let onlyScratch = gsettings.get_boolean('only-scratch-in-overview');
-        let disableScratch = gsettings.get_boolean('disable-scratch-in-overview');
-        if (onlyScratch || disableScratch) {
-            enableOverride(Workspace.Workspace.prototype, '_isOverviewWindow');
-        } else {
-            disableOverride(Workspace.Workspace.prototype, '_isOverviewWindow');
-        }
-    };
-    signals.connect(gsettings, 'changed::only-scratch-in-overview', scratchInOverview);
-    signals.connect(gsettings, 'changed::disable-scratch-in-overview', scratchInOverview);
-    scratchInOverview();
-}
-
 let actions;
 function setupActions() {
     /*
@@ -332,17 +325,17 @@ function setupActions() {
     actions.forEach(a => global.stage.remove_action(a));
 }
 
-let savedProps;
+let savedProps, signals;
 let gsettings, mutterSettings;
 function enable() {
     savedProps = new Map();
     gsettings = ExtensionUtils.getSettings();
     mutterSettings = new Gio.Settings({ schema_id: 'org.gnome.mutter' });
+    signals = new Utils.Signals();
     setupSwipeTrackers();
     setupOverrides();
     enableOverrides();
     setupRuntimeDisables();
-    setupSignals();
     setupActions();
 }
 

--- a/patches.js
+++ b/patches.js
@@ -172,7 +172,7 @@ function setupOverrides() {
     });
     registerOverridePrototype(WorkspaceThumbnail.WorkspaceThumbnail, '_isMyWindow', function(actor) {
         const window = actor.meta_window;
-        if (checkScratch(actor, this.metaWorkspace)) {
+        if (checkScratch(window, this.metaWorkspace)) {
             return true;
         }
 


### PR DESCRIPTION
Fixes #601.

This PR fixes an issue that caused scratch windows to not show in overview (and logic to address user preferred settings for this was broken).