### PR TITLE
Improve scratch window behaviours for Gnone-44

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,8 +159,6 @@ PaperWM currently works best using the workspaces span monitors preference, this
 The scratch layer is an escape hatch to a familiar floating layout. This layer is intended to store windows that are globally useful like chat applications and in general serve as the kitchen sink.
 When the scratch layer is active it will float above the tiled windows, when hidden the windows will be minimized.
 
-Opening a window when the scratch layer is active will make it float automatically.
-
 Pressing <kbd>Super</kbd><kbd>Escape</kbd> toggles between showing and hiding the windows in the scratch layer.
 Activating windows in the scratch layer is done using <kbd>Super</kbd><kbd>Tab</kbd>, the floating windows having priority in the list while active.
 When the tiling is active <kbd>Super</kbd><kbd>Shift</kbd><kbd>Tab</kbd> selects the most recently used scratch window.

--- a/tiling.js
+++ b/tiling.js
@@ -3271,12 +3271,7 @@ function insertWindow(metaWindow, { existing }) {
             focusWindow = mru[1];
         }
 
-        // Scratch if have scratch windows on this space and focused window is also scratch
-        let scratchIsFocused =
-            Scratch.getScratchWindows().length > 0 &&
-            space === spaces.spaceOfWindow(focusWindow) &&
-            Scratch.isScratchWindow(focusWindow);
-        let addToScratch = scratchIsFocused;
+        let addToScratch = false;
 
         let winprop = Settings.find_winprop(metaWindow);
         if (winprop) {
@@ -3298,9 +3293,7 @@ function insertWindow(metaWindow, { existing }) {
         if (addToScratch) {
             connectSizeChanged();
             Scratch.makeScratch(metaWindow);
-            if (scratchIsFocused) {
-                activateWindowAfterRendered(actor, metaWindow);
-            }
+            activateWindowAfterRendered(actor, metaWindow);
             return;
         }
     }


### PR DESCRIPTION
This PR changes several widow behaviours related to scratch windows.  It seeks to make scratch windows more predictable (in how one scratches a window) and try to minimise instances of "accidentally/unexpectedly" scratching windows.

Users (especially new users) seem to struggle with some of the behaviours for scratch windows.

See some example comments here:

- https://github.com/paperwm/PaperWM/issues/680#issuecomment-1806929052
- https://github.com/paperwm/PaperWM/issues/700#issue-1997608259
- https://github.com/paperwm/PaperWM/issues/700#issuecomment-1824202077

On review, a couple of behaviours are rather unintuitive with scratch windows:

1. when a scratch window is selected, any new window opened will also be scratched.  I understand the thought here, but this is rarely what's wanted (for me anyway) and often leads to confusion.  This PR undoes this.  New windows will be tiled (regardless of whether a scratch window is currently selected).

2. Dragging a window (with mouse) and NOT dropping on a target now re-tiles that window (previously it scratched that window).  I've had two user reports in the last few weeks of this (reported as a bug).  In any case, it seems the more intuitive option of for that window to be re-tiled:

https://github.com/paperwm/PaperWM/assets/30424662/9c4a20d6-52e3-408f-9c0a-62ee0ceb6244