### PR TITLE
FIX: address case where window/clone no longer exists while dragging window (it gets closed while dragging)

### DIFF
--- a/grab.js
+++ b/grab.js
@@ -314,7 +314,13 @@ export class MoveGrab {
             Utils.warpPointer(gx, gy, false);
         }
         let [dx, dy] = this.pointerOffset;
-        let clone = metaWindow.clone;
+        let clone = metaWindow?.clone;
+
+        // check if window and clone exists
+        if (!clone) {
+            this.end();
+            return;
+        }
 
         let tx = clone.get_transition('x');
         let ty = clone.get_transition('y');
@@ -379,11 +385,10 @@ export class MoveGrab {
             opacity: clone?.__oldOpacity ?? 255,
         };
 
-        if (this.dnd) {
-            let dndTarget = this.dndTarget;
-
+        if (this.clone && this.dnd) {
+            const dndTarget = this.dndTarget;
             if (dndTarget) {
-                let space = dndTarget.space;
+                const space = dndTarget.space;
                 space.showSelection();
 
                 if (Scratch.isScratchWindow(metaWindow))
@@ -422,7 +427,7 @@ export class MoveGrab {
 
                 Utils.actor_raise(clone);
             }
-            else {
+            else if (clone) {
                 metaWindow.move_frame(true, clone.x, clone.y);
                 Scratch.makeScratch(metaWindow);
                 this.initialSpace.moveDone();
@@ -450,7 +455,9 @@ export class MoveGrab {
 
             Navigator.getNavigator().accept();
         }
-        else if (this.initialSpace.indexOf(metaWindow) !== -1) {
+        else if (
+            this.clone &&
+            this.initialSpace.indexOf(metaWindow) !== -1) {
             let space = this.initialSpace;
             space.targetX = space.cloneContainer.x;
 
@@ -475,7 +482,7 @@ export class MoveGrab {
         this.initialSpace.layout();
         // ensure window is properly activated after layout/ensureViewport tweens
         Utils.later_add(Meta.LaterType.IDLE, () => {
-            Main.activateWindow(metaWindow);
+            metaWindow?.get_workspace() && Main.activateWindow(metaWindow);
         });
 
         // // Make sure the window is on the correct workspace.

--- a/tiling.js
+++ b/tiling.js
@@ -3845,7 +3845,7 @@ export function remove_handler(workspace, meta_window) {
 /**
    Handle windows entering workspaces.
 */
-export function add_handler(ws, metaWindow) {
+export function add_handler(_ws, metaWindow) {
     // Do not handle grabbed windows
     if (inGrab && inGrab.window === metaWindow)
         return;


### PR DESCRIPTION
Fixes #896.

Addresses the case where a while is closed while dragging.  See #896.