### PR TITLE
swipe: fix focus behavior

### DIFF
--- a/gestures.js
+++ b/gestures.js
@@ -317,7 +317,7 @@ export function update(space, dx, t) {
     let target = Math.round(space.targetX - d);
 
     space.targetX = target;
-    let selected = findTargetWindow(space, direction, start - space.targetX > 0);
+    const selected = findTargetWindow(space, start - space.targetX > 0);
     space.targetX = space.cloneContainer.x;
     Tiling.updateSelection(space, selected);
     space.selectedWindow = selected;


### PR DESCRIPTION
The unrelated direction variable was used as the direction argument there, and the intended direction was passed as an unused third argument.

---

With this fix, which window gets the focus when swiping at least makes some sense, it kinda didn't before. I'd like to also add a mode where it's the window under the cursor that ends up focused…