### PR TITLE
Fix #631 take window clickoverlay lose control (fix for Gnome 42-44)

### DIFF
--- a/navigator.js
+++ b/navigator.js
@@ -308,14 +308,16 @@ class NavigatorClass {
         this.was_accepted = true;
     }
 
-    finish(space, focus) {
-        if (grab)
+    finish(force = false) {
+        if (!force && grab) {
             return;
+        }
+
         this.accept();
-        this.destroy(space, focus);
+        this.destroy();
     }
 
-    destroy(space, focus) {
+    destroy() {
         this.minimaps.forEach(m => {
             if (typeof  m === 'number') {
                 Mainloop.source_remove(m);
@@ -336,10 +338,11 @@ class NavigatorClass {
         navigating = false;
 
         if (force) {
-            this.space.monitor.clickOverlay.hide();
+            this?.space?.monitor?.clickOverlay.hide();
         }
 
-        this.space = space || Tiling.spaces.selectedSpace;
+        let space = Tiling.spaces.selectedSpace;
+        this.space = space;
 
         let from = this.from;
         let selected = this.space.selectedWindow;
@@ -382,11 +385,9 @@ class NavigatorClass {
             : this.space.selectedWindow;
 
         let curFocus = display.focus_window;
-        if (force && curFocus && curFocus.is_on_all_workspaces())
+        if (force && curFocus && curFocus.is_on_all_workspaces()) {
             selected = curFocus;
-
-        if (focus)
-            selected = focus;
+        }
 
         if (selected && !Tiling.inGrab) {
             let hasFocus = selected && selected.has_focus();
@@ -428,9 +429,9 @@ function getNavigator() {
  * Finishes navigation if navigator exists.
  * Useful to call before disabling other modules.
  */
-function finishNavigation() {
+function finishNavigation(force = false) {
     if (navigator) {
-        navigator.finish();
+        navigator.finish(force);
     }
 }
 
@@ -446,6 +447,13 @@ function getActionDispatcher(mode) {
     }
     dispatcher = new ActionDispatcher();
     return getActionDispatcher(mode);
+}
+
+/**
+ * Fishes current dispatcher (if any).
+ */
+function finishDispatching() {
+    dispatcher?._finish(global.get_current_time());
 }
 
 /**

--- a/settings.js
+++ b/settings.js
@@ -47,10 +47,10 @@ function enable() {
     ['window-gap', 'vertical-margin', 'vertical-margin-bottom', 'horizontal-margin',
         'workspace-colors', 'default-background', 'animation-time', 'use-workspace-name',
         'pressure-barrier', 'default-show-top-bar', 'swipe-sensitivity', 'swipe-friction',
-        'cycle-width-steps', 'cycle-height-steps', 'maximize-width-percent', 'minimap-scale', 
-        'edge-preview-scale', 'window-switcher-preview-scale', 'winprops', 
-        'show-workspace-indicator', 'show-window-position-bar', 'show-focus-mode-icon', 
-        'disable-topbar-styling', 'default-focus-mode', 'gesture-enabled', 
+        'cycle-width-steps', 'cycle-height-steps', 'maximize-width-percent', 'minimap-scale',
+        'edge-preview-scale', 'window-switcher-preview-scale', 'winprops',
+        'show-workspace-indicator', 'show-window-position-bar', 'show-focus-mode-icon',
+        'disable-topbar-styling', 'default-focus-mode', 'gesture-enabled',
         'gesture-horizontal-fingers', 'gesture-workspace-fingers']
         .forEach(k => setState(null, k));
     prefs.__defineGetter__("minimum_margin", function () {

--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -189,7 +189,8 @@ var ClickOverlay = class ClickOverlay {
          * stop navigation before activating workspace. Avoids an issue
          * in multimonitors where workspaces can get snapped to another monitor.
          */
-        Navigator.finishNavigation();
+        Navigator.finishDispatching();
+        Navigator.finishNavigation(true);
         this.deactivate();
         let selected = this.space.selectedWindow;
         this.space.activateWithFocus(selected);

--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -2,7 +2,6 @@ const ExtensionUtils = imports.misc.extensionUtils;
 const Extension = ExtensionUtils.getCurrentExtension();
 const Settings = Extension.imports.settings;
 const Utils = Extension.imports.utils;
-const Grab = Extension.imports.grab;
 const Tiling = Extension.imports.tiling;
 const Navigator = Extension.imports.navigator;
 
@@ -169,7 +168,7 @@ var ClickOverlay = class ClickOverlay {
     }
 
     monitorActiveCheck() {
-        // if clickoverlay not active, then nothing to do
+        // if clickoverlay not active (space is already selected), then nothing to do
         if (!this.active) {
             return;
         }
@@ -185,6 +184,11 @@ var ClickOverlay = class ClickOverlay {
     }
 
     select() {
+        // if clickoverlay not active (space is already selected), then nothing to do
+        if (!this.active) {
+            return;
+        }
+
         /**
          * stop navigation before activating workspace. Avoids an issue
          * in multimonitors where workspaces can get snapped to another monitor.

--- a/tiling.js
+++ b/tiling.js
@@ -1728,6 +1728,12 @@ var Spaces = class Spaces extends Map {
     monitorsChanged() {
         this.onlyOnPrimary = this.overrideSettings.get_boolean('workspaces-only-on-primary');
         this.monitors = new Map();
+
+        // can be called async (after delay) on disable - use activeSpace as check
+        if (!this.activeSpace) {
+            return;
+        }
+
         this.activeSpace.getWindows().forEach(w => {
             animateWindow(w);
         });

--- a/tiling.js
+++ b/tiling.js
@@ -3376,9 +3376,11 @@ function updateSelection(space, metaWindow) {
     clone.set_child_below_sibling(space.selection, cloneActor);
     allocateClone(metaWindow);
 
-    // ensure window is properly activated
+    // ensure window is properly activated (if not activated)
     if (space === spaces.activeSpace) {
-        Main.activateWindow(metaWindow);
+        if (metaWindow !== display.focus_windoww) {
+            Main.activateWindow(metaWindow);
+        }
     }
 }
 
@@ -3664,7 +3666,7 @@ function toggleMaximizeHorizontally(metaWindow) {
     let workArea = space.workArea();
     let frame = metaWindow.get_frame_rect();
     let reqWidth = maxWidthPrc * workArea.width - Settings.prefs.minimum_margin * 2;
-    
+
 
     // Some windows only resize in increments > 1px so we can't rely on a precise width
     // Hopefully this heuristic is good enough

--- a/tiling.js
+++ b/tiling.js
@@ -2544,6 +2544,14 @@ var Spaces = class Spaces extends Map {
         return [...this.values()].find(s => uuid === s.uuid);
     }
 
+    get selectedSpace() {
+        return this._selectedSpace ?? this.activeSpace;
+    }
+
+    set selectedSpace(space) {
+        this._selectedSpace = space;
+    }
+
     /**
      * Returns the currently active space.
      */

--- a/tiling.js
+++ b/tiling.js
@@ -2067,7 +2067,7 @@ var Spaces = class Spaces extends Map {
             doAnimate,
             () => this.setSpaceTopbarElementsVisible());
 
-        toSpace.monitor.clickOverlay.deactivate();
+        toSpace.monitor?.clickOverlay.deactivate();
 
         for (let monitor of Main.layoutManager.monitors) {
             if (monitor === toSpace.monitor)

--- a/topbar.js
+++ b/topbar.js
@@ -614,7 +614,7 @@ function enable () {
 
     signals.connect(Main.overview, 'showing', fixTopBar);
     signals.connect(Main.overview, 'hidden', () => {
-        if (Tiling.spaces.selectedSpace.showTopBar)
+        if (Tiling.spaces?.selectedSpace?.showTopBar)
             return;
         fixTopBar();
     });


### PR DESCRIPTION
This PR fixes a multi-monitor issue #631 (for gnome 44 etc.).

The issue occurred every time in Gnome 45 (and #632 has fixed it) - but it only occurs sometimes in Gnome 44.  I've merged and released the fix for Gnome 45, but would like a bit more testing on Gnome 44 (mainly because I can only sometimes reproduce the issue on older version of gnome).

In any case, this PR fixes the issue from ever occurring on gnome 44.  E.g. this should fix both #631 for gnome 44 and #627.

@Lythenas - would love it if you could test this one out on gnome 44 (or 43, 42) and try reproduce the "losing control of other monitor" issue!