### PR TITLE
Fix warp pointer if focus window on another monitor

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -259,6 +259,7 @@ globals:
   ARGV: readonly
   Debugger: readonly
   GIRepositoryGType: readonly
+  global: readonly
   globalThis: readonly
   imports: readonly
   Intl: readonly

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -7,8 +7,8 @@
 env:
   es2021: true
 extends: 'eslint:recommended'
-  #plugins:
-  #  - jsdoc
+# plugins:
+#    - jsdoc
 rules:
   array-bracket-newline:
     - error
@@ -66,20 +66,21 @@ rules:
       - 'CallExpression[callee.object.name=GObject][callee.property.name=registerClass] > ClassExpression:first-child'
       # Allow dedenting chained member expressions
       MemberExpression: 'off'
-  jsdoc/check-alignment: error
-  jsdoc/check-param-names: error
-  jsdoc/check-tag-names: error
-  jsdoc/check-types: error
-  jsdoc/implements-on-classes: error
-  jsdoc/tag-lines:
-    - error
-    - any
-    - startLines: 1
-  jsdoc/require-jsdoc: error
-  jsdoc/require-param: error
-  jsdoc/require-param-description: error
-  jsdoc/require-param-name: error
-  jsdoc/require-param-type: error
+  # # disabling jsdoc while as plugin jsdoc is disabled (have always had issues with plugin)
+  # jsdoc/check-alignment: error
+  # jsdoc/check-param-names: error
+  # jsdoc/check-tag-names: error
+  # jsdoc/check-types: error
+  # jsdoc/implements-on-classes: error
+  # jsdoc/tag-lines:
+  #   - error
+  #   - any
+  #   - startLines: 1
+  # jsdoc/require-jsdoc: error
+  # jsdoc/require-param: error
+  # jsdoc/require-param-description: error
+  # jsdoc/require-param-name: error
+  # jsdoc/require-param-type: error
   key-spacing:
     - error
     - beforeColon: false

