### PR TITLE
Add `tab` shortcuts to cycle "take" windows (improves #808)

### DIFF
--- a/navigator.js
+++ b/navigator.js
@@ -294,6 +294,7 @@ class NavigatorClass {
         this.takeHint = new St.Label({ style_class: 'take-window-hint' });
         this.takeHint.clutter_text.set_markup(
             `<i>• release keys to return all taken windows</i>
+<i>• press <span foreground="#6be67b">tab</span> to cycle through taken windows</i>
 <i>• press <span foreground="#6be67b">spacebar</span> to return the last taken window</i>
 <i>• press <span foreground="#6be67b">q</span> to close all taken windows</i>`);
 
@@ -344,7 +345,7 @@ class NavigatorClass {
             // set position on stage, take into account monitor
             const monitor = this.space.monitor;
             const x = monitor.x + monitor.width - 334;
-            const y = monitor.height - 80;
+            const y = monitor.height - 98;
 
             this.takeHint.opacity = 0;
             global.stage.add_child(this.takeHint);

--- a/navigator.js
+++ b/navigator.js
@@ -293,8 +293,7 @@ class NavigatorClass {
          */
         this.takeHint = new St.Label({ style_class: 'take-window-hint' });
         this.takeHint.clutter_text.set_markup(
-            `<i>• release keys to return all taken windows</i>
-<i>• press <span foreground="#6be67b">spacebar</span> to return the last taken window</i>
+            `<i>• press <span foreground="#6be67b">spacebar</span> to return the last taken window</i>
 <i>• press <span foreground="#6be67b">tab</span> to cycle forward through taken windows</i>
 <i>• press <span foreground="#6be67b">grave</span> to cycle backward through taken windows</i>
 <i>• press <span foreground="#6be67b">q</span> to close all taken windows</i>`
@@ -347,7 +346,7 @@ class NavigatorClass {
             // set position on stage, take into account monitor
             const monitor = this.space.monitor;
             const x = monitor.x + monitor.width - 380;
-            const y = monitor.height - 118;
+            const y = monitor.height - 100;
 
             this.takeHint.opacity = 0;
             global.stage.add_child(this.takeHint);

--- a/navigator.js
+++ b/navigator.js
@@ -294,7 +294,8 @@ class NavigatorClass {
         this.takeHint = new St.Label({ style_class: 'take-window-hint' });
         this.takeHint.clutter_text.set_markup(
             `<i>• release keys to return all taken windows</i>
-<i>• press <span foreground="#6be67b">tab</span> to cycle through taken windows</i>
+<i>• press <span foreground="#6be67b">tab</span> to cycle forward through taken windows</i>
+<i>• press <span foreground="#6be67b">grave</span> to cycle backward through taken windows</i>
 <i>• press <span foreground="#6be67b">spacebar</span> to return the last taken window</i>
 <i>• press <span foreground="#6be67b">q</span> to close all taken windows</i>`);
 
@@ -344,8 +345,8 @@ class NavigatorClass {
         if (show) {
             // set position on stage, take into account monitor
             const monitor = this.space.monitor;
-            const x = monitor.x + monitor.width - 334;
-            const y = monitor.height - 98;
+            const x = monitor.x + monitor.width - 387;
+            const y = monitor.height - 118;
 
             this.takeHint.opacity = 0;
             global.stage.add_child(this.takeHint);

--- a/navigator.js
+++ b/navigator.js
@@ -294,10 +294,11 @@ class NavigatorClass {
         this.takeHint = new St.Label({ style_class: 'take-window-hint' });
         this.takeHint.clutter_text.set_markup(
             `<i>• release keys to return all taken windows</i>
+<i>• press <span foreground="#6be67b">spacebar</span> to return the last taken window</i>
 <i>• press <span foreground="#6be67b">tab</span> to cycle forward through taken windows</i>
 <i>• press <span foreground="#6be67b">grave</span> to cycle backward through taken windows</i>
-<i>• press <span foreground="#6be67b">spacebar</span> to return the last taken window</i>
-<i>• press <span foreground="#6be67b">q</span> to close all taken windows</i>`);
+<i>• press <span foreground="#6be67b">q</span> to close all taken windows</i>`
+        );
 
         navigating = true;
 
@@ -345,7 +346,7 @@ class NavigatorClass {
         if (show) {
             // set position on stage, take into account monitor
             const monitor = this.space.monitor;
-            const x = monitor.x + monitor.width - 387;
+            const x = monitor.x + monitor.width - 380;
             const y = monitor.height - 118;
 
             this.takeHint.opacity = 0;

--- a/navigator.js
+++ b/navigator.js
@@ -47,22 +47,16 @@ export function disable() {
     index = null;
 }
 
-export function dec2bin(dec) {
-    return (dec >>> 0).toString(2);
-}
+export function primaryModifier(mask) {
+    if (mask === 0)
+        return 0;
 
-const modMask =
-    Clutter.ModifierType.SUPER_MASK |
-    Clutter.ModifierType.HYPER_MASK |
-    Clutter.ModifierType.META_MASK |
-    Clutter.ModifierType.CONTROL_MASK |
-    Clutter.ModifierType.MOD1_MASK |
-    // Clutter.ModifierType.MOD2_MASK | uhmm, for some reason this is triggered on keygrab
-    Clutter.ModifierType.MOD3_MASK |
-    Clutter.ModifierType.MOD4_MASK |
-    Clutter.ModifierType.MOD5_MASK;
-export function getModLock(mods) {
-    return mods & modMask;
+    let primary = 1;
+    while (mask > 1) {
+        mask >>= 1;
+        primary <<= 1;
+    }
+    return primary;
 }
 
 /**
@@ -112,7 +106,7 @@ class ActionDispatcher {
     }
 
     show(backward, binding, mask) {
-        this._modifierMask = getModLock(mask);
+        this._modifierMask = primaryModifier(mask);
         this.navigator = getNavigator();
         Topbar.fixTopBar();
         let actionId = Keybindings.idOf(binding);
@@ -158,7 +152,7 @@ class ActionDispatcher {
 
     _keyPressEvent(actor, event) {
         if (!this._modifierMask) {
-            this._modifierMask = getModLock(event.get_state());
+            this._modifierMask = primaryModifier(event.get_state());
         }
         let keysym = event.get_key_symbol();
         let action = global.display.get_keybinding_action(
@@ -167,7 +161,7 @@ class ActionDispatcher {
 
         // run callbacks and if any return true, stop bubbling
         if (this.keyPressCallbacks.some(callback => {
-            return callback(actor, event);
+            return callback(this._modifierMask, keysym, event);
         })) {
             return Clutter.EVENT_STOP;
         }
@@ -295,7 +289,7 @@ class NavigatorClass {
         this.takeHint.clutter_text.set_markup(
             `<i>• press <span foreground="#6be67b">spacebar</span> to return the last taken window</i>
 <i>• press <span foreground="#6be67b">tab</span> to cycle forward through taken windows</i>
-<i>• press <span foreground="#6be67b">grave</span> to cycle backward through taken windows</i>
+<i>• press <span foreground="#6be67b">shift+tab</span> to cycle backward through taken windows</i>
 <i>• press <span foreground="#6be67b">q</span> to close all taken windows</i>`
         );
 
@@ -345,7 +339,7 @@ class NavigatorClass {
         if (show) {
             // set position on stage, take into account monitor
             const monitor = this.space.monitor;
-            const x = monitor.x + monitor.width - 380;
+            const x = monitor.x + monitor.width - 402;
             const y = monitor.height - 100;
 
             this.takeHint.opacity = 0;

--- a/tiling.js
+++ b/tiling.js
@@ -4845,7 +4845,6 @@ export function takeWindow(metaWindow, space, params) {
         // get the action dispatcher signal to connect to
         Navigator.getActionDispatcher(Clutter.GrabState.KEYBOARD)
             .addKeypressCallback((modmask, keysym, event) => {
-                console.log(`mask ${modmask}, keysym ${keysym}, state ${event.get_state()}`);
                 switch (keysym) {
                 case Clutter.KEY_space: {
                     // remove the last window you got

--- a/tiling.js
+++ b/tiling.js
@@ -4834,12 +4834,8 @@ export function takeWindow(metaWindow, space, params) {
          * array according to direction.
          */
         const cycler = order => {
-            const temparr = [];
             order(navigator._moving);
-            navigator._moving.forEach(w => {
-                temparr.push(w);
-            });
-
+            const temparr = [...navigator._moving];
             navigator._moving = [];
             temparr.forEach(w => {
                 animateTake(w, true);
@@ -4848,8 +4844,8 @@ export function takeWindow(metaWindow, space, params) {
 
         // get the action dispatcher signal to connect to
         Navigator.getActionDispatcher(Clutter.GrabState.KEYBOARD)
-            .addKeypressCallback((actor, event) => {
-                const keysym = event.get_key_symbol();
+            .addKeypressCallback((modmask, keysym, event) => {
+                console.log(`mask ${modmask}, keysym ${keysym}, state ${event.get_state()}`);
                 switch (keysym) {
                 case Clutter.KEY_space: {
                     // remove the last window you got
@@ -4871,8 +4867,8 @@ export function takeWindow(metaWindow, space, params) {
                     return true;
                 }
 
-                // cycle backwards through taken windows
-                case Clutter.KEY_grave: {
+                // cycle backwards through taken windows (shift+tab)
+                case Clutter.KEY_ISO_Left_Tab: {
                     cycler(moving => moving.push(moving.shift()));
                     return true;
                 }

--- a/tiling.js
+++ b/tiling.js
@@ -4786,17 +4786,24 @@ export function takeWindow(metaWindow, space, { navigator }) {
         navigator.showTakeHint(true);
         navigator._moving = [];
 
+        const selectedSpace = () => spaces.selectedSpace;
+        const changeSpace = metaWindow => {
+            const space = selectedSpace();
+            if (spaces.spaceOfWindow(metaWindow) !== space) {
+                metaWindow.change_workspace(space.workspace);
+            }
+        };
+
         /**
          * Cycling function which orders the navigator._moving
          * array according to direction.
          */
-        const selectedSpace = () => spaces.selectedSpace;
         const cycler = order => {
             const temparr = [];
             order(navigator._moving);
             navigator._moving.forEach(w => {
                 temparr.push(w);
-                w.change_workspace(selectedSpace().workspace);
+                changeSpace(w);
                 insertWindow(w, { existing: true });
             });
 
@@ -4815,7 +4822,7 @@ export function takeWindow(metaWindow, space, { navigator }) {
                     // remove the last window you got
                     const pop = navigator._moving.pop();
                     if (pop) {
-                        pop.change_workspace(selectedSpace().workspace);
+                        changeSpace(pop);
                         insertWindow(pop, { existing: true });
                         // make space selectedWindow (keeps index for next insert)
                         selectedSpace().selectedWindow = pop;
@@ -4840,7 +4847,7 @@ export function takeWindow(metaWindow, space, { navigator }) {
                 // close all taken windows
                 case Clutter.KEY_q: {
                     navigator._moving.forEach(w => {
-                        w.change_workspace(selectedSpace().workspace);
+                        changeSpace(w);
                         insertWindow(w, { existing: true });
                         w.delete(global.get_current_time());
                     });
@@ -4859,13 +4866,11 @@ export function takeWindow(metaWindow, space, { navigator }) {
             navigator.showTakeHint(false);
             let selectedSpace = spaces.selectedSpace;
             navigator._moving.forEach(w => {
-                w.change_workspace(selectedSpace.workspace);
-                if (w.get_workspace() === selectedSpace.workspace) {
-                    insertWindow(w, { existing: true });
+                changeSpace(w);
+                insertWindow(w, { existing: true });
 
-                    // make space selectedWindow (keeps index for next insert)
-                    selectedSpace.selectedWindow = w;
-                }
+                // make space selectedWindow (keeps index for next insert)
+                selectedSpace.selectedWindow = w;
             });
 
             // activate last metaWindow after taken windows inserted

--- a/tiling.js
+++ b/tiling.js
@@ -4893,9 +4893,9 @@ export function takeWindow(metaWindow, space, { navigator }) {
         }));
     metaWindow.clone.set_position(point.x, point.y);
     let x = Math.round(space.monitor.x + space.monitor.width -
-        (0.1 * space.monitor.width * (1 + navigator._moving.length)));
+        (0.08 * space.monitor.width * (1 + navigator._moving.length)));
     let y = Math.round(space.monitor.y + space.monitor.height * 2 / 3) +
-        20 * navigator._moving.length;
+        16 * navigator._moving.length;
     animateWindow(metaWindow);
     Easer.addEase(metaWindow.clone,
         {


### PR DESCRIPTION
This PR adds two new keyboard shortcuts to the new "take" functionality provided by #808:
- pressing `tab` forward cycles through the currently taken windows;
- pressing ~~`grave` (above tab)~~ `shift`+`tab` backward cycles through the currently taken windows;

This provides much more control of taking/dropping windows, see video below (watch for the cycling order of taken windows for dropping):

https://github.com/paperwm/PaperWM/assets/30424662/c7c50471-f352-4693-a936-2e711189f933


