### PR TITLE
Fullscreen fixes (including multimonitor fullscreen bug that can fullscreen window onto other monitor)

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -46,8 +46,8 @@
     <property name="page_increment">10</property>
   </object>
     <object class="GtkAdjustment" id="animation_time_adjustment">
-    <property name="upper">9.99</property>
-    <property name="lower">0.03</property>
+    <property name="upper">6.00</property>
+    <property name="lower">0.00</property>
     <property name="step_increment">0.01</property>
     <property name="page_increment">0.1</property>
   </object>

--- a/tiling.js
+++ b/tiling.js
@@ -1319,42 +1319,49 @@ border-radius: ${borderWidth}px;
      * @param {boolean} visible
      */
     setSpaceTopbarElementsVisible(visible = false, changeTopBarStyle = true) {
-        // if windowPositionBar shown, we want the topbar style to be transparent if visible
-        if (Settings.prefs.show_window_position_bar) {
-            if (changeTopBarStyle) {
-                if (visible && this.hasTopBar) {
-                    TopBar.setTransparentStyle();
-                }
-                else {
-                    TopBar.setNoBackgroundStyle();
-                }
+        const setVisible = v => {
+            if (v) {
+                this.updateSpaceIconPositions();
+                this.showWorkspaceIndicator(true);
+                this.showFocusModeIcon(true);
             }
-
-            // if on different monitor then override to show elements
-            if (!this.hasTopBar) {
-                visible = true;
+            else {
+                this.showWorkspaceIndicator(false);
+                this.showFocusModeIcon(false);
             }
+        };
 
-            // don't show elements on spaces with actual TopBar (unless inPreview)
-            if (this.hasTopBar && !inPreview) {
-                visible = false;
+        // if windowPositionBar is disabled ==> don't show elements
+        if (!Settings.prefs.show_window_position_bar) {
+            setVisible(false);
+            return;
+        }
+
+        if (changeTopBarStyle) {
+            if (visible && this.hasTopBar) {
+                TopBar.setTransparentStyle();
             }
-
-            // if current window is fullscreen, don't show
-            if (this?.selectedWindow?.fullscreen) {
-                visible = false;
+            else {
+                TopBar.setNoBackgroundStyle();
             }
         }
 
-        if (visible) {
-            this.updateSpaceIconPositions();
-            this.showWorkspaceIndicator(true);
-            this.showFocusModeIcon(true);
+        // if on different monitor then override to show elements
+        if (!this.hasTopBar) {
+            visible = true;
         }
-        else {
-            this.showWorkspaceIndicator(false);
-            this.showFocusModeIcon(false);
+
+        // don't show elements on spaces with actual TopBar (unless inPreview)
+        if (this.hasTopBar && !inPreview) {
+            visible = false;
         }
+
+        // if current window is fullscreen, don't show
+        if (this?.selectedWindow?.fullscreen) {
+            visible = false;
+        }
+
+        setVisible(visible);
     }
 
     /**

--- a/tiling.js
+++ b/tiling.js
@@ -3479,7 +3479,8 @@ function move_to(space, metaWindow, { x, force, animate }) {
     Easer.addEase(space.cloneContainer,
         {
             x: target,
-            time: animate ? Settings.prefs.animation_time : Easer.ANIMATION_INSTANT_TIME,
+            time: Settings.prefs.animation_time,
+            instant: !animate,
             onComplete: () => space.moveDone(),
         });
 

--- a/tiling.js
+++ b/tiling.js
@@ -1334,6 +1334,11 @@ border-radius: ${borderWidth}px;
             if (this.hasTopBar && !inPreview) {
                 visible = false;
             }
+
+            // if current window is fullscreen, don't show
+            if (this?.selectedWindow?.fullscreen) {
+                visible = false;
+            }
         }
 
         if (visible) {

--- a/tiling.js
+++ b/tiling.js
@@ -241,6 +241,11 @@ var Space = class Space extends Array {
             setFocusMode(getDefaultFocusMode(), this);
         });
 
+        // update space elements when in/out of fullscreen
+        this.signals.connect(global.display, 'in-fullscreen-changed', () => {
+            this.setSpaceTopbarElementsVisible(true);
+        });
+
         const settings = ExtensionUtils.getSettings();
         this.signals.connect(interfaceSettings, "changed::color-scheme", this.updateBackground.bind(this));
         this.signals.connect(settings, 'changed::default-background', this.updateBackground.bind(this));

--- a/tiling.js
+++ b/tiling.js
@@ -2886,17 +2886,21 @@ function resizeHandler(metaWindow) {
 
     const selected = metaWindow === space.selectedWindow;
     let animate = true;
+    let x;
 
     // if window is fullscreened, then don't animate background space.container animation etc.
     if (metaWindow?.fullscreen) {
         animate = false;
+        x = 0;
+    } else {
+        x = metaWindow.get_frame_rect().x - space.monitor.x;
     }
 
     if (!space._inLayout && needLayout) {
         // Restore window position when eg. exiting fullscreen
         if (!Navigator.navigating && selected) {
             move_to(space, metaWindow, {
-                x: metaWindow.get_frame_rect().x - space.monitor.x,
+                x,
                 animate,
             });
         }

--- a/tiling.js
+++ b/tiling.js
@@ -455,10 +455,7 @@ var Space = class Space extends Array {
         this._inLayout = true;
         this.startAnimate();
 
-        let time = animate ? Settings.prefs.animation_time : 0;
-        if (window.instant) {
-            time = 0;
-        }
+        let time = Settings.prefs.animation_time;
         let gap = Settings.prefs.window_gap;
         let x = 0;
         let selectedIndex = this.selectedIndex();
@@ -561,14 +558,14 @@ var Space = class Space extends Array {
         this.emit('layout', this);
     }
 
-    queueLayout() {
+    queueLayout(animate = true) {
         if (this._layoutQueued)
             return;
 
         this._layoutQueued = true;
         Utils.later_add(Meta.LaterType.RESIZE, () => {
             this._layoutQueued = false;
-            this.layout();
+            this.layout(animate);
         });
     }
 
@@ -2858,7 +2855,7 @@ function resizeHandler(metaWindow) {
     if (inGrab && inGrab.window === metaWindow)
         return;
 
-    let f = metaWindow.get_frame_rect();
+    const f = metaWindow.get_frame_rect();
     let needLayout = false;
     if (metaWindow._targetWidth !== f.width || metaWindow._targetHeight !== f.height) {
         needLayout = true;
@@ -2866,22 +2863,29 @@ function resizeHandler(metaWindow) {
     metaWindow._targetWidth = null;
     metaWindow._targetHeight = null;
 
-    let space = spaces.spaceOfWindow(metaWindow);
+    const space = spaces.spaceOfWindow(metaWindow);
     if (space.indexOf(metaWindow) === -1)
         return;
 
-    let selected = metaWindow === space.selectedWindow;
+    const selected = metaWindow === space.selectedWindow;
+    let animate = true;
+
+    // if window is fullscreened, then don't animate background space.container animation etc.
+    if (metaWindow?.fullscreen) {
+        animate = false;
+    }
 
     if (!space._inLayout && needLayout) {
         // Restore window position when eg. exiting fullscreen
         if (!Navigator.navigating && selected) {
             move_to(space, metaWindow, {
                 x: metaWindow.get_frame_rect().x - space.monitor.x,
+                animate,
             });
         }
 
         // Resizing from within a size-changed signal is troube (#73). Queue instead.
-        space.queueLayout();
+        space.queueLayout(animate);
     }
 }
 
@@ -3450,7 +3454,8 @@ function updateSelection(space, metaWindow) {
  * Move the column containing @meta_window to x, y and propagate the change
  * in @space. Coordinates are relative to monitor and y is optional.
  */
-function move_to(space, metaWindow, { x, y, force, instant }) {
+function move_to(space, metaWindow, { x, force, animate }) {
+    animate = animate ?? true;
     if (space.indexOf(metaWindow) === -1)
         return;
 
@@ -3474,8 +3479,8 @@ function move_to(space, metaWindow, { x, y, force, instant }) {
     Easer.addEase(space.cloneContainer,
         {
             x: target,
-            time: Settings.prefs.animation_time,
-            onComplete: space.moveDone.bind(space),
+            time: animate ? Settings.prefs.animation_time : Easer.ANIMATION_INSTANT_TIME,
+            onComplete: () => space.moveDone(),
         });
 
     space.fixOverlays(metaWindow);
@@ -3993,7 +3998,6 @@ function centerWindowHorizontally(metaWindow) {
     } else {
         move_to(space, metaWindow, {
             x: targetX,
-            onComplete: () => space.moveDone(),
         });
     }
 }

--- a/utils.js
+++ b/utils.js
@@ -523,7 +523,7 @@ var easer = {
      */
     _safeDuration(time, instant) {
         let duration = Math.max(time, this.ANIMATION_SAFE_TIME);
-        if (instant) {
+        if (instant === true) {
             duration = this.ANIMATION_INSTANT_TIME;
         }
 

--- a/utils.js
+++ b/utils.js
@@ -491,9 +491,16 @@ var Signals = class Signals extends Map {
  * module.
  */
 var easer = {
+    /**
+     * Safer time setting to essentiall disable easer animation.
+     * Setting to 0 can have some side-effects and cause race
+     * conditions.
+     */
+    ANIMATION_INSTANT_TIME: 0.0001,
+
     addEase(actor, params) {
         if (params.time) {
-            params.duration = params.time * 1000;
+            params.duration = this._safeTime(params.time) * 1000;
             delete params.time;
         }
         if (!params.mode)
@@ -501,12 +508,23 @@ var easer = {
         actor.ease(params);
     },
 
+    /**
+     * Returns a safe animation time to avoid timing
+     * race conditions etc.
+     */
+    _safeTime(time) {
+        return Math.max(time, this.ANIMATION_INSTANT_TIME);
+    },
+
     removeEase(actor) {
         actor.remove_all_transitions();
     },
 
     isEasing(actor) {
-        return actor.get_transition('x') || actor.get_transition('y') || actor.get_transition('scale-x') || actor.get_transition('scale-x');
+        return actor.get_transition('x') ||
+        actor.get_transition('y') ||
+        actor.get_transition('scale-x') ||
+        actor.get_transition('scale-x');
     },
 };
 


### PR DESCRIPTION
This PR fixes several window fullscreen bugs, including a multimonitor issue.  It also stops the space elements (focusmode icon etc.) from showing if a fullscreen window is selected on that space.

Noticed this when setting a window fullscreen on one monitor and then moving mouse cursor to another monitor (focusmode Icon etc. showed on the fullscreened monitor).