### PR TITLE
Add Action to rebase release PR to develop

### DIFF
--- a/.github/workflows/rebase-pr.yaml
+++ b/.github/workflows/rebase-pr.yaml
@@ -20,14 +20,14 @@ jobs:
         with:
           script: |
             github.rest.pulls.update({
-              pull_number: context.number,
+              pull_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
 
               base: "develop"
             });
             github.rest.issues.createComment({
-              issue_number: context.number,
+              issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: "Thanks for your contribution! We don't accept pull requests to the `release` branch. I have rebased your pull request onto `develop`, check for any conflicts."

--- a/.github/workflows/rebase-pr.yaml
+++ b/.github/workflows/rebase-pr.yaml
@@ -1,0 +1,34 @@
+#
+# This workflow catches PRs made to 'release' and rebases them onto 'develop'
+#
+
+name: rebase-pr
+
+on:
+  pull_request:
+    types: [opened]
+    branches:
+      - release
+
+jobs:
+  rebase-pr:
+    name: Rebase pull request
+    runs-on: ubuntu-latest
+    steps:
+      - name: Perform rebase
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.pulls.update({
+              pull_number = context.pull.number,
+              owner = context.repo.owner,
+              repo = context.repo.repo,
+
+              base = "develop"
+            });
+            github.rest.issues.createComment({
+              issue_number = context.pull.number,
+              owner = context.repo.owner,
+              repo = context.repo.repo,
+              body = "Thanks for your contribution! We don't accept pull requests to the `release` branch. I have rebased your pull request onto `develop`, check for any conflicts."
+            });

--- a/.github/workflows/rebase-pr.yaml
+++ b/.github/workflows/rebase-pr.yaml
@@ -20,15 +20,15 @@ jobs:
         with:
           script: |
             github.rest.pulls.update({
-              pull_number = context.pull.number,
-              owner = context.repo.owner,
-              repo = context.repo.repo,
+              pull_number: context.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
 
-              base = "develop"
+              base: "develop"
             });
             github.rest.issues.createComment({
-              issue_number = context.pull.number,
-              owner = context.repo.owner,
-              repo = context.repo.repo,
-              body = "Thanks for your contribution! We don't accept pull requests to the `release` branch. I have rebased your pull request onto `develop`, check for any conflicts."
+              issue_number: context.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "Thanks for your contribution! We don't accept pull requests to the `release` branch. I have rebased your pull request onto `develop`, check for any conflicts."
             });


### PR DESCRIPTION
This (as of yet untested) GitHub action will automatically detect PRs created against `release` and redirect them to `develop` (and leave a nice comment).

This only applies on creation, so PRs can still be rebased to `release` if needs be.