### PR TITLE
FIX: can't control scratch window restored from minimise state in X11

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -234,7 +234,9 @@ var Space = class Space extends Array {
             // warp pointer to monitor that is active
             Utils.warpPointerToMonitor(this.monitor);
             Utils.later_add(Meta.LaterType.IDLE, () => {
-                ensureViewport(display.focus_window, this, { moveto: true, force: true });
+                this.moveDone(() => {
+                    ensureViewport(display.focus_window, this, { moveto: true, force: true });
+                });
             });
         });
 


### PR DESCRIPTION
This PR fixes #666.