### PR TITLE
FIX #747: regression when resizing consumed window group

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -3903,7 +3903,7 @@ export function getDefaultFocusMode() {
 }
 
 // `MetaWindow::focus` handling
-export function focus_handler(metaWindow, user_data) {
+export function focus_handler(metaWindow) {
     console.debug("focus:", metaWindow?.title);
     if (Scratch.isScratchWindow(metaWindow)) {
         setAllWorkspacesInactive();
@@ -3927,11 +3927,11 @@ export function focus_handler(metaWindow, user_data) {
     else {
         let needLayout = false;
         /**
-         * For non-topbar spaces, bring down fullscreen windows to mimic
-         * gnome behaviour with a topbar.
+         * If has fullscreen window - when selected non-fullscreen window, do layout:
+         * For non-topbar spaces, Bring down fullscreen windows to mimic gnome behaviour with a topbar,
+         * Also ensures if columns group, then it's windows are correctly proportioned.
          */
-        if (!space.hasTopBar &&
-            space.hasFullScreenWindow()) {
+        if (space.hasFullScreenWindow()) {
             needLayout = true;
         }
 

--- a/tiling.js
+++ b/tiling.js
@@ -4498,8 +4498,13 @@ export function slurp(metaWindow) {
     }
 
     // slurping fullscreen windows is trouble
-    if (!metaWindowToSlurp || metaWindowToSlurp?.fullscreen || space.length < 2) {
+    if (!metaWindowToSlurp || space.length < 2) {
         return;
+    }
+
+    // slurping fullscreen windows is trouble, unfullscreen when slurping
+    if (metaWindowToSlurp?.fullscreen) {
+        metaWindowToSlurp.unmake_fullscreen();
     }
 
     space[to].push(metaWindowToSlurp);


### PR DESCRIPTION
This PR fixes #747.

It also better manages fullscreening a window when it's in a consumed window group.  Similarly, when "slurping" in a fullscreened window, unfullscreen it first (fullscreened windows in consumed window groups are trouble).