### PR TITLE
Fix 638 fullscreen animation window resize bug backport (for gnome 44)

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -46,8 +46,8 @@
     <property name="page_increment">10</property>
   </object>
     <object class="GtkAdjustment" id="animation_time_adjustment">
-    <property name="upper">9.99</property>
-    <property name="lower">0.03</property>
+    <property name="upper">6.00</property>
+    <property name="lower">0.00</property>
     <property name="step_increment">0.01</property>
     <property name="page_increment">0.1</property>
   </object>

--- a/tiling.js
+++ b/tiling.js
@@ -3479,7 +3479,8 @@ function move_to(space, metaWindow, { x, force, animate }) {
     Easer.addEase(space.cloneContainer,
         {
             x: target,
-            time: animate ? Settings.prefs.animation_time : Easer.ANIMATION_INSTANT_TIME,
+            time: Settings.prefs.animation_time,
+            instant: !animate,
             onComplete: () => space.moveDone(),
         });
 

--- a/tiling.js
+++ b/tiling.js
@@ -455,10 +455,7 @@ var Space = class Space extends Array {
         this._inLayout = true;
         this.startAnimate();
 
-        let time = animate ? Settings.prefs.animation_time : 0;
-        if (window.instant) {
-            time = 0;
-        }
+        let time = Settings.prefs.animation_time;
         let gap = Settings.prefs.window_gap;
         let x = 0;
         let selectedIndex = this.selectedIndex();
@@ -561,14 +558,14 @@ var Space = class Space extends Array {
         this.emit('layout', this);
     }
 
-    queueLayout() {
+    queueLayout(animate = true) {
         if (this._layoutQueued)
             return;
 
         this._layoutQueued = true;
         Utils.later_add(Meta.LaterType.RESIZE, () => {
             this._layoutQueued = false;
-            this.layout();
+            this.layout(animate);
         });
     }
 
@@ -2858,7 +2855,7 @@ function resizeHandler(metaWindow) {
     if (inGrab && inGrab.window === metaWindow)
         return;
 
-    let f = metaWindow.get_frame_rect();
+    const f = metaWindow.get_frame_rect();
     let needLayout = false;
     if (metaWindow._targetWidth !== f.width || metaWindow._targetHeight !== f.height) {
         needLayout = true;
@@ -2866,22 +2863,29 @@ function resizeHandler(metaWindow) {
     metaWindow._targetWidth = null;
     metaWindow._targetHeight = null;
 
-    let space = spaces.spaceOfWindow(metaWindow);
+    const space = spaces.spaceOfWindow(metaWindow);
     if (space.indexOf(metaWindow) === -1)
         return;
 
-    let selected = metaWindow === space.selectedWindow;
+    const selected = metaWindow === space.selectedWindow;
+    let animate = true;
+
+    // if window is fullscreened, then don't animate background space.container animation etc.
+    if (metaWindow?.fullscreen) {
+        animate = false;
+    }
 
     if (!space._inLayout && needLayout) {
         // Restore window position when eg. exiting fullscreen
         if (!Navigator.navigating && selected) {
             move_to(space, metaWindow, {
                 x: metaWindow.get_frame_rect().x - space.monitor.x,
+                animate,
             });
         }
 
         // Resizing from within a size-changed signal is troube (#73). Queue instead.
-        space.queueLayout();
+        space.queueLayout(animate);
     }
 }
 
@@ -3450,7 +3454,8 @@ function updateSelection(space, metaWindow) {
  * Move the column containing @meta_window to x, y and propagate the change
  * in @space. Coordinates are relative to monitor and y is optional.
  */
-function move_to(space, metaWindow, { x, y, force, instant }) {
+function move_to(space, metaWindow, { x, force, animate }) {
+    animate = animate ?? true;
     if (space.indexOf(metaWindow) === -1)
         return;
 
@@ -3474,8 +3479,8 @@ function move_to(space, metaWindow, { x, y, force, instant }) {
     Easer.addEase(space.cloneContainer,
         {
             x: target,
-            time: Settings.prefs.animation_time,
-            onComplete: space.moveDone.bind(space),
+            time: animate ? Settings.prefs.animation_time : Easer.ANIMATION_INSTANT_TIME,
+            onComplete: () => space.moveDone(),
         });
 
     space.fixOverlays(metaWindow);
@@ -3993,7 +3998,6 @@ function centerWindowHorizontally(metaWindow) {
     } else {
         move_to(space, metaWindow, {
             x: targetX,
-            onComplete: () => space.moveDone(),
         });
     }
 }

--- a/utils.js
+++ b/utils.js
@@ -523,7 +523,7 @@ var easer = {
      */
     _safeDuration(time, instant) {
         let duration = Math.max(time, this.ANIMATION_SAFE_TIME);
-        if (instant) {
+        if (instant === true) {
             duration = this.ANIMATION_INSTANT_TIME;
         }
 

--- a/utils.js
+++ b/utils.js
@@ -491,9 +491,16 @@ var Signals = class Signals extends Map {
  * module.
  */
 var easer = {
+    /**
+     * Safer time setting to essentiall disable easer animation.
+     * Setting to 0 can have some side-effects and cause race
+     * conditions.
+     */
+    ANIMATION_INSTANT_TIME: 0.0001,
+
     addEase(actor, params) {
         if (params.time) {
-            params.duration = params.time * 1000;
+            params.duration = this._safeTime(params.time) * 1000;
             delete params.time;
         }
         if (!params.mode)
@@ -501,12 +508,23 @@ var easer = {
         actor.ease(params);
     },
 
+    /**
+     * Returns a safe animation time to avoid timing
+     * race conditions etc.
+     */
+    _safeTime(time) {
+        return Math.max(time, this.ANIMATION_INSTANT_TIME);
+    },
+
     removeEase(actor) {
         actor.remove_all_transitions();
     },
 
     isEasing(actor) {
-        return actor.get_transition('x') || actor.get_transition('y') || actor.get_transition('scale-x') || actor.get_transition('scale-x');
+        return actor.get_transition('x') ||
+        actor.get_transition('y') ||
+        actor.get_transition('scale-x') ||
+        actor.get_transition('scale-x');
     },
 };
 


### PR DESCRIPTION
#641 is the gnome-45 version that was merged recently.  This PR is a backport of this fix for gnome-44.

See https://github.com/paperwm/PaperWM/issues/638.

This PR fixes an animation race-condition issue that can cause a fullscreened window to be shown incorrect (only part of it is shown).

I could reproduce the issue by setting the animation-time to 0 or a high number. This PR fixes this case of the issue.

This also adds safe boundaries on animation-time to avoid several issues related to three-finger swiping the tile.

It's improved the situation for [@Capsel](https://github.com/CapSel) - but a (related) issue can still occur (which we haven't been able to reproduce).