### PR TITLE
FIX: ensure fullscreened windows above "above" modal dialogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,9 +355,9 @@ Users can disable PaperWM's ability to change GNOME Top Bar styling from PaperWM
 
 _Note: several PaperWM specific features are dependent on changing the Gnome Top Bar to function correctly.  If you choose to disable PaperWM's ability to change the Top Bar styles (with the setting above), you may also want to disable the [Window Position Bar](#window-position-bar-colored-bar-segment-in-top-bar)_.
 
-## Recommended Gnome Shell Settings ##
+## Managed Gnome Shell Settings ##
 
-There's a few Gnome Shell settings which works poorly with PaperWM. Namely
+There's a few Gnome Shell settings that are incompatible with, or work poorly with, PaperWM. Namely
 - `workspaces-only-on-primary`: Multi monitor support require workspaces
   spanning all monitors
 - `edge-tiling`: We don't support the native half tiled windows

--- a/tiling.js
+++ b/tiling.js
@@ -4442,8 +4442,20 @@ export function focus_handler(metaWindow) {
         space.enableWindowPositionBar(false);
         space.setSpaceTopbarElementsVisible(false);
         space.hideSelection();
+        if (!metaWindow.is_above()) {
+            metaWindow.make_above();
+        }
     }
     else {
+        space.getWindows().filter(w => w.fullscreen).forEach(w => {
+            if (
+                w._fullscreen_above !== null &&
+                !w._fullscreen_above
+            ) {
+                w.unmake_above();
+            }
+        });
+
         let needLayout = false;
         /**
          * If has fullscreen window - when selected non-fullscreen window, do layout:

--- a/tiling.js
+++ b/tiling.js
@@ -2397,10 +2397,13 @@ export const Spaces = class Spaces extends Map {
 
                 if (
                     metaWindow.get_workspace() === workspaceManager.get_active_workspace() &&
-                    !metaWindow.minimized)
+                    !metaWindow.minimized
+                ) {
                     actor.show();
-                else
+                }
+                else {
                     actor.hide();
+                }
             });
 
         this.signals.destroy();

--- a/tiling.js
+++ b/tiling.js
@@ -2395,7 +2395,9 @@ export const Spaces = class Spaces extends Map {
                 metaWindow._targetHeight = null;
                 metaWindow._targetWidth = null;
 
-                if (metaWindow.get_workspace() === workspaceManager.get_active_workspace() && !metaWindow.minimized)
+                if (
+                    metaWindow.get_workspace() === workspaceManager.get_active_workspace() &&
+                    !metaWindow.minimized)
                     actor.show();
                 else
                     actor.hide();
@@ -3387,8 +3389,23 @@ export function registerWindow(metaWindow) {
         // if window is in a column, expel it
         barf(metaWindow, metaWindow);
 
-        const space = spaces.spaceOfWindow(metaWindow);
-        space?.setSpaceTopbarElementsVisible(true);
+        /**
+         * Set fullscreen windows to "always on top".  This is to ensure
+         * that the fullscreened window is "above" modal windows.
+         */
+        if (metaWindow.fullscreen) {
+            // get current "above" value (for later restoring)
+            metaWindow._fullscreen_above = metaWindow.is_above();
+            metaWindow.make_above();
+        }
+        else if (metaWindow._fullscreen_above !== null) {
+            if (!metaWindow._fullscreen_above) {
+                metaWindow.unmake_above();
+            }
+            delete metaWindow._fullscreen_above;
+        }
+
+        spaces.spaceOfWindow(metaWindow)?.setSpaceTopbarElementsVisible(true);
     });
     signals.connect(metaWindow, 'notify::minimized', metaWindow => {
         minimizeHandler(metaWindow);
@@ -3530,6 +3547,8 @@ export function removePaperWMFlags(w) {
     delete w._pos_mismatch_count;
     delete w._tiled_on_minimize;
     delete w._fullscreen_frame;
+    delete w._fullscreen_lock;
+    delete w._fullscreen_above;
     delete w._last_layout_frame;
 }
 


### PR DESCRIPTION
Resolves #902.

This PR simply ensures that when a window is fullscreened, it's set "above" other windows (namely, modal dialog windows).