### PR TITLE
FIX #657 - restore previous / simpler opening app animation.

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -391,8 +391,6 @@ var Space = class Space extends Array {
                 else {
                     console.warn("invalid preferredWidth unit:", `'${prop.unit}'`, "(should be 'px' or '%')");
                 }
-
-                delete mw.preferredWidth;
             }
 
             if (resizable) {
@@ -3323,6 +3321,9 @@ function insertWindow(metaWindow, { existing }) {
         toggleMaximizeHorizontally(metaWindow);
     }
 
+    // run a simple layout in pre-prepare layout
+    space.layout(false);
+
     /**
      * If window is new, then setup and ensure is in view
      * after actor is shown on stage.
@@ -3330,10 +3331,11 @@ function insertWindow(metaWindow, { existing }) {
     if (!existing) {
         clone.x = clone.targetX;
         clone.y = clone.targetY;
-        // this layout will implement any preferredWidth winprops
         space.layout();
         connectSizeChanged(true);
         callbackOnActorShow(actor, () => {
+            // after shown, remove preferred width winprop
+            delete metaWindow.preferredWidth;
             ensureViewport(metaWindow, space);
 
             // if only one window on space, then centre it
@@ -3341,11 +3343,11 @@ function insertWindow(metaWindow, { existing }) {
                 centerWindowHorizontally(metaWindow);
             }
         });
-        return;
     }
-
-    space.layout();
-    animateWindow(metaWindow);
+    else {
+        space.layout();
+        animateWindow(metaWindow);
+    }
 
     if (metaWindow === display.focus_window) {
         focus_handler(metaWindow);


### PR DESCRIPTION
FIxes #657.

This PR restores the previous opening application animation.  #642 required some changes to avoid a animation race condition - this was fixed but the animation change was a bit... jarring.  This PR keeps the winprops fix sets the animation more like the previous approach.