### PR TITLE
FIX 684 - windows change their horizontal position after consuming operation

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -671,7 +671,7 @@ export class Space extends Array {
         let width = Math.max(1, x - gap);
         this.cloneContainer.width = width;
 
-        if (auto && animate && !lockx) {
+        if (auto && animate) {
             if (width < workArea.width) {
                 this.targetX = min + Math.round((workArea.width - width) / 2);
             } else if (this.targetX + width < min + workArea.width) {

--- a/tiling.js
+++ b/tiling.js
@@ -4247,7 +4247,6 @@ export function slurp(metaWindow) {
     let index = space.indexOf(metaWindow);
 
     let to, from;
-    let metaWindowToEnsure = space.selectedWindow;
     let metaWindowToSlurp;
 
     if (index + 1 < space.length) {
@@ -4258,7 +4257,6 @@ export function slurp(metaWindow) {
         if (space[index].length > 1)
             return;
         metaWindowToSlurp = metaWindow;
-        metaWindowToEnsure = metaWindowToSlurp;
         to = index - 1;
         from = index;
     }
@@ -4281,7 +4279,6 @@ export function slurp(metaWindow) {
         customAllocators: { [to]: allocateEqualHeight },
     });
     space.emit("full-layout");
-    ensureViewport(metaWindowToEnsure, space, { force: true });
 }
 
 export function barf(metaWindow) {
@@ -4304,7 +4301,6 @@ export function barf(metaWindow) {
         customAllocators: { [index]: allocateEqualHeight },
     });
     space.emit("full-layout");
-    ensureViewport(space.selectedWindow, space, { force: true });
 }
 
 export function selectPreviousSpace(mw, space) {

--- a/tiling.js
+++ b/tiling.js
@@ -584,6 +584,11 @@ export class Space extends Array {
             return;
         if (this._inLayout)
             return;
+
+        // option properties
+        let lockx = options?.lockx ?? false;
+        let allocators = options?.customAllocators;
+
         this._inLayout = true;
         this.startAnimate();
 
@@ -631,7 +636,7 @@ export class Space extends Array {
             targetWidth = Math.min(targetWidth, workArea.width - 2 * Settings.prefs.minimum_margin);
 
             let resultingWidth, relayout;
-            let allocator = options.customAllocators && options.customAllocators[i];
+            let allocator = allocators && allocators[i];
             if (inGrab && column.includes(inGrab.window) && !allocator) {
                 [resultingWidth, relayout] =
                     this.layoutGrabColumn(column, x, y0, targetWidth, availableHeight, time,
@@ -666,7 +671,7 @@ export class Space extends Array {
         let width = Math.max(1, x - gap);
         this.cloneContainer.width = width;
 
-        if (auto && animate) {
+        if (auto && animate && !lockx) {
             if (width < workArea.width) {
                 this.targetX = min + Math.round((workArea.width - width) / 2);
             } else if (this.targetX + width < min + workArea.width) {
@@ -681,7 +686,7 @@ export class Space extends Array {
                     onComplete: this.moveDone.bind(this),
                 });
         }
-        if (animate) {
+        if (animate && !lockx) {
             ensureViewport(this.selectedWindow, this);
         } else {
             this.moveDone();
@@ -4276,9 +4281,8 @@ export function slurp(metaWindow) {
     }
 
     space.layout(true, {
-        customAllocators: { [to]: allocateEqualHeight },
+        customAllocators: { [to]: allocateEqualHeight, lockx: true },
     });
-    space.emit("full-layout");
 }
 
 export function barf(metaWindow) {
@@ -4298,9 +4302,8 @@ export function barf(metaWindow) {
     space.splice(index + 1, 0, [bottom]);
 
     space.layout(true, {
-        customAllocators: { [index]: allocateEqualHeight },
+        customAllocators: { [index]: allocateEqualHeight, lockx: true },
     });
-    space.emit("full-layout");
 }
 
 export function selectPreviousSpace(mw, space) {

--- a/tiling.js
+++ b/tiling.js
@@ -586,7 +586,7 @@ export class Space extends Array {
             return;
 
         // option properties
-        let lockx = options?.lockx ?? false;
+        let ensure = options?.ensure ?? true;
         let allocators = options?.customAllocators;
 
         this._inLayout = true;
@@ -594,7 +594,7 @@ export class Space extends Array {
 
         let time = Settings.prefs.animation_time;
         let gap = Settings.prefs.window_gap;
-        let x = 0;
+        let x = gap; // init (ensures autostart apps in particular start properly gapped)
         let selectedIndex = this.selectedIndex();
         let workArea = this.workArea();
 
@@ -660,8 +660,10 @@ export class Space extends Array {
 
             x += resultingWidth + gap;
         }
-        this._inLayout = false;
+        // final gap add - required to resolve https://github.com/paperwm/PaperWM/issues/684
+        x += gap;
 
+        this._inLayout = false;
         let oldWidth = this.cloneContainer.width;
         let min = workArea.x;
         let auto = (this.targetX + oldWidth >= min + workArea.width && this.targetX <= 0) ||
@@ -686,7 +688,7 @@ export class Space extends Array {
                     onComplete: this.moveDone.bind(this),
                 });
         }
-        if (animate && !lockx) {
+        if (animate && ensure) {
             ensureViewport(this.selectedWindow, this);
         } else {
             this.moveDone();
@@ -4281,7 +4283,7 @@ export function slurp(metaWindow) {
     }
 
     space.layout(true, {
-        customAllocators: { [to]: allocateEqualHeight, lockx: true },
+        customAllocators: { [to]: allocateEqualHeight, ensure: true },
     });
 }
 

--- a/tiling.js
+++ b/tiling.js
@@ -4283,7 +4283,7 @@ export function slurp(metaWindow) {
     }
 
     space.layout(true, {
-        customAllocators: { [to]: allocateEqualHeight, ensure: true },
+        customAllocators: { [to]: allocateEqualHeight, ensure: false },
     });
 }
 
@@ -4304,7 +4304,7 @@ export function barf(metaWindow) {
     space.splice(index + 1, 0, [bottom]);
 
     space.layout(true, {
-        customAllocators: { [index]: allocateEqualHeight, lockx: true },
+        customAllocators: { [index]: allocateEqualHeight, ensure: false },
     });
 }
 


### PR DESCRIPTION
Fixes #684.

This PR locks the consuming window position during consuming/expelling tile operations.  It also fixes the x position calculation to address the root cause of this issue.