### PR TITLE
Fixes 769 - guard against recursive call on position changed

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -846,6 +846,15 @@ export class Space extends Array {
         this.signals.connect(metaWindow, 'position-changed', w => {
             if (inGrab)
                 return;
+
+            // guard against recursively calling this method
+            // see https://github.com/paperwm/PaperWM/issues/769
+            if (w.pos_change_time &&
+                w.pos_change_time === global.get_current_time()) {
+                return;
+            }
+            delete w.pos_change_time;
+
             let f = w.get_frame_rect();
             let clone = w.clone;
             let x = this.visibleX(w);
@@ -854,6 +863,7 @@ export class Space extends Array {
             x += this.monitor.x;
             if (f.x !== x || f.y !== y) {
                 try {
+                    w.pos_change_time = global.get_current_time();
                     w.move_frame(true, x, y);
                 }
                 catch (ex) {

--- a/tiling.js
+++ b/tiling.js
@@ -847,6 +847,20 @@ export class Space extends Array {
             if (inGrab)
                 return;
 
+            let f = w.get_frame_rect();
+            let clone = w.clone;
+            let x = this.visibleX(w);
+            let y = this.monitor.y + clone.targetY;
+            x = Math.min(this.width - stack_margin, Math.max(stack_margin - f.width, x));
+            x += this.monitor.x;
+
+            // check if mismatch tracking needed, otherwise leave
+            if (f.x === x && f.y === y) {
+                // delete any mismatch counter (e.g. from previous attempt)
+                delete w.pos_mismatch_count;
+                return;
+            }
+
             // guard against recursively calling this method
             // see https://github.com/paperwm/PaperWM/issues/769
             if (w.pos_mismatch_count &&
@@ -855,30 +869,19 @@ export class Space extends Array {
                 return;
             }
 
-            let f = w.get_frame_rect();
-            let clone = w.clone;
-            let x = this.visibleX(w);
-            let y = this.monitor.y + clone.targetY;
-            x = Math.min(this.width - stack_margin, Math.max(stack_margin - f.width, x));
-            x += this.monitor.x;
-            if (f.x === x && f.y === y) {
-                delete w.pos_mismatch_count;
+            // mismatch detected
+            // move frame to ensure window position matches clone
+            try {
+                if (!w.pos_mismatch_count) {
+                    w.pos_mismatch_count = 0;
+                }
+                else {
+                    w.pos_mismatch_count += 1;
+                }
+                w.move_frame(true, x, y);
             }
-            else {
-                // mismatch detected
-                // move frame to ensure window position matches clone
-                try {
-                    if (!w.pos_mismatch_count) {
-                        w.pos_mismatch_count = 0;
-                    }
-                    else {
-                        w.pos_mismatch_count += 1;
-                    }
-                    w.move_frame(true, x, y);
-                }
-                catch (ex) {
+            catch (ex) {
 
-                }
             }
         });
 

--- a/tiling.js
+++ b/tiling.js
@@ -839,9 +839,9 @@ export class Space extends Array {
         }
 
         /*
-         * Fix (still needed is 44) for bug where move_frame sometimes triggers
+         * Fix (still needed in 45) for bug where move_frame sometimes triggers
          * another move back to its original position. Make sure tiled windows are
-         * always positioned correctly.
+         * always positioned correctly (synced with clone position).
          */
         this.signals.connect(metaWindow, 'position-changed', w => {
             if (inGrab)
@@ -851,6 +851,7 @@ export class Space extends Array {
             // see https://github.com/paperwm/PaperWM/issues/769
             if (w.pos_change_time &&
                 w.pos_change_time === global.get_current_time()) {
+                console.warn(`clone/window position-changed recursive call: ${w.title}`);
                 return;
             }
             delete w.pos_change_time;


### PR DESCRIPTION
Resovles #769.

See #769.  Adds a guard on recursively  calling `position-changed`.  This purportedly can happen on windows that resist / do not respect `move_frame`, which causes a recursion and can lead to session freeze.