### PR TITLE
Added Nix build files for bleeding-edge NixOS

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,27 @@
+{ pkgs, stdenv, glib, ... }:
+
+let
+  uuid = "paperwm@paperwm.github.com";
+in
+stdenv.mkDerivation {
+  pname = "gnome-shell-extension-paperwm";
+  version = "unstable";
+  src = ./.;
+
+  nativeBuildInputs = with pkgs;
+    [ glib
+    ];
+  buildPhase = ''
+    make -C schemas gschemas.compiled
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/gnome-shell/extensions
+    cp -r -T . $out/share/gnome-shell/extensions/${uuid}
+  '';
+
+  passthru = {
+    extensionPortalSlug = "paperwm";
+    extensionUuid = uuid;
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,59 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1719492850,
+        "narHash": "sha256-koLuAz11nFcQ8DADmt15XEqEV8c1WcJ2S0JpSRTUxKo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "69bee9866a4e2708b3153fdb61c1425e7857d6b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,12 @@
+{ description = "Tiled, scrollable window management for GNOME Shell";
+
+  inputs."nixpkgs".url = github:NixOS/nixpkgs;
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+  flake-utils.lib.eachDefaultSystem
+    (system:
+    let pkgs = import nixpkgs { inherit system; };
+    in
+    { packages.default = pkgs.callPackage ./default.nix {};
+    });
+}


### PR DESCRIPTION
This allows NixOS users to directly use PaperWM source as their extensions package, which tracks changes faster than even Nixpkgs ever could.

It's also a very low-maintenance patch, maybe requiring someone run `nix flake update nixpkgs` once in a blue moon to bump the dependency locks.