### PR TITLE
Improve topbar mouse scrolling feature to work better with other extensions

### DIFF
--- a/topbar.js
+++ b/topbar.js
@@ -164,13 +164,13 @@ export function disable() {
 export function topBarScrollAction(event) {
     // if topbar workspaceMenu (indicator) has pointer, exit
     if (menu && menu.has_pointer) {
-        return Clutter.EVENT_STOP;
+        return Clutter.EVENT_PROPAGATE;
     }
 
     // same check for gnome pill
     const pill = Main.panel?.statusArea?.activities;
     if (pill && pill.has_pointer) {
-        return Clutter.EVENT_STOP;
+        return Clutter.EVENT_PROPAGATE;
     }
 
     let direction = event.get_scroll_direction();
@@ -195,7 +195,7 @@ export function topBarScrollAction(event) {
         }
     }
 
-    return Clutter.EVENT_STOP;
+    return Clutter.EVENT_PROPAGATE;
 }
 
 export function showWorkspaceMenu(show = false) {


### PR DESCRIPTION
@Thesola10 mentioned some potential conflicts with the new mouse scrolling (on topbar) feature (#883) and other extensions (e.g. V-Shell and/or dash-to-panel).

Small change in how PaperWM: propagate scroll-event signal after switching windows (in case other extensions require the event).

Not sure if it will make a difference though.