--- a/liveAltTab.js
+++ b/liveAltTab.js
@@ -41,10 +41,10 @@ export const LiveAltTab = GObject.registerClass(
         }
 
         _getWindowList(reverse) {
-            let tabList = Utils.getGlobal().display.get_tab_list(
+            let tabList = global.display.get_tab_list(
                 Meta.TabList.NORMAL_ALL,
                 switcherSettings.get_boolean('current-workspace-only')
-                    ? Utils.getGlobal().workspace_manager.get_active_workspace() : null)
+                    ? global.workspace_manager.get_active_workspace() : null)
                 .filter(w => !Scratch.isScratchWindow(w));
 
             let scratch = Scratch.getScratchWindows();
@@ -52,7 +52,7 @@ export const LiveAltTab = GObject.registerClass(
             if (this.scratchOnly) {
                 return reverse ? scratch.reverse() : scratch;
             }
-            else if (Scratch.isScratchWindow(Utils.getGlobal().display.focus_window)) {
+            else if (Scratch.isScratchWindow(global.display.focus_window)) {
                 // Access scratch windows in mru order with shift-super-tab
                 return scratch.concat(reverse ? tabList.reverse() : tabList);
             } else {
@@ -73,7 +73,7 @@ export const LiveAltTab = GObject.registerClass(
             // this.space.cloneContainer.add_effect(this.blur);
             this.space.setSelectionInactive();
 
-            Main.uiGroup.insert_child_above(fog, Utils.getGlobal().window_group);
+            Main.uiGroup.insert_child_above(fog, global.window_group);
             Easer.addEase(fog, {
                 time: Settings.prefs.animation_time,
                 opacity: 100,

--- a/liveAltTab.js
+++ b/liveAltTab.js
@@ -6,13 +6,13 @@ import GObject from 'gi://GObject';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as AltTab from 'resource:///org/gnome/shell/ui/altTab.js';
 
-import { Settings, Keybindings, Tiling, Scratch } from './imports.js';
+import { Utils, Settings, Keybindings, Tiling, Scratch } from './imports.js';
 import { Easer } from './utils.js';
 
 let switcherSettings;
 export function enable() {
     switcherSettings = new Gio.Settings({
-        schema_id: 'org.gnome.shell.window-switcher',
+        schema_id: 'org.gnome.shell.app-switcher',
     });
 }
 
@@ -20,12 +20,12 @@ export function disable() {
     switcherSettings = null;
 }
 
-export function liveAltTab(meta_window, space, { display, screen, binding }) {
+export function liveAltTab(meta_window, space, { _display, _screen, binding }) {
     let tabPopup = new LiveAltTab(binding.is_reversed(), false);
     tabPopup.show(binding.is_reversed(), binding.get_name(), binding.get_mask());
 }
 
-export function liveAltTabScratch(meta_window, space, { display, screen, binding }) {
+export function liveAltTabScratch(meta_window, space, { _display, _screen, binding }) {
     let tabPopup = new LiveAltTab(binding.is_reversed(), true);
     tabPopup.show(binding.is_reversed(), binding.get_name(), binding.get_mask());
 }
@@ -41,10 +41,10 @@ export const LiveAltTab = GObject.registerClass(
         }
 
         _getWindowList(reverse) {
-            let tabList = global.display.get_tab_list(
+            let tabList = Utils.getGlobal().display.get_tab_list(
                 Meta.TabList.NORMAL_ALL,
                 switcherSettings.get_boolean('current-workspace-only')
-                    ? global.workspace_manager.get_active_workspace() : null)
+                    ? Utils.getGlobal().workspace_manager.get_active_workspace() : null)
                 .filter(w => !Scratch.isScratchWindow(w));
 
             let scratch = Scratch.getScratchWindows();
@@ -52,7 +52,7 @@ export const LiveAltTab = GObject.registerClass(
             if (this.scratchOnly) {
                 return reverse ? scratch.reverse() : scratch;
             }
-            else if (Scratch.isScratchWindow(global.display.focus_window)) {
+            else if (Scratch.isScratchWindow(Utils.getGlobal().display.focus_window)) {
                 // Access scratch windows in mru order with shift-super-tab
                 return scratch.concat(reverse ? tabList.reverse() : tabList);
             } else {
@@ -73,7 +73,7 @@ export const LiveAltTab = GObject.registerClass(
             // this.space.cloneContainer.add_effect(this.blur);
             this.space.setSelectionInactive();
 
-            Main.uiGroup.insert_child_above(fog, global.window_group);
+            Main.uiGroup.insert_child_above(fog, Utils.getGlobal().window_group);
             Easer.addEase(fog, {
                 time: Settings.prefs.animation_time,
                 opacity: 100,
@@ -154,6 +154,7 @@ export const LiveAltTab = GObject.registerClass(
             // accepted. This can cause _select to run on the item below the pointer
             // ensuring the wrong window.
             if (!this.was_accepted) {
+                // eslint-disable-next-line prefer-rest-params
                 super._itemEnteredHandler.apply(this, arguments);
             }
         }

--- a/tiling.js
+++ b/tiling.js
@@ -4228,7 +4228,7 @@ export function focus_handler(metaWindow) {
     let space = spaces.spaceOfWindow(metaWindow);
 
     // if window is on another monitor then warp pointer there
-    if (spaces.activeSpace?.monitor !== space.monitor) {
+    if (Utils.monitorAtCurrentPoint() !== space.monitor) {
         Utils.warpPointerToMonitor(space.monitor);
     }
 

--- a/tiling.js
+++ b/tiling.js
@@ -4226,6 +4226,12 @@ export function focus_handler(metaWindow) {
     }
 
     let space = spaces.spaceOfWindow(metaWindow);
+
+    // if window is on another monitor then warp pointer there
+    if (spaces.activeSpace?.monitor !== space.monitor) {
+        Utils.warpPointerToMonitor(space.monitor);
+    }
+
     if (metaWindow.fullscreen) {
         space.enableWindowPositionBar(false);
         space.setSpaceTopbarElementsVisible(false);

--- a/utils.js
+++ b/utils.js
@@ -12,7 +12,7 @@ import * as Config from 'resource:///org/gnome/shell/misc/config.js';
 
 import { Lib } from './imports.js';
 
-const Display = getGlobal().display;
+const Display = global.display;
 export let version = Config.PACKAGE_VERSION.split('.').map(Number);
 
 let warpRipple;
@@ -20,22 +20,12 @@ let warpRipple;
 let signals, touchCoords;
 let inTouch = false;
 
-/**
- * Convenience function to get global.  Avoids linter flagging
- * references to global as no-undef
- * @returns global
- */
-export function getGlobal() {
-    // eslint-disable-next-line no-undef
-    return global;
-}
-
 export function enable() {
     warpRipple = new Ripples.Ripples(0.5, 0.5, 'ripple-pointer-location');
     warpRipple.addTo(Main.uiGroup);
 
     signals = new Signals();
-    signals.connect(getGlobal().stage, "captured-event", (actor, event) => {
+    signals.connect(global.stage, "captured-event", (actor, event) => {
         switch (event.type()) {
         case Clutter.EventType.TOUCH_BEGIN:
         case Clutter.EventType.TOUCH_UPDATE:
@@ -154,7 +144,7 @@ export function toggleWindowBoxes(metaWindow) {
         boxes.push(makeFrameBox(actor, "yellow"));
     }
 
-    boxes.forEach(box => getGlobal().stage.add_child(box));
+    boxes.forEach(box => global.stage.add_child(box));
 
     metaWindow._paperDebugBoxes = boxes;
     return boxes;
@@ -206,7 +196,7 @@ export function getPointerCoords() {
     if (inTouch) {
         return touchCoords;
     } else {
-        return getGlobal().get_pointer();
+        return global.get_pointer();
     }
 }
 
@@ -242,7 +232,7 @@ export function warpPointerToMonitor(monitor, params = { center: false, ripple: 
         return;
     }
 
-    let [x, y] = getGlobal().get_pointer();
+    let [x, y] = global.get_pointer();
     if (center) {
         x -= monitor.x;
         y -= monitor.y;
@@ -278,7 +268,7 @@ export function warpPointer(x, y, ripple = true) {
  * Return current modifiers state (or'ed Clutter.ModifierType.*)
  */
 export function getModiferState() {
-    let [, , mods] = getGlobal().get_pointer();
+    let [, , mods] = global.get_pointer();
     return mods;
 }
 
@@ -396,7 +386,7 @@ export function actor_reparent(actor, newParent) {
  * Backwards compatible later_add function.
  */
 export function later_add(...args) {
-    getGlobal().compositor.get_laters().add(...args);
+    global.compositor.get_laters().add(...args);
 }
 
 /**
@@ -601,7 +591,7 @@ export class DisplayConfig {
     }
 
     get monitorManager() {
-        return getGlobal().backend.get_monitor_manager();
+        return global.backend.get_monitor_manager();
     }
 
     get gnomeMonitors() {

--- a/utils.js
+++ b/utils.js
@@ -232,7 +232,10 @@ export function monitorAtCurrentPoint() {
 /**
  * Warps pointer to the center of a monitor.
  */
-export function warpPointerToMonitor(monitor, center = false) {
+export function warpPointerToMonitor(monitor, params = { center: false, ripple: true }) {
+    const center = params?.center ?? false;
+    const ripple = params?.ripple ?? true;
+
     // no need to warp if already on this monitor
     let currMonitor = monitorAtCurrentPoint();
     if (currMonitor === monitor) {
@@ -243,8 +246,10 @@ export function warpPointerToMonitor(monitor, center = false) {
     if (center) {
         x -= monitor.x;
         y -= monitor.y;
-        warpPointer(monitor.x + Math.floor(monitor.width / 2),
-            monitor.y + Math.floor(monitor.height / 2));
+        warpPointer(
+            monitor.x + Math.floor(monitor.width / 2),
+            monitor.y + Math.floor(monitor.height / 2),
+            ripple);
         return;
     }
 
@@ -252,7 +257,8 @@ export function warpPointerToMonitor(monitor, center = false) {
     let proportionalY = (y - currMonitor.y) / currMonitor.height;
     warpPointer(
         monitor.x + Math.floor(proportionalX * monitor.width),
-        monitor.y + Math.floor(proportionalY * monitor.height)
+        monitor.y + Math.floor(proportionalY * monitor.height),
+        ripple
     );
 }
 


### PR DESCRIPTION
Fixes a related issue partly described in #837.

Note that in Gnome 45+, PaperWM `alt`+`tab` does indeed switch through all windows across spaces and monitors (by default).  However, an issue does occur that if we switch to (and focus) a window on another monitor via `alt`+`tab` etc., when we move the mouse focus will be pulled to the monitor that the mouse is on.

This PR fixes this by warping the mouse pointer to the new monitor if needed (along with a mouse pointer ripple effect).

This PR also now links the behaviour for showing `all` windows or `only windows from current space` in PaperWM to the Gnome Multitasking setting:

![image](https://github.com/paperwm/PaperWM/assets/30424662/b49736a5-a105-4534-a98b-2300f5a399e0)