### PR TITLE
Fix #631 take window clickoverlay lose control gnome45

### DIFF
--- a/navigator.js
+++ b/navigator.js
@@ -306,14 +306,16 @@ class NavigatorClass {
         this.was_accepted = true;
     }
 
-    finish(space, focus) {
-        if (grab)
+    finish(force = false) {
+        if (!force && grab) {
             return;
+        }
+
         this.accept();
-        this.destroy(space, focus);
+        this.destroy();
     }
 
-    destroy(space, focus) {
+    destroy() {
         this.minimaps.forEach(m => {
             if (typeof  m === 'number') {
                 Utils.timeout_remove(m);
@@ -334,10 +336,11 @@ class NavigatorClass {
         navigating = false;
 
         if (force) {
-            this.space.monitor.clickOverlay.hide();
+            this?.space?.monitor?.clickOverlay.hide();
         }
 
-        this.space = space || Tiling.spaces.selectedSpace;
+        let space = Tiling.spaces.selectedSpace;
+        this.space = space;
 
         let from = this.from;
         let selected = this.space.selectedWindow;
@@ -380,11 +383,9 @@ class NavigatorClass {
             : this.space.selectedWindow;
 
         let curFocus = display.focus_window;
-        if (force && curFocus && curFocus.is_on_all_workspaces())
+        if (force && curFocus && curFocus.is_on_all_workspaces()) {
             selected = curFocus;
-
-        if (focus)
-            selected = focus;
+        }
 
         if (selected && !Tiling.inGrab) {
             let hasFocus = selected && selected.has_focus();
@@ -426,9 +427,9 @@ export function getNavigator() {
  * Finishes navigation if navigator exists.
  * Useful to call before disabling other modules.
  */
-export function finishNavigation() {
+export function finishNavigation(force = true) {
     if (navigator) {
-        navigator.finish();
+        navigator.finish(force);
     }
 }
 
@@ -444,6 +445,13 @@ export function getActionDispatcher(mode) {
     }
     dispatcher = new ActionDispatcher();
     return getActionDispatcher(mode);
+}
+
+/**
+ * Fishes current dispatcher (if any).
+ */
+export function finishDispatching() {
+    dispatcher?._finish(global.get_current_time());
 }
 
 /**

--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -190,7 +190,8 @@ export class ClickOverlay {
          * stop navigation before activating workspace. Avoids an issue
          * in multimonitors where workspaces can get snapped to another monitor.
          */
-        Navigator.finishNavigation();
+        Navigator.finishDispatching();
+        Navigator.finishNavigation(true);
         this.deactivate();
         let selected = this.space.selectedWindow;
         this.space.activateWithFocus(selected, false, false);

--- a/tiling.js
+++ b/tiling.js
@@ -3419,9 +3419,11 @@ export function updateSelection(space, metaWindow) {
     clone.set_child_below_sibling(space.selection, cloneActor);
     allocateClone(metaWindow);
 
-    // ensure window is properly activated
+    // ensure window is properly activated (if not activated)
     if (space === spaces.activeSpace) {
-        Main.activateWindow(metaWindow);
+        if (metaWindow !== display.focus_windoww) {
+            Main.activateWindow(metaWindow);
+        }
     }
 }
 

--- a/tiling.js
+++ b/tiling.js
@@ -2705,6 +2705,14 @@ export const Spaces = class Spaces extends Map {
         return [...this.values()].find(s => uuid === s.uuid);
     }
 
+    get selectedSpace() {
+        return this._selectedSpace ?? this.activeSpace;
+    }
+
+    set selectedSpace(space) {
+        this._selectedSpace = space;
+    }
+
     /**
      * Returns the currently active space.
      */

--- a/tiling.js
+++ b/tiling.js
@@ -2227,7 +2227,7 @@ export const Spaces = class Spaces extends Map {
             fromSpace,
             doAnimate);
 
-        toSpace.monitor.clickOverlay.deactivate();
+        toSpace.monitor?.clickOverlay.deactivate();
 
         for (let monitor of Main.layoutManager.monitors) {
             if (monitor === toSpace.monitor)


### PR DESCRIPTION
This PR fixes #631 on Gnome 45.

The issue occurs every time in Gnome 45 (see #631 for reproduce steps).  It occurs *sometimes* in gnome 44.

Hence will be merging this one in for Gnome 45 since it fixes an easily reproducible issue with multi-monitors on gnome 45.

