### PR TITLE
FIX: regression which causes incorrect window to be activated after lock/unlock

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -3369,8 +3369,11 @@ function updateSelection(space, metaWindow) {
     Utils.actor_reparent(space.selection, clone);
     clone.set_child_below_sibling(space.selection, cloneActor);
     allocateClone(metaWindow);
+
     // ensure window is properly activated
-    Main.activateWindow(metaWindow);
+    if (space === spaces.activeSpace) {
+        Main.activateWindow(metaWindow);
+    }
 }
 
 /**


### PR DESCRIPTION
This PR fixes an issue where disable-enable or lock/unlock causes activation of window NOT on current space (which causes a strange state on unlock).