### PR TITLE
FIX: 835 xorg windows slip under topbar

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -2258,7 +2258,7 @@ export const Spaces = class Spaces extends Map {
             //         this.activeSpace.layout();
             //         return false; // on return false destroys timeout
             //     });
-
+            console.warn(`MONITOR_CHANGED: no primary monitor`);
             return;
         }
 
@@ -2296,7 +2296,7 @@ export const Spaces = class Spaces extends Map {
 
             // finally run a layout
             activeSpace?.queueLayout();
-            console.log(`monitorChange completed: queing layout on ${activeSpace?.name}`);
+            console.warn(`MONITORS_CHANGED: completed - queing layout on ${activeSpace?.name}`);
         };
 
         if (this.onlyOnPrimary) {

--- a/tiling.js
+++ b/tiling.js
@@ -2251,13 +2251,13 @@ export const Spaces = class Spaces extends Map {
         let primary = Main.layoutManager.primaryMonitor;
         if (!primary) {
             // TEST:
-            GLib.timeout_add(
-                GLib.PRIORITY_DEFAULT,
-                2000,
-                () => {
-                    this.activeSpace.layout();
-                    return false; // on return false destroys timeout
-                });
+            // GLib.timeout_add(
+            //     GLib.PRIORITY_DEFAULT,
+            //     2000,
+            //     () => {
+            //         this.activeSpace.layout();
+            //         return false; // on return false destroys timeout
+            //     });
 
             return;
         }
@@ -2293,6 +2293,10 @@ export const Spaces = class Spaces extends Map {
             Topbar.refreshWorkspaceIndicator();
             this.forEach(s => s.setSpaceTopbarElementsVisible());
             Stackoverlay.multimonitorSupport();
+
+            // finally run a layout
+            activeSpace?.queueLayout();
+            console.log(`monitorChange completed: queing layout on ${activeSpace?.name}`);
         };
 
         if (this.onlyOnPrimary) {

--- a/tiling.js
+++ b/tiling.js
@@ -2249,6 +2249,10 @@ export const Spaces = class Spaces extends Map {
         let mru = this.mru();
 
         let primary = Main.layoutManager.primaryMonitor;
+        if (!primary) {
+            return;
+        }
+
         // get monitors but ensure primary monitor is first
         let monitors = Main.layoutManager.monitors.filter(m => m !== primary);
         monitors.unshift(primary);

--- a/tiling.js
+++ b/tiling.js
@@ -2258,14 +2258,15 @@ export const Spaces = class Spaces extends Map {
             let monitorTimeoutCount = 0;
             monitorChangeTimeout = GLib.timeout_add(
                 GLib.PRIORITY_DEFAULT,
-                2000,
+                1000,
                 () => {
                     this.activeSpace.layout();
-                    if (monitorTimeoutCount < 4) {
-                        monitorChangeTimeout++;
-                        console.warn(`MONITORS_CHANGED: no primary monitor - 'space.layout' call ${monitorChangeTimeout}`);
+                    if (monitorTimeoutCount < 5) {
+                        monitorTimeoutCount++;
+                        console.warn(`MONITORS_CHANGED: no primary monitor - 'space.layout' call ${monitorTimeoutCount}`);
                         return true;
                     }
+                    monitorChangeTimeout = null;
                     return false; // on return false destroys timeout
                 });
             return;

--- a/tiling.js
+++ b/tiling.js
@@ -3499,25 +3499,29 @@ export function registerWindow(metaWindow) {
             return;
         }
 
-        let tries = 0;
-        const timeout = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 100, () => {
-            if (tries >= 10) {
-                done(timeout);
-                return false;
+        const timeout = Utils.periodic_timeout(
+            {
+                period_ms: 100,
+                count: 10,
+                callback: () => {
+                    const f = metaWindow.get_frame_rect();
+                    if (metaWindow._targetHeight !== f.height) {
+                        if (!isNaN(metaWindow._targetHeight)) {
+                            metaWindow.move_resize_frame(
+                                true,
+                                f.x,
+                                f.y,
+                                f.width,
+                                metaWindow._targetHeight
+                            );
+                        }
+                    }
+                },
+                onComplete: () => {
+                    done(timeout);
+                },
             }
-            tries++;
-            // console.log(`try ${tries} height check on ${metaWindow.title}`);
-            const f = metaWindow.get_frame_rect();
-            if (metaWindow._targetHeight !== f.height) {
-                if (!isNaN(metaWindow._targetHeight)) {
-                    metaWindow.move_resize_frame(true, f.x, f.y, f.width, metaWindow._targetHeight);
-                }
-                return true;
-            }
-
-            done(timeout);
-            return false;
-        });
+        );
         workspaceChangeTimeouts.push(timeout);
     });
 

--- a/tiling.js
+++ b/tiling.js
@@ -2260,16 +2260,15 @@ export const Spaces = class Spaces extends Map {
                     Utils.timeout_remove(monitorChangeTimeout);
                 },
                 callback: () => {
-                    this?.spaces.forEach(s => s.layout());
+                    this?.forEach(s => s.layout());
                 },
                 onContinue: called => {
-                    console.warn(`MONITORS_CHANGED: no primary monitor - 'space.layout' call ${called}`);
+                    console.warn(`MONITORS_CHANGED: no primary monitor - 'layout' on spaces call ${called}`);
                 },
                 onComplete: () => {
                     monitorChangeTimeout = null;
                 },
             });
-
             return;
         }
 

--- a/tiling.js
+++ b/tiling.js
@@ -2263,7 +2263,7 @@ export const Spaces = class Spaces extends Map {
                     this.activeSpace.layout();
                     if (monitorTimeoutCount < 4) {
                         monitorChangeTimeout++;
-                        console.warn(`MONITORS_CHANGED: no primary monitor, check ${monitorChangeTimeout}`);
+                        console.warn(`MONITORS_CHANGED: no primary monitor - 'space.layout' call ${monitorChangeTimeout}`);
                         return true;
                     }
                     return false; // on return false destroys timeout

--- a/tiling.js
+++ b/tiling.js
@@ -2250,6 +2250,15 @@ export const Spaces = class Spaces extends Map {
 
         let primary = Main.layoutManager.primaryMonitor;
         if (!primary) {
+            // TEST:
+            GLib.timeout_add(
+                GLib.PRIORITY_DEFAULT,
+                2000,
+                () => {
+                    this.activeSpace.layout();
+                    return false; // on return false destroys timeout
+                });
+
             return;
         }
 

--- a/utils.js
+++ b/utils.js
@@ -459,26 +459,26 @@ export function timeout_remove(...timeouts) {
  * @returns GLib timeout id
  */
 export function periodic_timeout(options = { }) {
-    const pperiod = options.period_ms ?? 1000;
-    const pcount = options.count ?? 1;
-    const pinit = options.init ?? function() {};
-    const pcallback = options.callback ?? function() {};
-    const pcontinue = options.onContinue ?? function() {};
-    const pcomplete = options.onComplete ?? function() {};
+    const operiod = options?.period_ms ?? 1000;
+    const ocount = options?.count ?? 1;
+    const oinit = options?.init ?? function() {};
+    const ocallback = options?.callback ?? function() {};
+    const ocontinue = options?.onContinue ?? function() {};
+    const ocomplete = options?.onComplete ?? function() {};
 
-    pinit();
+    oinit();
     let called = 0;
     return GLib.timeout_add(
         GLib.PRIORITY_DEFAULT,
-        pperiod,
+        operiod,
         () => {
-            pcallback();
-            if (called < pcount) {
+            ocallback();
+            if (called < ocount) {
                 called++;
-                pcontinue(called);
+                ocontinue(called);
                 return true;
             }
-            pcomplete();
+            ocomplete();
             return false; // on return false destroys timeout
         });
 }

--- a/utils.js
+++ b/utils.js
@@ -445,6 +445,44 @@ export function timeout_remove(...timeouts) {
     });
 }
 
+/**
+ * Calls a period timeout (GLib.timeout_add) that calls a callback function.
+ * Also contains parameters for init (call for initialisation), onContinue (callback when continuing),
+ * onComplete (callback when completed last callback).
+ * @param {Object} options
+ * @param {Number} options.period_ms
+ * @param {Number} options.count
+ * @param {Function} options.init
+ * @param {Function} options.callback
+ * @param {Function} options.onContinue
+ * @param {Function} options.onComplete
+ * @returns GLib timeout id
+ */
+export function periodic_timeout(options = { }) {
+    const pperiod = options.period_ms ?? 1000;
+    let pcount = options.count ?? 1;
+    const pinit = options.init ?? function() {};
+    const pcallback = options.callback ?? function() {};
+    const pcontinue = options.onContinue ?? function() {};
+    const pcomplete = options.onComplete ?? function() {};
+
+    pinit();
+    let called = 0;
+    return GLib.timeout_add(
+        GLib.PRIORITY_DEFAULT,
+        pperiod,
+        () => {
+            pcallback();
+            if (called < pcount) {
+                pcount++;
+                pcontinue(called);
+                return true;
+            }
+            pcomplete();
+            return false; // on return false destroys timeout
+        });
+}
+
 export class Signals extends Map {
     static get [Symbol.species]() { return Map; }
 

--- a/utils.js
+++ b/utils.js
@@ -472,12 +472,18 @@ export function periodic_timeout(options = { }) {
         GLib.PRIORITY_DEFAULT,
         operiod,
         () => {
-            ocallback();
+            // check for early exit (if callback returns false)
+            if (ocallback() === false) {
+                ocomplete();
+                return false;
+            }
+
             if (called < ocount) {
                 called++;
                 ocontinue(called);
                 return true;
             }
+
             ocomplete();
             return false; // on return false destroys timeout
         });

--- a/utils.js
+++ b/utils.js
@@ -460,7 +460,7 @@ export function timeout_remove(...timeouts) {
  */
 export function periodic_timeout(options = { }) {
     const pperiod = options.period_ms ?? 1000;
-    let pcount = options.count ?? 1;
+    const pcount = options.count ?? 1;
     const pinit = options.init ?? function() {};
     const pcallback = options.callback ?? function() {};
     const pcontinue = options.onContinue ?? function() {};
@@ -474,7 +474,7 @@ export function periodic_timeout(options = { }) {
         () => {
             pcallback();
             if (called < pcount) {
-                pcount++;
+                called++;
                 pcontinue(called);
                 return true;
             }


### PR DESCRIPTION
This PR fixes #835.

After much debugging with help from @glupi-borna, we've now addressed this issue.  See #835 for details.

This PR also implements a new utility function which can call a controlled, periodic timeout (with various callback options).