### PR TITLE
(Gnome 42/43/44) If a window is tiled on minimize, then restore to tiling.  Otherwise restore to scratch layer.

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -1675,6 +1675,9 @@ border-radius: ${borderWidth}px;
     }
 
     destroy() {
+        this.getWindows().forEach(w => {
+            delete w.tiled_on_minimize;
+        });
         this.signals.destroy();
         this.signals = null;
         this.background.destroy();
@@ -3767,9 +3770,22 @@ var focus_wrapper = Utils.dynamic_function_ref('focus_handler', this);
    Push all minimized windows to the scratch layer
  */
 function minimizeHandler(metaWindow) {
-    console.debug('minimized', metaWindow?.title);
     if (metaWindow.minimized) {
+        console.debug('minimized', metaWindow?.title);
+        // check if was tiled
+        if (isTiled(metaWindow)) {
+            metaWindow.tiled_on_minimize = true;
+        }
         Scratch.makeScratch(metaWindow);
+    }
+    else {
+        console.debug('unminimized', metaWindow?.title);
+        if (metaWindow.tiled_on_minimize) {
+            delete metaWindow.tiled_on_minimize;
+            Utils.later_add(Meta.LaterType.IDLE, () => {
+                Scratch.unmakeScratch(metaWindow);
+            });
+        }
     }
 }
 var minimizeWrapper = Utils.dynamic_function_ref('minimizeHandler', this);


### PR DESCRIPTION
Fixes #838 for Gnome 42/43/44.