### PR TITLE
tiling: cycle through windows when switching beyond the first or last windows

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -1012,6 +1012,11 @@ export class Space extends Array {
         let row = column.indexOf(this.selectedWindow);
         if (Lib.in_bounds(column, row + dir) === false) {
             index += dir;
+            if (index >= this.length) {
+                index = 0;
+            } else if (index < 0) {
+                index = this.length - 1;
+            }
             if (dir === 1) {
                 if (index < this.length)
                     row = 0;


### PR DESCRIPTION
The "switch-next" and "switch-prev" actions currently do nothing once they reach the first or last or windows. Make these actions more useful by making them cycle around instead.

Cycle to the first window when using "switch-next" on the last window.

Cycle to the last window when using "switch-prev" on the first window.