### PR TITLE
Add global touch coords broker

### DIFF
--- a/grab.js
+++ b/grab.js
@@ -63,7 +63,7 @@ export class MoveGrab {
 
         this.initialY = clone.targetY;
         Easer.removeEase(clone);
-        let [gx, gy, $] = global.get_pointer();
+        let [gx, gy, $] = Utils.getPointerCoords();
 
         let px = (gx - actor.x) / actor.width;
         let py = (gy - actor.y) / actor.height;
@@ -86,7 +86,8 @@ export class MoveGrab {
 
         this.signals.connect(this.actor, "button-release-event", this.end.bind(this));
         this.signals.connect(this.actor, "touch-event", (act, evt) => {
-            if (evt.type() === Clutter.EventType.TOUCH_END) {
+            if (evt.type() === Clutter.EventType.TOUCH_END
+                || evt.type() === Clutter.EventType.TOUCH_CANCEL) {
                 this.end();
             }
             else {
@@ -121,7 +122,7 @@ export class MoveGrab {
         let clone = metaWindow.clone;
         let space = this.initialSpace;
 
-        let [gx, gy, $] = global.get_pointer();
+        let [gx, gy, $] = Utils.getPointerCoords();
         let point = {};
         if (center) {
             point = space.cloneContainer.apply_relative_transform_to_point(
@@ -177,7 +178,7 @@ export class MoveGrab {
     }
 
     spaceMotion(space, background, event) {
-        let [gx, gy, $] = global.get_pointer();
+        let [gx, gy, $] = Utils.getPointerCoords();
         let [sx, sy] = space.globalToScroll(gx, gy, { useTarget: true });
         this.selectDndZone(space, sx, sy);
     }
@@ -308,12 +309,7 @@ export class MoveGrab {
     motion(actor, event) {
         let metaWindow = this.window;
         // let [gx, gy] = event.get_coords();
-        let [gx, gy, $] = global.get_pointer();
-        if (event.type() === Clutter.EventType.TOUCH_UPDATE) {
-            [gx, gy] = event.get_coords();
-            // We update global pointer to match touch event
-            Utils.warpPointer(gx, gy, false);
-        }
+        let [gx, gy, $] = Utils.getPointerCoords();
         let [dx, dy] = this.pointerOffset;
         let clone = metaWindow.clone;
 
@@ -370,7 +366,7 @@ export class MoveGrab {
         let metaWindow = this.window;
         let actor = metaWindow.get_compositor_private();
         let clone = metaWindow.clone;
-        let [gx, gy, $] = global.get_pointer();
+        let [gx, gy, $] = Utils.getPointerCoords();
 
         this.zoneActors.forEach(actor => actor.destroy());
         let params = {
@@ -498,7 +494,7 @@ export class MoveGrab {
         Utils.later_add(Meta.LaterType.IDLE, () => {
             if (!global.display.end_grab_op && this.wasTiled) {
                 // move to current cursor position
-                let [x, y, _mods] = global.get_pointer();
+                let [x, y, _mods] = Utils.getPointerCoords();
                 getVirtualPointer().notify_absolute_motion(
                     Clutter.get_current_event_time(),
                     x, y);

--- a/utils.js
+++ b/utils.js
@@ -16,15 +16,37 @@ const Display = global.display;
 export let version = Config.PACKAGE_VERSION.split('.').map(Number);
 
 let warpRipple;
+
+let touchSignal = null;
+let inTouch = false;
+let touchCoords = null;
+
 export function enable() {
     warpRipple = new Ripples.Ripples(0.5, 0.5, 'ripple-pointer-location');
     warpRipple.addTo(Main.uiGroup);
+
+    touchSignal = global.stage.connect("captured-event", (actor, event) => {
+        switch (event.type()) {
+        case Clutter.EventType.TOUCH_BEGIN:
+        case Clutter.EventType.TOUCH_UPDATE:
+            inTouch = true;
+            break;
+        case Clutter.EventType.TOUCH_END:
+        case Clutter.EventType.TOUCH_CANCEL:
+            inTouch = false;
+            break;
+        }
+        touchCoords = event.get_coords();
+        return Clutter.EVENT_PROPAGATE;
+    });
 }
 
 export function disable() {
     warpRipple?.destroy();
     warpRipple = null;
     markNewClonesSignalId = null;
+
+    global.stage.disconnect(touchSignal);
 }
 
 export function assert(condition, message, ...dump) {
@@ -162,6 +184,16 @@ export function isInRect(x, y, r) {
 }
 
 /**
+ * Retrieves global pointer coordinates taking into account touch screen events.
+ */
+export function getPointerCoords() {
+    if (inTouch)
+        return touchCoords;
+    else
+        return global.get_pointer();
+}
+
+/**
  * Returns monitor a pointer co-ordinates.
  */
 export function monitorAtPoint(gx, gy) {
@@ -176,7 +208,7 @@ export function monitorAtPoint(gx, gy) {
  * Returns the monitor current pointer coordinates.
  */
 export function monitorAtCurrentPoint() {
-    let [gx, gy, $] = global.get_pointer();
+    let [gx, gy, $] = getPointerCoords();
     return monitorAtPoint(gx, gy);
 }
 

--- a/utils.js
+++ b/utils.js
@@ -35,7 +35,11 @@ export function enable() {
         case Clutter.EventType.TOUCH_CANCEL:
             inTouch = false;
             break;
+        default:
+            return Clutter.EVENT_PROPAGATE;
         }
+
+        // was one of our touch events
         touchCoords = event.get_coords();
         return Clutter.EVENT_PROPAGATE;
     });


### PR DESCRIPTION
This closes #764 by implementing a broker function, `Utils.getPointerCoords()`, which selects from `global.get_cursor()` and a memorized set of coordinates from the last touch event on Stage.

Hopefully this approach will also correct future touchscreen misbehavior.

**Edit** 2024-03-09:

This PR has been ~~repurposed as a continuation for~~ accidentally superseded by the broker partly introduced in #791.