### PR TITLE
Fix 876 windows on second screen not full height with no top bar on second screen

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -2023,8 +2023,6 @@ border-radius: ${borderWidth}px;
 
     destroy() {
         this.getWindows().forEach(w => {
-
-            
             removePaperWMFlags(w);
         });
         this.signals.destroy();
@@ -3371,11 +3369,14 @@ export function registerWindow(metaWindow) {
         showHandler(actor);
     });
 
-    signals.connect(metaWindow, 'workspace-changed', metaWindow => {
-        const actor = metaWindow.get_compositor_private();
-        signals.connectOneShot(actor, 'stage-views-changed', _actor => {
+    /**
+     * Ensures when moving window that it's targetHeight is met.
+     */
+    signals.connect(actor, 'stage-views-changed', _actor => {
+        const f = metaWindow.get_frame_rect();
+        if (metaWindow._targetHeight !== f.height) {
             resizeHandler(metaWindow);
-        });
+        }
     });
 
     signals.connect(actor, 'destroy', destroyHandler);

--- a/tiling.js
+++ b/tiling.js
@@ -3375,7 +3375,7 @@ export function registerWindow(metaWindow) {
     signals.connect(actor, 'stage-views-changed', _actor => {
         const f = metaWindow.get_frame_rect();
         if (metaWindow._targetHeight !== f.height) {
-            resizeHandler(metaWindow);
+            metaWindow.move_resize_frame(true, f.x, f.y, f.width, metaWindow._targetHeight);
         }
     });
 

--- a/tiling.js
+++ b/tiling.js
@@ -3375,7 +3375,7 @@ export function registerWindow(metaWindow) {
     signals.connect(actor, 'stage-views-changed', _actor => {
         const f = metaWindow.get_frame_rect();
         if (metaWindow._targetHeight !== f.height) {
-            metaWindow.move_resize_frame(true, f.x, f.y, f.width, metaWindow._targetHeight);
+            resizeHandler(metaWindow);
         }
     });
 
@@ -3486,11 +3486,15 @@ export function resizeHandler(metaWindow) {
     if (inGrab && inGrab.window === metaWindow)
         return;
 
+    const space = spaces.spaceOfWindow(metaWindow);
+    if (!space) {
+        return;
+    }
+
     const f = metaWindow.get_frame_rect();
     metaWindow._targetWidth = null;
     metaWindow._targetHeight = null;
 
-    const space = spaces.spaceOfWindow(metaWindow);
     if (space.indexOf(metaWindow) === -1) {
         nonTiledSizeHandler(metaWindow);
         return;

--- a/tiling.js
+++ b/tiling.js
@@ -309,6 +309,10 @@ export class Space extends Array {
             style_class: 'paperwm-selection tile-preview',
         });
         this.selection = selection;
+        // initial state is shown (unless border-size is 0)
+        if (Settings.prefs.selection_border_size <= 0) {
+            this.hideSelection();
+        }
 
         clip.space = this;
         cloneContainer.space = this;
@@ -3365,6 +3369,13 @@ export function registerWindow(metaWindow) {
 
     signals.connect(actor, 'show', actor => {
         showHandler(actor);
+    });
+
+    signals.connect(metaWindow, 'workspace-changed', metaWindow => {
+        const actor = metaWindow.get_compositor_private();
+        signals.connectOneShot(actor, 'stage-views-changed', _actor => {
+            resizeHandler(metaWindow);
+        });
     });
 
     signals.connect(actor, 'destroy', destroyHandler);


### PR DESCRIPTION
Fixes #876.

This PR fixes an issue where on second monitor (and with `window position bar` being disabled), some windows aren't taking up target height (leaving a space at the bottom).

Also fixes a border width issue (where is set width to 0, can still show on startup).