### PR TITLE
FIX: if border selection size is set to 0px, then hide selection completely

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -129,8 +129,12 @@ export function enable(extension) {
     gsettings.connect('changed::vertical-margin-bottom', marginsGapChanged);
     gsettings.connect('changed::window-gap', marginsGapChanged);
     gsettings.connect('changed::selection-border-size', () => {
-        const selected = spaces.activeSpace?.selectedWindow;
-        allocateClone(selected);
+        spaces.forEach(s => {
+            Settings.prefs.selection_border_size <= 0 ? s.hideSelection() : s.showSelection();
+            if (s.selectedWindow) {
+                allocateClone(s.selectedWindow);
+            }
+        });
     });
 
     backgroundGroup = Main.layoutManager._backgroundGroup;
@@ -1431,6 +1435,9 @@ export class Space extends Array {
     }
 
     showSelection() {
+        if (Settings.prefs.selection_border_size <= 0) {
+            return;
+        }
         this.selection.set_style_class_name('paperwm-selection tile-preview');
     }
 


### PR DESCRIPTION
Fixes #860.

If user sets the border (selection element) size to 0(px), then hide the PaperWM window selection element completely.

See below to show entire window selection element hiding:

[Screencast from 2024-05-17 08-30-32.webm](https://github.com/paperwm/PaperWM/assets/30424662/5bc40156-967a-4062-a76a-4691f93eaf2e)
