### PR TITLE
FIX: Paperwm and ddterm crashes gnome shell

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -3264,18 +3264,17 @@ Signals.addSignalMethods(Spaces.prototype);
  * @param metaWindow
  */
 export function isTiled(metaWindow) {
-    if (!metaWindow) {
+    if (
+        !metaWindow ||
+        metaWindow?.is_on_all_workspaces() ||
+        isFloating(metaWindow) ||
+        isScratch(metaWindow) ||
+        isTransient(metaWindow)
+    ) {
         return false;
     }
 
-    if (!isFloating(metaWindow) &&
-        !isScratch(metaWindow) &&
-        !isTransient(metaWindow)) {
-        return true;
-    }
-    else {
-        return false;
-    }
+    return true;
 }
 
 /**


### PR DESCRIPTION
Version `46.12.0` introduced a helper function to ensure windows use full height (needed for spaces that have `topbar` disabled.

The `isTiled` function is used to avoid running this helper functions on windows that aren't PaperWM tiled.

This PR should fix issues such as #880.