### PR TITLE
Disable stackoverlay switching if tiling preview scale is set to 0

### DIFF
--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -181,7 +181,9 @@ export class StackOverlay {
 
         this.triggerPreviewTimeout = null;
         this.signals.connect(overlay, 'button-press-event', () => {
-            Main.activateWindow(this.target);
+            if (Settings.prefs.edge_preview_scale > 0) {
+                Main.activateWindow(this.target);
+            }
             // remove/cleanup the previous preview
             this.removePreview();
             this.triggerPreviewTimeout = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 200, () => {


### PR DESCRIPTION
This PR resovles #793.

If tiling preview scale is set to zero, then stop switching to offscreen windows.  See #793.