### PR TITLE
Warp pointer when switching to workspace

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -2276,6 +2276,8 @@ export const Spaces = class Spaces extends Map {
         signals.disconnect(Main.panel, this.touchSignal);
         this.touchSignal = signals.connect(Main.panel, "captured-event", Gestures.horizontalTouchScroll.bind(toSpace));
 
+        Utils.warpPointerToMonitor(monitor);
+
         inPreview = PreviewMode.NONE;
     }
 


### PR DESCRIPTION
Attempt to implement/fix #704 

When switching to workspace that is either already visible on non-focused monitor, or is restored from previous state to non-focused monitor, cursor stays in the old workspace.

This warps the cursor to the monitor of workspace the user is switching to.

I actually stumbled upon a code that warped the cursor in switchWorkspace, as I accidentally first went to the master branch, and it has code for warping cursor inside of switchWorkspace. So PaperWM did have this functionality before, I am not sure why it was removed.