### PR TITLE
FIX for #758: tiling window is unclickable sometimes after session unlock

### DIFF
--- a/scratch.js
+++ b/scratch.js
@@ -206,8 +206,7 @@ export function show(top) {
     windows[0].activate(global.get_current_time());
 
     let monitor = Tiling.focusMonitor();
-    if (monitor.clickOverlay)
-        monitor.clickOverlay.hide();
+    monitor.clickOverlay?.hide();
 }
 
 export function hide() {

--- a/tiling.js
+++ b/tiling.js
@@ -1927,8 +1927,6 @@ export const Spaces = class Spaces extends Map {
         // Initialize spaces _after_ monitors are set up
         this.forEach(space => space.init());
 
-
-
         // Bind to visible workspace when starting up
         this.touchSignal = signals.connect(Main.panel, "captured-event", Gestures.horizontalTouchScroll.bind(this.activeSpace));
 

--- a/tiling.js
+++ b/tiling.js
@@ -159,6 +159,16 @@ export function enable(extension) {
             spaces.forEach(s => {
                 s.setSpaceTopbarElementsVisible();
                 s.updateName();
+
+                /**
+                 * The below resolves https://github.com/paperwm/PaperWM/issues/758.
+                 */
+                const active = spaces.activeSpace;
+                if (active) {
+                    const x = active.cloneContainer.x;
+                    active.viewportMoveToX(0);
+                    active.viewportMoveToX(x);
+                }
             });
         });
     };
@@ -1916,6 +1926,8 @@ export const Spaces = class Spaces extends Map {
 
         // Initialize spaces _after_ monitors are set up
         this.forEach(space => space.init());
+
+
 
         // Bind to visible workspace when starting up
         this.touchSignal = signals.connect(Main.panel, "captured-event", Gestures.horizontalTouchScroll.bind(this.activeSpace));


### PR DESCRIPTION
This PR fixes #758.

On unlock (or disable/enable), a tiled window that can be unclickable (and not respond to normal window events... almost like it's still unmapped) until a PaperWM action (e.g. move selection or move cloneContainer etc.).

This may be related to autostarted windows (those that start before PaperWM starts).