### PR TITLE
Ease scratch windows when centering horizontally

### DIFF
--- a/scratch.js
+++ b/scratch.js
@@ -42,10 +42,11 @@ export function disable() {
    other windows/clones (clones if the space animates)
  */
 export function easeScratch(metaWindow, targetX, targetY, params = {}) {
-    let f = metaWindow.get_frame_rect();
-    let b = metaWindow.get_buffer_rect();
-    let dx = f.x - b.x;
-    let dy = f.y - b.y;
+    const complete = params?.onComplete ?? function() {};
+    const f = metaWindow.get_frame_rect();
+    const b = metaWindow.get_buffer_rect();
+    const dx = f.x - b.x;
+    const dy = f.y - b.y;
 
     Easer.addEase(metaWindow.get_compositor_private(), {
         x: targetX - dx,
@@ -53,7 +54,7 @@ export function easeScratch(metaWindow, targetX, targetY, params = {}) {
         time: Settings.prefs.animation_time,
         onComplete: () => {
             metaWindow.move_frame(true, targetX, targetY);
-            params?.onComplete();
+            complete();
         },
     });
 }

--- a/scratch.js
+++ b/scratch.js
@@ -41,25 +41,21 @@ export function disable() {
    The actual window actor (not clone) is tweened to ensure it's on top of the
    other windows/clones (clones if the space animates)
  */
-export function easeScratch(metaWindow, targetX, targetY, tweenParams = {}) {
+export function easeScratch(metaWindow, targetX, targetY, params = {}) {
     let f = metaWindow.get_frame_rect();
     let b = metaWindow.get_buffer_rect();
     let dx = f.x - b.x;
     let dy = f.y - b.y;
 
-    Easer.addEase(metaWindow.get_compositor_private(), Object.assign(
-        {
-            time: Settings.prefs.animation_time,
-            x: targetX - dx,
-            y: targetY - dy,
+    Easer.addEase(metaWindow.get_compositor_private(), {
+        x: targetX - dx,
+        y: targetY - dy,
+        time: Settings.prefs.animation_time,
+        onComplete: () => {
+            metaWindow.move_frame(true, targetX, targetY);
+            params?.onComplete();
         },
-        tweenParams,
-        {
-            onComplete (...args) {
-                metaWindow.move_frame(true, targetX, targetY);
-                tweenParams.onComplete && tweenParams.onComplete.apply(this, args);
-            },
-        }));
+    });
 }
 
 export function makeScratch(metaWindow) {

--- a/tiling.js
+++ b/tiling.js
@@ -4955,7 +4955,7 @@ export function centerWindowHorizontally(metaWindow) {
 
     const targetX = workArea.x + Math.round((workArea.width - frame.width) / 2);
     if (space.indexOf(metaWindow) === -1) {
-        metaWindow.move_frame(true, targetX + monitor.x, frame.y);
+        Scratch.easeScratch(metaWindow, targetX + monitor.x, frame.y);
     } else {
         move_to(space, metaWindow, {
             x: targetX,


### PR DESCRIPTION
I was poking around the code and found the `easeScratch` function, which looked to me like it could be used to implement #911. I'm not sure if this is the right function to call because it's used only in one other place (in `makeScratch`), but it seems to work fine at first glance -- though I don't know if there are edge cases to consider. 