### PR TITLE
Removed wrap property from keybinds list items

### DIFF
--- a/KeybindingsRow.ui
+++ b/KeybindingsRow.ui
@@ -28,8 +28,7 @@
                 <property name="ellipsize">end</property>
                 <property name="halign">start</property>
                 <property name="lines">1</property>
-                <property name="wrap">True</property>
-                <property name="wrap-mode">word-char</property>
+                <property name="wrap">False</property>
                 <property name="xalign">0</property>
               </object>
             </child>

--- a/WinpropsRow.ui
+++ b/WinpropsRow.ui
@@ -25,8 +25,7 @@
                 <property name="ellipsize">end</property>
                 <property name="halign">start</property>
                 <property name="lines">1</property>
-                <property name="wrap">True</property>
-                <property name="wrap-mode">word-char</property>
+                <property name="wrap">False</property>
                 <property name="xalign">0</property>
               </object>
             </child>


### PR DESCRIPTION
This caused keybinds and window rules descriptions to wrap too early, making them unreadable.