### PR TITLE
Replace ClickOverlay `enterMonitor` reactive actor approach with much simpler implementation

### DIFF
--- a/grab.js
+++ b/grab.js
@@ -53,10 +53,6 @@ export class MoveGrab {
         this.dispatcher = new Navigator.getActionDispatcher(Clutter.GrabState.POINTER);
         this.actor = this.dispatcher.actor;
 
-        for (let [monitor, $] of Tiling.spaces.monitors) {
-            monitor.clickOverlay.deactivate();
-        }
-
         let metaWindow = this.window;
         let actor = metaWindow.get_compositor_private();
         let clone = metaWindow.clone;

--- a/navigator.js
+++ b/navigator.js
@@ -356,9 +356,6 @@ class NavigatorClass {
         let visible = [];
         for (let monitor of Main.layoutManager.monitors) {
             visible.push(Tiling.spaces.monitors.get(monitor));
-            if (monitor === this.monitor)
-                continue;
-            monitor.clickOverlay.activate();
         }
 
         if (!visible.includes(space) && this.monitor !== this.space.monitor) {

--- a/scratch.js
+++ b/scratch.js
@@ -134,9 +134,7 @@ export function makeScratch(metaWindow) {
         }
     }
 
-    let monitor = Tiling.focusMonitor();
-    if (monitor.clickOverlay)
-        monitor.clickOverlay.hide();
+    Tiling.focusMonitor()?.clickOverlay?.hide();
 }
 
 export function unmakeScratch(metaWindow) {

--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -69,9 +69,31 @@ export function multimonitorDragDropSupport() {
 export function enableMultimonitorDragDropSupport() {
     pointerWatch = PointerWatcher.getPointerWatcher().addWatch(100,
         () => {
-            Tiling.spaces?.clickOverlays?.forEach(c => {
-                c.monitorActiveCheck();
-            });
+            // check if in the midst of a window resize action
+            if (Tiling.inGrab && Tiling.inGrab instanceof Grab.ResizeGrab) {
+                const window = global.display?.focus_window;
+                if (window) {
+                    Scratch.makeScratch(window);
+                }
+            }
+
+            /**
+             * stop navigation before activating workspace. Avoids an issue
+             * in multimonitors where workspaces can get snapped to another monitor.
+             */
+            Navigator.finishDispatching();
+            Navigator.finishNavigation(true);
+
+            const monitor = Utils.monitorAtCurrentPoint();
+            const space = Tiling.spaces.monitors.get(monitor);
+
+            // if space is already active, do nothing
+            if (Tiling.spaces.isActiveSpace(space)) {
+                return;
+            }
+
+            const selected = space?.selectedWindow;
+            space?.activateWithFocus(selected, false, false);
         });
     console.debug('paperwm multimonitor drag/drop support is ENABLED');
 }
@@ -102,139 +124,6 @@ export class ClickOverlay {
         this.onlyOnPrimary = onlyOnPrimary;
         this.left = new StackOverlay(Meta.MotionDirection.LEFT, monitor);
         this.right = new StackOverlay(Meta.MotionDirection.RIGHT, monitor);
-
-        let enterMonitor = new Clutter.Actor({ reactive: true });
-        this.enterMonitor = enterMonitor;
-        enterMonitor.set_position(monitor.x, monitor.y);
-
-        // Uncomment to debug the overlays
-        // enterMonitor.background_color = Clutter.color_from_string('green')[1];
-        // enterMonitor.opacity = 100;
-
-        Main.uiGroup.add_actor(enterMonitor);
-        Main.layoutManager.trackChrome(enterMonitor);
-
-        this.signals = new Utils.Signals();
-
-        this._lastPointer = [];
-        this._lastPointerTimeout = null;
-
-        this.signals.connect(enterMonitor, 'touch-event', () => {
-            if (Tiling.inPreview)
-                return;
-            this.select();
-        });
-
-        this.signals.connect(enterMonitor, 'enter-event', () => {
-            if (Tiling.inPreview)
-                return;
-            this.select();
-        });
-
-        this.signals.connect(enterMonitor, 'button-press-event', () => {
-            if (Tiling.inPreview)
-                return;
-            this.select();
-            return Clutter.EVENT_STOP;
-        });
-
-        this.signals.connect(Main.overview, 'showing', () => {
-            this.deactivate();
-            this.hide();
-        });
-
-        this.signals.connect(Main.overview, 'hidden', () => {
-            this.activate();
-            this.show();
-        });
-
-        /**
-         * Handle grabbed (drag & drop) windows in ClickOverlay.  If a window is
-         * grabbed-dragged-and-dropped on a monitor, then select() on this ClickOverlay
-         * (which deactivates ClickOverlay and immediately activates/selects the dropped window.
-         */
-        this.signals.connect(global.display, 'grab-op-end', (display, mw, type) => {
-            if (this.monitor === this.mouseMonitor) {
-                this.select();
-            }
-        });
-    }
-
-    /**
-     * Returns the space of this ClickOverlay instance.
-     */
-    get space() {
-        return Tiling.spaces.monitors.get(this.monitor);
-    }
-
-    /**
-     * Returns the monitor the mouse is currently on.
-     */
-    get mouseMonitor() {
-        return Utils.monitorAtCurrentPoint();
-    }
-
-    monitorActiveCheck() {
-        // if clickoverlay not active (space is already selected), then nothing to do
-        if (!this.active) {
-            return;
-        }
-
-        if (Main.overview.visible || Tiling.inPreview) {
-            return;
-        }
-
-        // if mouse on me, select
-        if (this.monitor === this.mouseMonitor) {
-            this.select();
-        }
-    }
-
-    select() {
-        // if clickoverlay not active (space is already selected), then nothing to do
-        if (!this.active) {
-            return;
-        }
-
-        // check if in the midst of a window resize action
-        if (Tiling.inGrab && Tiling.inGrab instanceof Grab.ResizeGrab) {
-            const window = global.display?.focus_window;
-            if (window) {
-                Scratch.makeScratch(window);
-            }
-        }
-
-        /**
-         * stop navigation before activating workspace. Avoids an issue
-         * in multimonitors where workspaces can get snapped to another monitor.
-         */
-        Navigator.finishDispatching();
-        Navigator.finishNavigation(true);
-        this.deactivate();
-        let selected = this.space.selectedWindow;
-        this.space.activateWithFocus(selected, false, false);
-    }
-
-    activate() {
-        if (this.onlyOnPrimary || Main.overview.visible)
-            return;
-
-        let spaces = Tiling.spaces;
-        let active = global.workspace_manager.get_active_workspace();
-        let monitor = this.monitor;
-        // Never activate the clickoverlay of the active monitor
-        if (spaces && spaces.monitors.get(monitor) === spaces.get(active))
-            return;
-
-        this.active = true;
-        this.space?.setSelectionInactive();
-        this.enterMonitor.set_position(monitor.x, monitor.y);
-        this.enterMonitor.set_size(monitor.width, monitor.height);
-    }
-
-    deactivate() {
-        this.active = false;
-        this.enterMonitor.set_size(0, 0);
     }
 
     reset() {
@@ -255,10 +144,6 @@ export class ClickOverlay {
     }
 
     destroy() {
-        Utils.timeout_remove(this._lastPointerTimeout);
-        this._lastPointerTimeout = null;
-        this.signals.destroy();
-        this.signals = null;
         for (let overlay of [this.left, this.right]) {
             let actor = overlay.overlay;
             overlay.signals.destroy();
@@ -269,9 +154,6 @@ export class ClickOverlay {
             }
             actor.destroy();
         }
-
-        Main.layoutManager.untrackChrome(this.enterMonitor);
-        this.enterMonitor.destroy();
     }
 }
 

--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -87,14 +87,15 @@ export function enableMultimonitorDragDropSupport() {
                 if (window) {
                     Scratch.makeScratch(window);
                 }
+                return;
             }
 
-            /**
-             * stop navigation before activating workspace. Avoids an issue
-             * in multimonitors where workspaces can get snapped to another monitor.
-             */
-            Navigator.finishDispatching();
-            Navigator.finishNavigation(true);
+            // if drag/grabbing window, do simple activate
+            if (Tiling.inGrab) {
+                space?.activate(false, false);
+                return;
+            }
+
             const selected = space?.selectedWindow;
             space?.activateWithFocus(selected, false, false);
         });

--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -49,25 +49,25 @@ export function enable(extension) {
 }
 
 export function disable() {
-    disableMultimonitorDragDropSupport();
+    disableMultimonitorSupport();
     lastSpace = null;
 }
 
 /**
  * Checks for multiple monitors and if so, then enables multimonitor
- * drag/drop support in PaperWM.
+ * support in PaperWM.
  */
-export function multimonitorDragDropSupport() {
+export function multimonitorSupport() {
     // if only one monitor, return
     if (Tiling.spaces.monitors?.size > 1) {
-        enableMultimonitorDragDropSupport();
+        enableMultimonitorSupport();
     }
     else {
-        disableMultimonitorDragDropSupport();
+        disableMultimonitorSupport();
     }
 }
 
-export function enableMultimonitorDragDropSupport() {
+export function enableMultimonitorSupport() {
     pointerWatch = PointerWatcher.getPointerWatcher().addWatch(100,
         () => {
             const monitor = Utils.monitorAtCurrentPoint();
@@ -99,13 +99,13 @@ export function enableMultimonitorDragDropSupport() {
             const selected = space?.selectedWindow;
             space?.activateWithFocus(selected, false, false);
         });
-    console.debug('paperwm multimonitor drag/drop support is ENABLED');
+    console.debug('paperwm multimonitor support is ENABLED');
 }
 
-export function disableMultimonitorDragDropSupport() {
+export function disableMultimonitorSupport() {
     pointerWatch?.remove();
     pointerWatch = null;
-    console.debug('paperwm multimonitor drag/drop support is DISABLED');
+    console.debug('paperwm multimonitor support is DISABLED');
 }
 
 export function createAppIcon(metaWindow, size) {

--- a/tiling.js
+++ b/tiling.js
@@ -1955,7 +1955,6 @@ export const Spaces = class Spaces extends Map {
         for (let monitor of monitors) {
             let overlay = new ClickOverlay(monitor, this.onlyOnPrimary);
             monitor.clickOverlay = overlay;
-            overlay.activate();
             this.clickOverlays.push(overlay);
         }
 
@@ -1977,7 +1976,6 @@ export const Spaces = class Spaces extends Map {
             });
 
             this.spaceContainer.show();
-            activeSpace.monitor.clickOverlay.deactivate();
             Topbar.refreshWorkspaceIndicator();
             this.setSpaceTopbarElementsVisible();
             Stackoverlay.multimonitorDragDropSupport();
@@ -2294,14 +2292,6 @@ export const Spaces = class Spaces extends Map {
             toSpace,
             fromSpace,
             doAnimate);
-
-        toSpace.monitor?.clickOverlay.deactivate();
-
-        for (let monitor of Main.layoutManager.monitors) {
-            if (monitor === toSpace.monitor)
-                continue;
-            monitor.clickOverlay.activate();
-        }
 
         // Update panel to handle target workspace
         signals.disconnect(Main.panel, this.touchSignal);

--- a/tiling.js
+++ b/tiling.js
@@ -1978,7 +1978,7 @@ export const Spaces = class Spaces extends Map {
             this.spaceContainer.show();
             Topbar.refreshWorkspaceIndicator();
             this.setSpaceTopbarElementsVisible();
-            Stackoverlay.multimonitorDragDropSupport();
+            Stackoverlay.multimonitorSupport();
         };
 
         if (this.onlyOnPrimary) {


### PR DESCRIPTION
@Lythenas, @Thesola10, I've been thinking about this one for a while:

PaperWM uses a very curious approach to implement a "one space per monitor" paradigm (see [my response](https://github.com/peterfajdiga/karousel/issues/3#issuecomment-1705214515) to a question of how PaperWM does this).

Unfortunately this approach is quite complex and exhibits many side-effects that have required many workarounds (which often causes further issues).

This PR replaces this approach with a simpler `PointerWatcher` implementation (a Gnome supported implementation to monitor mouse pointer movements).  Moving to this approach provides the following advantages:

- switch to a Gnome supported feature to detect when mouse pointer moves to another monitor (instead of an unsupported, custom, error-prone implementation);
- significantly simplifies the codebase for PaperWM's multimonitor support;
- replaces around ~164 lines of (now) unneeded code with ~31 lines;
- removes a complex part of multimonitor support and would allow us to add simple behaviours (based on user preference) like https://github.com/paperwm/PaperWM/issues/389;

_Note: we actually already use the `PointerWatcher` approach for multi-monitor drag/drop support - so this PR is essentially removing the other approach and adding a "activate space" method to the `PointerWatcher`._

@Lythenas and @Thesola10 - could you give this PR branch a test?  I'll set it as a draft atm given it's quite a large change and I'm sure there might be some side-effects from this.

@Thesola10 - I note that this may impact some of your touch signals, although, we no longer have the ClickOverlay element blocking actions so it may turn out better (just a hypothesis).