### PR TITLE
FIX for #758: tiling window is unclickable sometimes after session unlock (for all spaces)

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -163,12 +163,9 @@ export function enable(extension) {
                 /**
                  * The below resolves https://github.com/paperwm/PaperWM/issues/758.
                  */
-                const active = spaces.activeSpace;
-                if (active) {
-                    const x = active.cloneContainer.x;
-                    active.viewportMoveToX(0);
-                    active.viewportMoveToX(x);
-                }
+                const x = s.cloneContainer.x;
+                s.viewportMoveToX(0);
+                s.viewportMoveToX(x);
             });
         });
     };


### PR DESCRIPTION
Improvement on #760.

#760 fixed this issue for the active space only.  This applies to all spaces on init to fix the issue for all spaces.