### PR TITLE
Fix regression touchscreen support

### DIFF
--- a/grab.js
+++ b/grab.js
@@ -372,7 +372,7 @@ export class MoveGrab {
 
             if (dndTarget) {
                 let space = dndTarget.space;
-                space.selection.show();
+                space.showSelection();
 
                 if (Scratch.isScratchWindow(metaWindow))
                     Scratch.unmakeScratch(metaWindow);
@@ -414,6 +414,7 @@ export class MoveGrab {
                 metaWindow.move_frame(true, clone.x, clone.y);
                 Scratch.makeScratch(metaWindow);
                 this.initialSpace.moveDone();
+                this.initialSpace.showSelection();
 
                 actor.set_scale(clone.scale_x, clone.scale_y);
                 actor.opacity = clone.opacity;
@@ -542,7 +543,7 @@ export class MoveGrab {
         }
 
         zone.space.cloneContainer.add_child(zone.actor);
-        zone.space.selection.hide();
+        zone.space.hideSelection();
         zone.actor.show();
         raise();
         Easer.addEase(zone.actor, params);
@@ -550,7 +551,7 @@ export class MoveGrab {
 
     deactivateDndTarget(zone) {
         if (zone) {
-            zone.space.selection.show();
+            zone.space.showSelection();
             Easer.addEase(zone.actor, {
                 time: Settings.prefs.animation_time,
                 [zone.originProp]: zone.center,

--- a/minimap.js
+++ b/minimap.js
@@ -42,13 +42,13 @@ export class Minimap extends Array {
         let container = new St.Widget({ name: 'minimap-container' });
         this.container = container;
 
-        actor.add_actor(highlight);
-        actor.add_actor(label);
-        actor.add_actor(clip);
-        clip.add_actor(container);
+        actor.add_child(highlight);
+        actor.add_child(label);
+        actor.add_child(clip);
+        clip.add_child(container);
         clip.set_position(12 + Settings.prefs.window_gap, 12 + Math.round(1.5 * Settings.prefs.window_gap));
         highlight.y = clip.y - 10;
-        Main.uiGroup.add_actor(this.actor);
+        Main.uiGroup.add_child(this.actor);
         this.actor.opacity = 0;
         this.createClones();
 
@@ -143,8 +143,8 @@ export class Minimap extends Array {
         clone.meta_window = mw;
         container.clone = clone;
         container.meta_window = mw;
-        container.add_actor(clone);
-        this.container.add_actor(container);
+        container.add_child(clone);
+        this.container.add_child(container);
         return container;
     }
 

--- a/patches.js
+++ b/patches.js
@@ -321,21 +321,21 @@ export function setupOverrides() {
         }
         switch (mode) {
         case AppIconMode.THUMBNAIL_ONLY:
-            this._icon.add_actor(_createWindowClone(mutterWindow, size * scaleFactor));
+            this._icon.add_child(_createWindowClone(mutterWindow, size * scaleFactor));
             break;
 
         case AppIconMode.BOTH:
-            this._icon.add_actor(_createWindowClone(mutterWindow, size * scaleFactor));
+            this._icon.add_child(_createWindowClone(mutterWindow, size * scaleFactor));
 
             if (this.app) {
-                this._icon.add_actor(
+                this._icon.add_child(
                     this._createAppIcon(this.app, APP_ICON_SIZE_SMALL));
             }
             break;
 
         case AppIconMode.APP_ICON_ONLY:
             size = APP_ICON_SIZE;
-            this._icon.add_actor(this._createAppIcon(this.app, size));
+            this._icon.add_child(this._createAppIcon(this.app, size));
         }
 
         this._icon.set_size(size * scaleFactor, size * scaleFactor);

--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -262,7 +262,7 @@ export class StackOverlay {
         clone.opacity = 255 * 0.95;
 
         clone.set_scale(scale, scale);
-        Main.uiGroup.add_actor(clone);
+        Main.uiGroup.add_child(clone);
 
         let monitor = this.monitor;
         let scaleWidth = scale * clone.width;

--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -43,14 +43,13 @@ import { Settings, Utils, Tiling, Navigator, Grab, Scratch } from './imports.js'
   restack loops)
 */
 
-let pointerWatch, lastSpace;
+let pointerWatch;
 export function enable(extension) {
 
 }
 
 export function disable() {
     disableMultimonitorSupport();
-    lastSpace = null;
 }
 
 /**
@@ -74,11 +73,9 @@ export function enableMultimonitorSupport() {
             const space = Tiling.spaces.monitors.get(monitor);
 
             // same space
-            if (space === lastSpace) {
+            if (space === Tiling.spaces.activeSpace) {
                 return;
             }
-            // update to space
-            lastSpace = space;
 
             // check if in the midst of a window resize action
             if (Tiling.inGrab &&

--- a/tiling.js
+++ b/tiling.js
@@ -1630,8 +1630,13 @@ border-radius: ${borderWidth}px;
                 Navigator.finishNavigation();
             });
 
-        this.signals.connect(
-            this.background, 'scroll-event',
+        // ensure this space is active if touched
+        this.signals.connect(this.background, 'touch-event',
+            (actor, event) => {
+                this.activateWithFocus(this.selectedWindow, false, false);
+            });
+
+        this.signals.connect(this.background, 'scroll-event',
             (actor, event) => {
                 if (!inGrab && !Navigator.navigating)
                     return;

--- a/tiling.js
+++ b/tiling.js
@@ -268,7 +268,7 @@ export class Space extends Array {
         workspaceIndicator.connect('button-press-event', () => Main.overview.toggle());
         this.workspaceIndicator = workspaceIndicator;
         let workspaceLabel = new St.Label();
-        workspaceIndicator.add_actor(workspaceLabel);
+        workspaceIndicator.add_child(workspaceLabel);
         this.workspaceLabel = workspaceLabel;
         workspaceLabel.hide();
 
@@ -281,15 +281,15 @@ export class Space extends Array {
         clip.space = this;
         cloneContainer.space = this;
 
-        container.add_actor(clip);
-        clip.add_actor(actor);
-        actor.add_actor(workspaceIndicator);
+        container.add_child(clip);
+        clip.add_child(actor);
+        actor.add_child(workspaceIndicator);
         actor.add_child(this.focusModeIcon);
-        actor.add_actor(cloneClip);
-        cloneClip.add_actor(cloneContainer);
+        actor.add_child(cloneClip);
+        cloneClip.add_child(cloneContainer);
 
         this.border = new St.Widget({ name: "border" });
-        this.actor.add_actor(this.border);
+        this.actor.add_child(this.border);
         this.border.hide();
 
         let monitor = Main.layoutManager.primaryMonitor;
@@ -891,10 +891,10 @@ export class Space extends Array {
         this.visible.splice(this.visible.indexOf(metaWindow), 1);
 
         let clone = metaWindow.clone;
-        this.cloneContainer.remove_actor(clone);
+        this.cloneContainer.remove_child(clone);
         // Don't destroy the selection highlight widget
         if (clone.first_child.name === 'selection')
-            clone.remove_actor(clone.first_child);
+            clone.remove_child(clone.first_child);
         let actor = metaWindow.get_compositor_private();
         if (actor)
             actor.remove_clip();
@@ -930,7 +930,7 @@ export class Space extends Array {
         if (i === -1)
             return false;
         this._floating.splice(i, 1);
-        this.actor.remove_actor(metaWindow.clone);
+        this.actor.remove_child(metaWindow.clone);
         return true;
     }
 
@@ -1313,11 +1313,11 @@ export class Space extends Array {
         let showTopBar = this.getShowTopBarSetting();
 
         // remove window position bar actors
-        this.actor.remove_actor(this.windowPositionBarBackdrop);
-        this.actor.remove_actor(this.windowPositionBar);
+        this.actor.remove_child(this.windowPositionBarBackdrop);
+        this.actor.remove_child(this.windowPositionBar);
         if (showTopBar) {
-            this.actor.add_actor(this.windowPositionBarBackdrop);
-            this.actor.add_actor(this.windowPositionBar);
+            this.actor.add_child(this.windowPositionBarBackdrop);
+            this.actor.add_child(this.windowPositionBar);
         }
 
         this.updateShowTopBar();
@@ -3006,7 +3006,7 @@ export function registerWindow(metaWindow) {
     let cloneActor = new Clutter.Clone({ source: actor });
     let clone = new Clutter.Actor();
 
-    clone.add_actor(cloneActor);
+    clone.add_child(cloneActor);
     clone.targetX = 0;
     clone.meta_window = metaWindow;
 
@@ -4644,7 +4644,7 @@ export function takeWindow(metaWindow, space, { navigator }) {
 
     navigator._moving.push(metaWindow);
     let parent = backgroundGroup;
-    parent.add_actor(metaWindow.clone);
+    parent.add_child(metaWindow.clone);
     let lowest = navigator._moving[navigator._moving.length - 2];
     lowest && parent.set_child_below_sibling(metaWindow.clone, lowest.clone);
     let point = space.cloneContainer.apply_relative_transform_to_point(

--- a/topbar.js
+++ b/topbar.js
@@ -177,9 +177,9 @@ export function popupMenuEntryHelper(text) {
         this.prevIcon.grab_key_focus();
     });
 
-    this.actor.add_actor(this.prevIcon);
-    this.actor.add_actor(this.label);
-    this.actor.add_actor(this.nextIcon);
+    this.actor.add_child(this.prevIcon);
+    this.actor.add_child(this.label);
+    this.actor.add_child(this.nextIcon);
     this.actor.label_actor = this.label;
     this.label.clutter_text.connect('activate', this.emit.bind(this, 'activate'));
 }
@@ -213,7 +213,7 @@ class Color {
         this.color = color;
         this.actor = new St.Button();
         let icon = new St.Widget();
-        this.actor.add_actor(icon);
+        this.actor.add_child(icon);
         icon.set_style(`background: ${color}`);
         icon.set_size(20, 20);
         icon.set_position(4, 4);
@@ -235,11 +235,11 @@ class ColorEntry {
         let flowbox = new St.Widget();
         let flowLayout = new Clutter.FlowLayout();
         let flow = new St.Widget();
-        flowbox.add_actor(flow);
+        flowbox.add_child(flow);
         flow.layout_manager = flowLayout;
         flow.width = 24 * 16;
         for (let c of colors) {
-            flow.add_actor(new Color(c, this).actor);
+            flow.add_child(new Color(c, this).actor);
         }
 
         this.entry = new PopupMenuEntry(startColor, 'Set color');
@@ -251,8 +251,8 @@ class ColorEntry {
 
         this.entry.button.connect('clicked', this.clicked.bind(this));
 
-        this.actor.add_actor(this.entry.actor);
-        this.actor.add_actor(flowbox);
+        this.actor.add_child(this.entry.actor);
+        this.actor.add_child(flowbox);
     }
 
     clicked() {
@@ -429,7 +429,7 @@ export const WorkspaceMenu = GObject.registerClass(
 
             this.setName(Meta.prefs_get_workspace_name(workspaceManager.get_active_workspace_index()));
 
-            this.add_actor(this.label);
+            this.add_child(this.label);
 
             this.signals = new Utils.Signals();
             this.signals.connect(global.window_manager,
@@ -531,7 +531,7 @@ export const WorkspaceMenu = GObject.registerClass(
                     this._navigator = Navigator.getNavigator();
                     Tiling.spaces.initWorkspaceSequence();
                     this._enterbox = new Clutter.Actor({ reactive: true });
-                    Main.uiGroup.add_actor(this._enterbox);
+                    Main.uiGroup.add_child(this._enterbox);
                     this._enterbox.set_position(panelBox.x, panelBox.y + panelBox.height + 20);
                     this._enterbox.set_size(global.screen_width, global.screen_height);
                     Main.layoutManager.trackChrome(this._enterbox);

--- a/utils.js
+++ b/utils.js
@@ -117,7 +117,7 @@ export function toggleWindowBoxes(metaWindow) {
         boxes.push(makeFrameBox(actor, "yellow"));
     }
 
-    boxes.forEach(box => global.stage.add_actor(box));
+    boxes.forEach(box => global.stage.add_child(box));
 
     metaWindow._paperDebugBoxes = boxes;
     return boxes;

--- a/virtTiling.js
+++ b/virtTiling.js
@@ -55,13 +55,13 @@ export function repl() {
     let tilingStyle = `background-color: rgba(190, 190, 0, 0.3);`;
     let tilingContainer = new St.Widget({ name: "tiling", style: tilingStyle });
 
-    global.stage.add_actor(virtStage);
+    global.stage.add_child(virtStage);
     virtStage.x = 3000;
     virtStage.y = 300;
 
-    virtStage.add_actor(monitor);
-    monitor.add_actor(panel);
-    monitor.add_actor(tilingContainer);
+    virtStage.add_child(monitor);
+    monitor.add_child(panel);
+    monitor.add_child(tilingContainer);
 
     function sync(space_ = space) {
         let columns = layout(
@@ -143,7 +143,7 @@ export function render(columns, tiling) {
     for (let col of columns) {
         for (let window of col) {
             let windowActor = createWindowActor(window);
-            tiling.add_actor(windowActor);
+            tiling.add_child(windowActor);
         }
     }
 }


### PR DESCRIPTION
This PR implements some fixes for a regression to touchscreen support by #751.

It also includes some smaller fixes implemented during development of #755.  Lastly, it includes replacing deprecated methods (which are entirely removed int Gnome 46).

@Thesola10, can you give this branch a test and let me know if touch is working again?