### PR TITLE
FIX: connectResize was triggering a layout after initial layout that set preferredWidth

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -3096,6 +3096,16 @@ function focusMonitor() {
 }
 
 /**
+ * Convenience method to run a callback method when an actor is shown the stage.
+ * Uses a `connectOneShot` signal.
+ * @param actor
+ * @param callback
+ */
+function callbackOnActorShow(actor, callback) {
+    signals.connectOneShot(actor, 'show', callback);
+}
+
+/**
    Types of windows which never should be tiled.
  */
 function add_filter(meta_window) {
@@ -3293,7 +3303,7 @@ function insertWindow(metaWindow, { existing }) {
         // this layout will implement any preferredWidth winprops
         space.layout();
         connectSizeChanged(true);
-        signals.connectOneShot(actor, 'show', () => {
+        callbackOnActorShow(actor, () => {
             ensureViewport(metaWindow, space);
         });
         return;
@@ -3972,7 +3982,7 @@ function activateLastWindow(mw, space) {
  * https://github.com/paperwm/PaperWM/issues/448 for details).
  */
 function activateWindowAfterRendered(actor, mw) {
-    signals.connectOneShot(actor, 'show', () => {
+    callbackOnActorShow(actor, () => {
         Main.activateWindow(mw);
     });
 }

--- a/tiling.js
+++ b/tiling.js
@@ -3295,7 +3295,7 @@ function insertWindow(metaWindow, { existing }) {
 
     if (metaWindow === display.focus_window) {
         focus_handler(metaWindow);
-    } else if (space.workspace === workspaceManager.get_active_workspace()) {
+    } else if (space === spaces.activeSpace) {
         Main.activateWindow(metaWindow);
     } else {
         ensureViewport(space.selectedWindow, space);

--- a/tiling.js
+++ b/tiling.js
@@ -3278,18 +3278,18 @@ function insertWindow(metaWindow, { existing }) {
         return;
 
     metaWindow.unmake_above();
-    if (metaWindow.get_maximized() == Meta.MaximizeFlags.BOTH) {
+    if (metaWindow.get_maximized() === Meta.MaximizeFlags.BOTH) {
         metaWindow.unmaximize(Meta.MaximizeFlags.BOTH);
         toggleMaximizeHorizontally(metaWindow);
     }
-    space.layout();
 
     if (!existing) {
         clone.x = clone.targetX;
         clone.y = clone.targetY;
-        connectSizeChanged(true);
         space.layout();
+        connectSizeChanged(true);
     } else {
+        space.layout();
         animateWindow(metaWindow);
     }
 

--- a/tiling.js
+++ b/tiling.js
@@ -3283,15 +3283,24 @@ function insertWindow(metaWindow, { existing }) {
         toggleMaximizeHorizontally(metaWindow);
     }
 
+    /**
+     * If window is new, then setup and ensure is in view
+     * after actor is shown on stage.
+     */
     if (!existing) {
         clone.x = clone.targetX;
         clone.y = clone.targetY;
+        // this layout will implement any preferredWidth winprops
         space.layout();
         connectSizeChanged(true);
-    } else {
-        space.layout();
-        animateWindow(metaWindow);
+        signals.connectOneShot(actor, 'show', () => {
+            ensureViewport(metaWindow, space);
+        });
+        return;
     }
+
+    space.layout();
+    animateWindow(metaWindow);
 
     if (metaWindow === display.focus_window) {
         focus_handler(metaWindow);


### PR DESCRIPTION
Fix #642.

Fixes a preferredWidth winprop issue that caused some apps not to respect preferred width.