### PR TITLE
Adds multiple window management with new "take window" functionality

### DIFF
--- a/navigator.js
+++ b/navigator.js
@@ -293,7 +293,7 @@ class NavigatorClass {
          */
         this.takeHint = new St.Label({ style_class: 'take-window-hint' });
         this.takeHint.clutter_text.set_markup(
-            `<b>Take window mode:</b>
+            `<b>"Take window" mode:</b>
 <i>• release keys to return all taken windows</i>
 <i>• press <span foreground="#6be67b">spacebar</span> to return the last taken window</i>
 <i>• press <span foreground="#6be67b">q</span> to close all taken windows</i>`);
@@ -344,7 +344,7 @@ class NavigatorClass {
         if (show) {
             const stage = global.stage;
             // set position on stage
-            const x = stage.width - 400;
+            const x = stage.width - 334;
             const y = 40;
 
             this.takeHint.opacity = 0;

--- a/navigator.js
+++ b/navigator.js
@@ -342,9 +342,9 @@ class NavigatorClass {
      */
     showTakeHint(show = true) {
         if (show) {
-            const stage = global.stage;
-            // set position on stage
-            const x = stage.width - 334;
+            // set position on stage, take into account monitor
+            const monitor = this.space.monitor;
+            const x = monitor.x + monitor.width - 335;
             const y = 40;
 
             this.takeHint.opacity = 0;

--- a/navigator.js
+++ b/navigator.js
@@ -157,12 +157,16 @@ class ActionDispatcher {
             this._modifierMask = getModLock(event.get_state());
         }
         let keysym = event.get_key_symbol();
-        let action = global.display.get_keybinding_action(event.get_key_code(), event.get_state());
+        let action = global.display.get_keybinding_action(
+            event.get_key_code(),
+            event.get_state());
 
-        // action callbacks that have been added
-        this.keyPressCallbacks.forEach(callback => {
-            callback(actor, event);
-        });
+        // run callbacks and if any return true, stop bubbling
+        if (this.keyPressCallbacks.some(callback => {
+            return callback(actor, event);
+        })) {
+            return Clutter.EVENT_STOP;
+        }
 
         // Popping the modal on keypress doesn't work properly, as the release
         // event will leak to the active window. To work around this we initate
@@ -457,14 +461,6 @@ export function getActionDispatcher(mode) {
     }
     dispatcher = new ActionDispatcher();
     return getActionDispatcher(mode);
-}
-
-/**
- * Returns the current ActionDispatcher (if there is one).
- * @returns {ActionDispatcher}
- */
-export function getCurrentDispatcher() {
-    return dispatcher;
 }
 
 /**

--- a/navigator.js
+++ b/navigator.js
@@ -293,8 +293,7 @@ class NavigatorClass {
          */
         this.takeHint = new St.Label({ style_class: 'take-window-hint' });
         this.takeHint.clutter_text.set_markup(
-            `<b>"Take window" mode:</b>
-<i>• release keys to return all taken windows</i>
+            `<i>• release keys to return all taken windows</i>
 <i>• press <span foreground="#6be67b">spacebar</span> to return the last taken window</i>
 <i>• press <span foreground="#6be67b">q</span> to close all taken windows</i>`);
 
@@ -344,8 +343,8 @@ class NavigatorClass {
         if (show) {
             // set position on stage, take into account monitor
             const monitor = this.space.monitor;
-            const x = monitor.x + monitor.width - 335;
-            const y = 40;
+            const x = monitor.x + monitor.width - 334;
+            const y = monitor.height - 80;
 
             this.takeHint.opacity = 0;
             global.stage.add_child(this.takeHint);

--- a/navigator.js
+++ b/navigator.js
@@ -93,8 +93,18 @@ class ActionDispatcher {
         this.signals.connect(this.actor, 'key-press-event', this._keyPressEvent.bind(this));
         this.signals.connect(this.actor, 'key-release-event', this._keyReleaseEvent.bind(this));
 
+        this.keyPressCallbacks = [];
+
         this._noModsTimeoutId = null;
         this._doActionTimeout = null;
+    }
+
+    /**
+     * Adds a signal to this dispatcher.  Will be destroyed when this
+     * dispatcher is destroyed.
+     */
+    addKeypressCallback(handler) {
+        this.keyPressCallbacks.push(handler);
     }
 
     show(backward, binding, mask) {
@@ -148,6 +158,11 @@ class ActionDispatcher {
         }
         let keysym = event.get_key_symbol();
         let action = global.display.get_keybinding_action(event.get_key_code(), event.get_state());
+
+        // action callbacks that have been added
+        this.keyPressCallbacks.forEach(callback => {
+            callback(actor, event);
+        });
 
         // Popping the modal on keypress doesn't work properly, as the release
         // event will leak to the active window. To work around this we initate
@@ -442,6 +457,14 @@ export function getActionDispatcher(mode) {
     }
     dispatcher = new ActionDispatcher();
     return getActionDispatcher(mode);
+}
+
+/**
+ * Returns the current ActionDispatcher (if there is one).
+ * @returns {ActionDispatcher}
+ */
+export function getCurrentDispatcher() {
+    return dispatcher;
 }
 
 /**

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -33,7 +33,7 @@ NOTE: please update `./config/users.css` with any new styles added here.
 }
 
 .take-window-hint {
-    background-color: rgba(0, 0, 0, 0.6);
+    background-color: rgba(0, 0, 0, 0.8);
     padding: 8px;
     border-radius: 8px;
 }

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -32,6 +32,12 @@ NOTE: please update `./config/users.css` with any new styles added here.
     font-weight: 600;
 }
 
+.take-window-hint {
+    background-color: rgba(0, 0, 0, 0.6);
+    padding: 8px;
+    border-radius: 8px;
+}
+
 .workspace-icon-button {
     -st-icon-style: symbolic;
     border: none;

--- a/tiling.js
+++ b/tiling.js
@@ -4799,6 +4799,7 @@ export function takeWindow(metaWindow, space, { navigator }) {
                         insertWindow(pop, { existing: true });
                         // make space selectedWindow (keeps index for next insert)
                         selectedSpace.selectedWindow = pop;
+                        ensureViewport(pop);
                     }
                     // return true if this was actioned
                     return true;

--- a/tiling.js
+++ b/tiling.js
@@ -4808,13 +4808,8 @@ export function takeWindow(metaWindow, space, { navigator }) {
                 if (keysym === Clutter.KEY_q) {
                     // close all taken windows
                     navigator._moving.forEach(w => {
-                        Utils.Easer.addEase(w.clone, {
-                            time: Settings.prefs.animation_time,
-                            opacity: 0,
-                            onComplete: () => {
-                                w.delete(global.get_current_time());
-                            },
-                        });
+                        insertWindow(w, { existing: true });
+                        w.delete(global.get_current_time());
                     });
 
                     navigator._moving = [];

--- a/tiling.js
+++ b/tiling.js
@@ -4786,7 +4786,7 @@ export function takeWindow(metaWindow, space, { navigator }) {
         navigator._moving = [];
 
         // get the action dispatcher signal to connect to
-        Navigator.getCurrentDispatcher()
+        Navigator.getActionDispatcher(Clutter.GrabState.KEYBOARD)
             .addKeypressCallback((actor, event) => {
                 const keysym = event.get_key_symbol();
                 if (keysym === Clutter.KEY_space) {
@@ -4799,7 +4799,23 @@ export function takeWindow(metaWindow, space, { navigator }) {
                         // make space selectedWindow (keeps index for next insert)
                         selectedSpace.selectedWindow = pop;
                     }
+                    // return true if this was actioned
+                    return true;
                 }
+
+                // quit / close all that have been taken
+                if (keysym === Clutter.KEY_q) {
+                    // close all taken windows
+                    navigator._moving.forEach(w => {
+                        w.delete(global.get_current_time());
+                    });
+
+                    navigator._moving = [];
+                    return true;
+                }
+
+                // return false if no action taken
+                return false;
             });
 
 

--- a/tiling.js
+++ b/tiling.js
@@ -4788,22 +4788,17 @@ export function takeWindow(metaWindow, space, { navigator }) {
         // get the action dispatcher signal to connect to
         Navigator.getCurrentDispatcher()
             .addKeypressCallback((actor, event) => {
-                console.log(`pressed`);
                 const keysym = event.get_key_symbol();
                 if (keysym === Clutter.KEY_space) {
                     // remove the last window you got
+                    const pop = navigator._moving.pop();
                     let selectedSpace = spaces.selectedSpace;
-                    navigator._moving.forEach(w => {
-                        w.change_workspace(selectedSpace.workspace);
-                        if (w.get_workspace() === selectedSpace.workspace) {
-                            insertWindow(w, { existing: true });
-
-                            // make space selectedWindow (keeps index for next insert)
-                            selectedSpace.selectedWindow = w;
-                        }
-                    });
-
-                    return Clutter.EVENT_STOP;
+                    if (pop) {
+                        pop.change_workspace(selectedSpace.workspace);
+                        insertWindow(pop, { existing: true });
+                        // make space selectedWindow (keeps index for next insert)
+                        selectedSpace.selectedWindow = pop;
+                    }
                 }
             });
 

--- a/tiling.js
+++ b/tiling.js
@@ -4807,7 +4807,13 @@ export function takeWindow(metaWindow, space, { navigator }) {
                 if (keysym === Clutter.KEY_q) {
                     // close all taken windows
                     navigator._moving.forEach(w => {
-                        w.delete(global.get_current_time());
+                        Easer.addEase(w.clone, {
+                            time: Settings.prefs.animation_time,
+                            opacity: 0,
+                            onComplete: () => {
+                                w.delete(global.get_current_time());
+                            },
+                        });
                     });
 
                     navigator._moving = [];

--- a/tiling.js
+++ b/tiling.js
@@ -4783,6 +4783,7 @@ export function takeWindow(metaWindow, space, { navigator }) {
         return;
 
     if (!navigator._moving) {
+        navigator.showTakeHint(true);
         navigator._moving = [];
 
         // get the action dispatcher signal to connect to
@@ -4807,7 +4808,7 @@ export function takeWindow(metaWindow, space, { navigator }) {
                 if (keysym === Clutter.KEY_q) {
                     // close all taken windows
                     navigator._moving.forEach(w => {
-                        Easer.addEase(w.clone, {
+                        Utils.Easer.addEase(w.clone, {
                             time: Settings.prefs.animation_time,
                             opacity: 0,
                             onComplete: () => {
@@ -4826,6 +4827,7 @@ export function takeWindow(metaWindow, space, { navigator }) {
 
 
         signals.connectOneShot(navigator, 'destroy', () => {
+            navigator.showTakeHint(false);
             let selectedSpace = spaces.selectedSpace;
             navigator._moving.forEach(w => {
                 w.change_workspace(selectedSpace.workspace);


### PR DESCRIPTION
This PR adds new functionality to the "take" window implementation in PaperWM.

I often use the "take" window functionality.  However, sometimes I accidentally take a window I don't want, meant that I have to "drop" all windows and start again.  This PR adds the following features when users are in "take" mode:
- press `spacebar` to return/drop (only) the last taken window;
- press `q` to close all taken windows;

This functionality can now be used to manage multiple windows at once, e.g. you could collect multiple windows to close them all at once, or you can now take multiple windows and place a few on another space, and some on yet another space.

#### Selectively take/drop windows (pressing `spacebar` to drop the latest taken window):
https://github.com/paperwm/PaperWM/assets/30424662/f736adea-d5ba-4c9d-aca0-2f63322c08cb

#### Selecting multiple windows to close at once (pressing `q`):
https://github.com/paperwm/PaperWM/assets/30424662/e0d9aca1-93e5-4f51-b4c5-8d8e299a02f8

#### Selecting all windows across spaces to close at once (pressing `q`):
https://github.com/paperwm/PaperWM/assets/30424662/e6596de2-f5f7-46af-b447-044f17f326f9







