### PR TITLE
Fix gnome pill (indicator) workspace switch animation and improve PaperWM switching animations

### DIFF
--- a/patches.js
+++ b/patches.js
@@ -136,13 +136,19 @@ export function setupOverrides() {
         // WorkspaceAnimation.WorkspaceAnimationController.animateSwitch
         // Disable the workspace switching animation in Gnome 40+
         function (_from, _to, _direction, onComplete) {
-            onComplete();
+            // if using PaperWM workspace switch animation, just do complete here
+            if (Tiling.spaces.space_activate_animate) {
+                onComplete();
+            }
+            else {
+                const saved = getSavedPrototype(WorkspaceAnimation.WorkspaceAnimationController, 'animateSwitch');
+                saved.call(this, _from, _to, _direction, onComplete);
+            }
         });
 
     registerOverridePrototype(WorkspaceAnimation.WorkspaceAnimationController, '_prepareWorkspaceSwitch',
         function (workspaceIndices) {
-            const saved = getSavedPrototype(WorkspaceAnimation.WorkspaceAnimationController,
-                '_prepareWorkspaceSwitch');
+            const saved = getSavedPrototype(WorkspaceAnimation.WorkspaceAnimationController, '_prepareWorkspaceSwitch');
             // hide selection during workspace switch
             Tiling.spaces.forEach(s => s.hideSelection());
             saved.call(this, workspaceIndices);

--- a/patches.js
+++ b/patches.js
@@ -3,6 +3,8 @@ import Gio from 'gi://Gio';
 import Meta from 'gi://Meta';
 import Shell from 'gi://Shell';
 import St from 'gi://St';
+import GLib from 'gi://GLib';
+
 
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as Workspace from 'resource:///org/gnome/shell/ui/workspace.js';
@@ -24,6 +26,7 @@ import { Utils, Tiling, Scratch, Settings } from './imports.js';
 
 let savedProps, signals;
 let gsettings, mutterSettings;
+let pillSwipeTimer;
 export function enable(extension) {
     savedProps = new Map();
     gsettings = extension.getSettings();
@@ -49,6 +52,7 @@ export function disable() {
     swipeTrackers = null;
     gsettings = null;
     mutterSettings = null;
+    pillSwipeTimer = null;
     actions = null;
 }
 
@@ -144,6 +148,13 @@ export function setupOverrides() {
                 const saved = getSavedPrototype(WorkspaceAnimation.WorkspaceAnimationController, 'animateSwitch');
                 saved.call(this, _from, _to, _direction, onComplete);
             }
+
+            // ensure swipeTrackers are disabled after this
+            pillSwipeTimer = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 500, () => {
+                swipeTrackers.forEach(t => t.enabled = false);
+                pillSwipeTimer = null;
+                return false; // on return false destroys timeout
+            });
         });
 
     registerOverridePrototype(WorkspaceAnimation.WorkspaceAnimationController, '_prepareWorkspaceSwitch',

--- a/patches.js
+++ b/patches.js
@@ -141,7 +141,7 @@ export function setupOverrides() {
         // Disable the workspace switching animation in Gnome 40+
         function (_from, _to, _direction, onComplete) {
             // if using PaperWM workspace switch animation, just do complete here
-            if (Tiling.spaces.space_activate_animate) {
+            if (Tiling.inPreview || Tiling.spaces.space_activate_animate) {
                 onComplete();
             }
             else {

--- a/patches.js
+++ b/patches.js
@@ -52,6 +52,7 @@ export function disable() {
     swipeTrackers = null;
     gsettings = null;
     mutterSettings = null;
+    Utils.timeout_remove(pillSwipeTimer);
     pillSwipeTimer = null;
     actions = null;
 }

--- a/tiling.js
+++ b/tiling.js
@@ -2285,10 +2285,6 @@ export const Spaces = class Spaces extends Map {
         let currentSpace = this.activeSpace;
         let monitorSpaces = this._getOrderedSpaces(currentSpace.monitor);
 
-        if (!inPreview) {
-            this.initWorkspaceSequence();
-        }
-
         let from = monitorSpaces.indexOf(this.selectedSpace);
         let newSpace = this.selectedSpace;
         let to = from;
@@ -2303,10 +2299,12 @@ export const Spaces = class Spaces extends Map {
             }
         }
 
-        if (direction === Meta.MotionDirection.DOWN)
+        if (direction === Meta.MotionDirection.DOWN) {
             to = from + 1;
-        else
+        }
+        else {
             to = from - 1;
+        }
 
         if (to < 0 || to >= monitorSpaces.length) {
             return;
@@ -2314,6 +2312,10 @@ export const Spaces = class Spaces extends Map {
 
         if (to === from && Easer.isEasing(newSpace.actor)) {
             return;
+        }
+
+        if (!inPreview) {
+            this.initWorkspaceSequence();
         }
 
         newSpace = monitorSpaces[to];

--- a/tiling.js
+++ b/tiling.js
@@ -1860,6 +1860,12 @@ export const Spaces = class Spaces extends Map {
     monitorsChanged() {
         this.onlyOnPrimary = this.overrideSettings.get_boolean('workspaces-only-on-primary');
         this.monitors = new Map();
+
+        // can be called async (after delay) on disable - use activeSpace as check
+        if (!this.activeSpace) {
+            return;
+        }
+
         this.activeSpace.getWindows().forEach(w => {
             animateWindow(w);
         });

--- a/tiling.js
+++ b/tiling.js
@@ -2282,6 +2282,7 @@ export const Spaces = class Spaces extends Map {
             Main.panel.statusArea.appMenu.container.hide();
         }
 
+        this.setSpaceTopbarElementsVisible(true);
         this._animateToSpaceOrdered(this.selectedSpace, false);
 
         let selected = this.selectedSpace.selectedWindow;
@@ -2346,7 +2347,6 @@ export const Spaces = class Spaces extends Map {
         const scale = 0.825;
         const padding_percentage = 4;
         let last = monitorSpaces.length - 1;
-        this.setSpaceTopbarElementsVisible(true);
         monitorSpaces.forEach((space, i) => {
             let padding = (space.height * scale / 100) * padding_percentage;
             let center = (space.height - (space.height * scale)) / 2;
@@ -2389,6 +2389,7 @@ export const Spaces = class Spaces extends Map {
         let monitor = space.monitor;
         this.selectedSpace = space;
 
+        this.setSpaceTopbarElementsVisible(true);
         let cloneParent = space.clip.get_parent();
         mru.forEach((space, i) => {
             space.startAnimate();
@@ -2504,7 +2505,6 @@ export const Spaces = class Spaces extends Map {
             Topbar.updateWorkspaceIndicator(newSpace.index);
         }
 
-        this.setSpaceTopbarElementsVisible(true);
         mru.forEach((space, i) => {
             let actor = space.actor;
             let h, onComplete = () => {};

--- a/tiling.js
+++ b/tiling.js
@@ -389,9 +389,9 @@ export class Space extends Array {
      * @param {Boolean} animate
      */
     activate(animate = false) {
-        spaces._space_activate_animate = animate;
+        spaces.space_activate_animate = animate;
         this.workspace.activate(global.get_current_time());
-        spaces._space_activate_animate = false; // switch to default
+        spaces.space_activate_animate = false; // switch to default
     }
 
     /**
@@ -400,14 +400,14 @@ export class Space extends Array {
      * @param {Boolean} animate
      */
     activateWithFocus(metaWindow, animate = false) {
-        spaces._space_activate_animate = animate;
+        spaces.space_activate_animate = animate;
         if (metaWindow) {
             this.workspace.activate_with_focus(metaWindow, global.get_current_time());
         }
         else {
             this.workspace.activate(global.get_current_time());
         }
-        spaces._space_activate_animate = false; // switch to default
+        spaces.space_activate_animate = false; // switch to default
     }
 
     show() {
@@ -2168,7 +2168,7 @@ export const Spaces = class Spaces extends Map {
         let monitor = toSpace.monitor;
         this.setMonitors(monitor, toSpace, true);
 
-        let doAnimate = animate || this._space_activate_animate;
+        let doAnimate = animate || this.space_activate_animate;
         this.animateToSpace(
             toSpace,
             fromSpace,

--- a/tiling.js
+++ b/tiling.js
@@ -1469,10 +1469,15 @@ border-radius: ${borderWidth}px;
         // get positions of topbar elements to replicate positions in spaces
         const vertex = new Graphene.Point3D({ x: 0, y: 0 });
         const labelPosition = Topbar.menu.label.apply_relative_transform_to_point(Main.panel, vertex);
-        const focusPosition = Topbar.focusButton.apply_relative_transform_to_point(Main.panel, vertex);
-
         this.workspaceLabel.set_position(labelPosition.x, labelPosition.y);
-        this.focusModeIcon.set_position(focusPosition.x, focusPosition.y);
+
+        if (Settings.prefs.show_workspace_indicator) {
+            const focusPosition = Topbar.focusButton.apply_relative_transform_to_point(Main.panel, vertex);
+            this.focusModeIcon.set_position(focusPosition.x, focusPosition.y);
+        } else {
+            // using gnome pill, set focus icon at first position
+            this.focusModeIcon.set_position(0, 0);
+        }
     }
 
     /**

--- a/tiling.js
+++ b/tiling.js
@@ -1488,9 +1488,18 @@ border-radius: ${borderWidth}px;
         this.updateName();
         if (show && Settings.prefs.show_workspace_indicator) {
             Utils.actor_raise(this.workspaceIndicator);
+            this.workspaceIndicator.opacity = 0;
             this.workspaceIndicator.show();
+            Easer.addEase(this.workspaceIndicator, {
+                opacity: 255,
+                time: Settings.prefs.animation_time,
+            });
         } else {
-            this.workspaceIndicator.hide();
+            Easer.addEase(this.workspaceIndicator, {
+                opacity: 0,
+                time: Settings.prefs.animation_time,
+                onComplete: () => this.workspaceIndicator.hide(),
+            });
         }
     }
 
@@ -1501,9 +1510,18 @@ border-radius: ${borderWidth}px;
     showFocusModeIcon(show = true) {
         if (show && Settings.prefs.show_focus_mode_icon) {
             Utils.actor_raise(this.focusModeIcon);
+            this.focusModeIcon.opacity = 0;
             this.focusModeIcon.show();
+            Easer.addEase(this.focusModeIcon, {
+                opacity: 255,
+                time: Settings.prefs.animation_time,
+            });
         } else {
-            this.focusModeIcon.hide();
+            Easer.addEase(this.focusModeIcon, {
+                opacity: 0,
+                time: Settings.prefs.animation_time,
+                onComplete: () => this.focusModeIcon.hide(),
+            });
         }
     }
 
@@ -2168,12 +2186,12 @@ export const Spaces = class Spaces extends Map {
         let monitor = toSpace.monitor;
         this.setMonitors(monitor, toSpace, true);
 
+        this.setSpaceTopbarElementsVisible();
         let doAnimate = animate || this.space_activate_animate;
         this.animateToSpace(
             toSpace,
             fromSpace,
-            doAnimate,
-            () => this.setSpaceTopbarElementsVisible());
+            doAnimate);
 
         toSpace.monitor.clickOverlay.deactivate();
 
@@ -2259,7 +2277,6 @@ export const Spaces = class Spaces extends Map {
             return;
         }
         inPreview = PreviewMode.SEQUENTIAL;
-        this.setSpaceTopbarElementsVisible(true);
 
         if (Main.panel.statusArea.appMenu) {
             Main.panel.statusArea.appMenu.container.hide();
@@ -2329,6 +2346,7 @@ export const Spaces = class Spaces extends Map {
         const scale = 0.825;
         const padding_percentage = 4;
         let last = monitorSpaces.length - 1;
+        this.setSpaceTopbarElementsVisible(true);
         monitorSpaces.forEach((space, i) => {
             let padding = (space.height * scale / 100) * padding_percentage;
             let center = (space.height - (space.height * scale)) / 2;
@@ -2360,7 +2378,6 @@ export const Spaces = class Spaces extends Map {
 
         // Always show the topbar when using the workspace stack
         Topbar.fixTopBar();
-        this.setSpaceTopbarElementsVisible(true);
         const scale = 0.9;
         let space = this.activeSpace;
         let mru = [...this.stack];
@@ -2487,6 +2504,7 @@ export const Spaces = class Spaces extends Map {
             Topbar.updateWorkspaceIndicator(newSpace.index);
         }
 
+        this.setSpaceTopbarElementsVisible(true);
         mru.forEach((space, i) => {
             let actor = space.actor;
             let h, onComplete = () => {};
@@ -2508,7 +2526,6 @@ export const Spaces = class Spaces extends Map {
             } else {
                 space.show();
             }
-
             Easer.addEase(actor,
                 {
                     y: h * space.height,


### PR DESCRIPTION
This PR fixes the broken (no) animation for the new Gnome pill workspace indicator (when you do two-finger swipe on it).

This also improves PaperWM workspace switching visuals - namely the workspace elements (like the FocusModeIcon) now fade in/out - which is much less jarring.