### PR TITLE
FIX: with take windows, ensure keyboard grabstate is released if navigator exited by mouse click.

### DIFF
--- a/navigator.js
+++ b/navigator.js
@@ -105,7 +105,7 @@ class ActionDispatcher {
         this.keyPressCallbacks.push(handler);
     }
 
-    show(backward, binding, mask) {
+    show(_backward, binding, mask) {
         this._modifierMask = primaryModifier(mask);
         this.navigator = getNavigator();
         Topbar.fixTopBar();
@@ -150,7 +150,7 @@ class ActionDispatcher {
             });
     }
 
-    _keyPressEvent(actor, event) {
+    _keyPressEvent(_actor, event) {
         if (!this._modifierMask) {
             this._modifierMask = primaryModifier(event.get_state());
         }
@@ -183,7 +183,7 @@ class ActionDispatcher {
         return Clutter.EVENT_STOP;
     }
 
-    _keyReleaseEvent(actor, event) {
+    _keyReleaseEvent(_actor, event) {
         if (this._destroy) {
             dismissDispatcher(Clutter.GrabState.KEYBOARD);
         }

--- a/tiling.js
+++ b/tiling.js
@@ -5201,7 +5201,6 @@ export function takeWindow(metaWindow, space, params) {
     const animateTake = (window, existing) => {
         navigator._moving.push(window);
         if (!existing) {
-            // backgroundGroup.add_child(metaWindow.clone);
             Utils.actor_add_child(backgroundGroup, metaWindow.clone);
         }
 
@@ -5258,7 +5257,7 @@ export function takeWindow(metaWindow, space, params) {
 
         // get the action dispatcher signal to connect to
         Navigator.getActionDispatcher(Clutter.GrabState.KEYBOARD)
-            .addKeypressCallback((modmask, keysym, _event) => {
+            .addKeypressCallback((_modmask, keysym, _event) => {
                 switch (keysym) {
                 case Clutter.KEY_space: {
                     // remove the last window you got
@@ -5304,7 +5303,10 @@ export function takeWindow(metaWindow, space, params) {
             });
 
         signals.connectOneShot(navigator, 'destroy', () => {
+            // ensure keyboard grabstate is dimissed (in case moving stopped via pointer)
+            Navigator.dismissDispatcher(Clutter.GrabState.KEYBOARD);
             navigator.showTakeHint(false);
+
             let selectedSpace = spaces.selectedSpace;
             navigator._moving.forEach(w => {
                 changeSpace(w);


### PR DESCRIPTION
Fixes #895.

Issue was keyboard grabstate was not released if mouse clicked when "taking" windows.

See #895 for details.