### PR TITLE
Fix for #729: address keybind conflicts with Ubuntu 23.10's default enabled 'Tiling Assistant' extension

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -88,7 +88,11 @@ export function getConflictSettings() {
         addSchemaToConflictSettings('org.gnome.mutter.wayland.keybindings');
         addSchemaToConflictSettings('org.gnome.desktop.wm.keybindings');
         addSchemaToConflictSettings('org.gnome.shell.keybindings');
-        addSchemaToConflictSettings('org.gnome.settings-daemon.plugins.media-keys');
+
+        // below schemas are checked but may not exist in all distributions
+        addSchemaToConflictSettings('org.gnome.settings-daemon.plugins.media-keys', false);
+        // ubuntu tiling-assistant (enabled by default on Ubuntu 23.10)
+        addSchemaToConflictSettings('org.gnome.shell.extensions.tiling-assistant', false);
     }
 
     return conflictSettings;
@@ -98,12 +102,14 @@ export function getConflictSettings() {
  * Adds a Gio.Settings object to conflictSettings.  Fails gracefully.
  * @param {Gio.Settings} schemaId
  */
-export function addSchemaToConflictSettings(schemaId) {
+export function addSchemaToConflictSettings(schemaId, warn = true) {
     try {
         conflictSettings.push(new Gio.Settings({ schema_id: schemaId }));
     }
     catch (e) {
-        console.warn(`Invalid schema_id '${schemaId}': could not add to keybind conflict checks`);
+        if (warn) {
+            console.warn(`Invalid schema_id '${schemaId}': could not add to keybind conflict checks`);
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #729.

This PR adds gschema 'org.gnome.shell.extensions.tiling-assistant' schema to keybind conflict detection.

Ubuntu 23.10 enables a `Tiling Assistnt` gnome extension by default.  This extensions contains keybinds that clash with PaperWM's default keybinds.

This PR adds the Tiling Assistant schema to those that PaperWM checks for conflicts.  It disables conflicting keybinds (in Tiling Assistant) - and restores them when PaperWM is disabled (like other schemas that PaperWM checks).