### PR TITLE
Add winprop to select space for new window

### DIFF
--- a/WinpropsRow.ui
+++ b/WinpropsRow.ui
@@ -204,7 +204,7 @@
                             <property name="focusable">False</property>
                             <property name="hexpand">1</property>
                             <property name="use_markup">True</property>
-                            <property name="label" translatable="yes">Insert into workspace (blank for current workspace)</property>
+                            <property name="label" translatable="yes">Insert into workspace</property>
                             <property name="xalign">0</property>
                             <layout>
                               <property name="column">0</property>
@@ -240,7 +240,7 @@
                             <property name="focusable">False</property>
                             <property name="hexpand">1</property>
                             <property name="use_markup">True</property>
-                            <property name="label" translatable="yes">Focus space after inserting</property>
+                            <property name="label" translatable="yes">Focus window after inserting into workspace</property>
                             <property name="xalign">0</property>
                             <layout>
                               <property name="column">0</property>

--- a/WinpropsRow.ui
+++ b/WinpropsRow.ui
@@ -227,6 +227,37 @@
                         </child>
                       </object>
                     </child>
+                    <child>
+                      <object class="GtkGrid">
+                        <property name="focusable">False</property>
+                        <property name="margin_start">12</property>
+                        <property name="margin_end">12</property>
+                        <property name="margin_top">6</property>
+                        <property name="margin_bottom">6</property>
+                        <property name="column_spacing">32</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="focusable">False</property>
+                            <property name="hexpand">1</property>
+                            <property name="use_markup">True</property>
+                            <property name="label" translatable="yes">Focus space after inserting</property>
+                            <property name="xalign">0</property>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">0</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkSwitch" id="focus">
+                            <layout>
+                              <property name="column">2</property>
+                              <property name="row">0</property>
+                            </layout>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
                   </object>
                 </child>
                 <child>

--- a/WinpropsRow.ui
+++ b/WinpropsRow.ui
@@ -213,9 +213,12 @@
                           </object>
                         </child>
                         <child>
-                          <object class="GtkEntry" id="space">
-                            <property name="width_chars">12</property>
-                            <property name="max_width_chars">12</property>
+                          <object class="GtkComboBoxText" id="space">
+                            <property name="focusable">False</property>
+                            <property name="hexpand">0</property>
+                            <property name="width-request">120</property>
+                            <!-- <property name="width_chars">12</property> -->
+                            <!-- <property name="max_width_chars">12</property> -->
                             <layout>
                               <property name="column">2</property>
                               <property name="row">0</property>

--- a/WinpropsRow.ui
+++ b/WinpropsRow.ui
@@ -191,6 +191,39 @@
                         </child>
                       </object>
                     </child>
+                    <child>
+                      <object class="GtkGrid">
+                        <property name="focusable">False</property>
+                        <property name="margin_start">12</property>
+                        <property name="margin_end">12</property>
+                        <property name="margin_top">6</property>
+                        <property name="margin_bottom">6</property>
+                        <property name="column_spacing">32</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="focusable">False</property>
+                            <property name="hexpand">1</property>
+                            <property name="use_markup">True</property>
+                            <property name="label" translatable="yes">Insert into workspace (blank for current workspace)</property>
+                            <property name="xalign">0</property>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">0</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkEntry" id="space">
+                            <property name="width_chars">12</property>
+                            <property name="max_width_chars">12</property>
+                            <layout>
+                              <property name="column">2</property>
+                              <property name="row">0</property>
+                            </layout>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
                   </object>
                 </child>
                 <child>

--- a/examples/keybindings.js
+++ b/examples/keybindings.js
@@ -305,7 +305,7 @@ function cycleEdgeSnap(binding = "<Super>u") {
 
 function reorderWorkspace(bindingUp = "<Alt><Super>Page_Up", bindingDown = "<Alt><Super>Page_Down") {
     if (!global.workspace_manager.reorder_workspace) {
-        console.log("Reorder workspaces not supported by this gnome-shell version");
+        console.warn("Reorder workspaces not supported by this gnome-shell version");
         return;
     }
     function moveWorkspace(dir, metaWindow, space) {

--- a/patches.js
+++ b/patches.js
@@ -72,7 +72,7 @@ export function registerOverrideProp(obj, name, override, warn = true) {
     // check if prop exists
     const exists = obj?.[name];
     if (!exists && warn) {
-        console.log(`#PaperWM: attempt to override prop for '${name}' failed: is null or undefined`);
+        console.warn(`#PaperWM: attempt to override prop for '${name}' failed: is null or undefined`);
     }
 
     let saved = getSavedProp(obj, name) ?? obj[name];
@@ -94,7 +94,7 @@ export function registerOverridePrototype(obj, name, override) {
     // check if method for prototype exists
     const exists = obj?.prototype?.[name];
     if (!exists) {
-        console.log(`#PaperWM: attempt to override prototype for '${name}' failed: is null or undefined`);
+        console.warn(`#PaperWM: attempt to override prototype for '${name}' failed: is null or undefined`);
     }
 
     registerOverrideProp(obj.prototype, name, override);

--- a/prefs.js
+++ b/prefs.js
@@ -7,7 +7,9 @@ import { ExtensionPreferences } from 'resource:///org/gnome/Shell/Extensions/js/
 
 import * as Settings from './settings.js';
 import { WorkspaceSettings } from './workspace.js';
+// eslint-disable-next-line no-unused-vars
 import * as KeybindingsPane from './prefsKeybinding.js';
+// eslint-disable-next-line no-unused-vars
 import * as WinpropsPane from './winpropsPane.js';
 
 const _ = s => s;
@@ -35,7 +37,7 @@ export default class PaperWMPrefs extends ExtensionPreferences {
             tempFile.delete(null);
         } catch (e) { }
 
-        let selectedTab = selectedWorkspace !== null ? 1 : 0;
+        const selectedTab = selectedWorkspace !== null ? 1 : 0;
         window.set_size_request(626, 700);
         new SettingsWidget(
             this,
@@ -153,12 +155,12 @@ class SettingsWidget {
         intValueChanged('bottom_margin_spinner', 'vertical-margin-bottom');
 
         // processing function for cycle values
-        let cycleProcessor = (elementName, settingName, resetElementName) => {
-            let element = this.builder.get_object(elementName);
-            let steps = this._settings.get_value(settingName).deep_unpack();
+        const cycleProcessor = (elementName, settingName, resetElementName) => {
+            const element = this.builder.get_object(elementName);
+            const steps = this._settings.get_value(settingName).deep_unpack();
 
             // need to check if current values are ratio or pixel ==> assume if all <=1 is ratio
-            let isRatio = steps.every(v => v <= 1);
+            const isRatio = steps.every(v => v <= 1);
             let value;
             if (isRatio) {
                 value = steps.map(v => `${(v * 100.0).toString()}%`).toString();
@@ -170,9 +172,9 @@ class SettingsWidget {
             element.connect('changed', () => {
                 // process values
                 // check if values are percent or pixel
-                let value = element.get_text();
-                let isPercent = value.split(';').map(v => v.trim()).every(v => /^.*%$/.test(v));
-                let isPixels = value.split(';').map(v => v.trim()).every(v => /^.*px$/.test(v));
+                const value = element.get_text();
+                const isPercent = value.split(';').map(v => v.trim()).every(v => /^.*%$/.test(v));
+                const isPixels = value.split(';').map(v => v.trim()).every(v => /^.*px$/.test(v));
                 if (isPercent && isPixels) {
                     console.error("cycle width/height values cannot mix percentage and pixel values");
                     element.add_css_class('error');
@@ -185,7 +187,7 @@ class SettingsWidget {
                 }
 
                 // now process element value into internal array
-                let varr = value
+                const varr = value
                     .split(';')
                     .map(v => v.trim())
                     .map(v => v.replaceAll(/[^\d.]/g, '')) // strip everything but digits and period
@@ -212,23 +214,23 @@ class SettingsWidget {
         cycleProcessor('cycle_widths_entry', 'cycle-width-steps', 'cycle_widths_reset_button');
         cycleProcessor('cycle_heights_entry', 'cycle-height-steps', 'cycle_heights_reset_button');
 
-        let vSens = this.builder.get_object('vertical-sensitivity');
-        let hSens = this.builder.get_object('horizontal-sensitivity');
-        let [sx, sy] = this._settings.get_value('swipe-sensitivity').deep_unpack();
+        const vSens = this.builder.get_object('vertical-sensitivity');
+        const hSens = this.builder.get_object('horizontal-sensitivity');
+        const [sx, sy] = this._settings.get_value('swipe-sensitivity').deep_unpack();
         hSens.set_value(sx);
         vSens.set_value(sy);
-        let sensChanged = () => {
+        const sensChanged = () => {
             this._settings.set_value('swipe-sensitivity', new GLib.Variant('ad', [hSens.get_value(), vSens.get_value()]));
         };
         vSens.connect('value-changed', sensChanged);
         hSens.connect('value-changed', sensChanged);
 
-        let vFric = this.builder.get_object('vertical-friction');
-        let hFric = this.builder.get_object('horizontal-friction');
-        let [fx, fy] = this._settings.get_value('swipe-friction').deep_unpack();
+        const vFric = this.builder.get_object('vertical-friction');
+        const hFric = this.builder.get_object('horizontal-friction');
+        const [fx, fy] = this._settings.get_value('swipe-friction').deep_unpack();
         hFric.set_value(fx);
         vFric.set_value(fy);
-        let fricChanged = () => {
+        const fricChanged = () => {
             this._settings.set_value('swipe-friction', new GLib.Variant('ad', [hFric.get_value(), vFric.get_value()]));
         };
         vFric.connect('value-changed', fricChanged);
@@ -347,20 +349,20 @@ class SettingsWidget {
         //       stack at construction time.. (!)
         //       Ensure the initially selected workspace is added to the stack
         //       first as a workaround.
-        let wsIndices = this.range(nWorkspaces);
-        let wsSettingsByIndex = wsIndices.map(i => this.workspaceSettings.getWorkspaceSettings(i)[1]);
-        let wsIndicesSelectedFirst =
+        const wsIndices = this.range(nWorkspaces);
+        const wsSettingsByIndex = wsIndices.map(i => this.workspaceSettings.getWorkspaceSettings(i)[1]);
+        const wsIndicesSelectedFirst =
             this.swapArrayElements(wsIndices.slice(), 0, selectedWorkspace);
 
         for (let i of wsIndicesSelectedFirst) {
-            let view = this.createWorkspacePage(wsSettingsByIndex[i], i);
+            const view = this.createWorkspacePage(wsSettingsByIndex[i], i);
             workspaceStack.add_named(view, i.toString());
         }
 
-        let workspaces = [];
+        const workspaces = [];
         for (let i of wsIndices) {
             // Combo box entries in normal workspace index order
-            let name = this.getWorkspaceName(wsSettingsByIndex[i], i);
+            const name = this.getWorkspaceName(wsSettingsByIndex[i], i);
             workspaceCombo.append_text(name);
             workspaces.push(name);
         }
@@ -371,8 +373,8 @@ class SettingsWidget {
             this._updatingName = true;
             wmSettings.set_strv('workspace-names', []);
 
-            let settings = i => wsSettingsByIndex[i];
-            let name = (s, i) => this.getWorkspaceName(s, i);
+            const settings = i => wsSettingsByIndex[i];
+            const name = (s, i) => this.getWorkspaceName(s, i);
             workspaceCombo.remove_all();
             for (let i of wsIndices) {
                 settings(i).reset('name');
@@ -381,8 +383,8 @@ class SettingsWidget {
 
             // update pages
             for (let j of wsIndicesSelectedFirst) {
-                let view = workspaceStack.get_child_by_name(j.toString());
-                let nameEntry = view.get_first_child().get_last_child();
+                const view = workspaceStack.get_child_by_name(j.toString());
+                const nameEntry = view.get_first_child().get_last_child();
                 nameEntry.set_text(name(settings(j), j));
             }
             this._updatingName = false;
@@ -394,21 +396,21 @@ class SettingsWidget {
             if (this._updatingName)
                 return;
 
-            let active = workspaceCombo.get_active();
+            const active = workspaceCombo.get_active();
             workspaceStack.set_visible_child_name(active.toString());
         });
 
         workspaceCombo.set_active(selectedWorkspace);
 
         // Keybindings
-        let keybindingsPane = this.builder.get_object('keybindings_pane');
+        const keybindingsPane = this.builder.get_object('keybindings_pane');
         keybindingsPane.init(extension);
 
         // Winprops
-        let winprops = this._settings.get_value('winprops').deep_unpack()
+        const winprops = this._settings.get_value('winprops').deep_unpack()
             .map(p => JSON.parse(p));
         // sort a little nicer
-        let valueFn = wp => {
+        const valueFn = wp => {
             if (wp.wm_class) {
                 return wp.wm_class;
             }
@@ -418,15 +420,15 @@ class SettingsWidget {
             return '';
         };
         winprops.sort((a, b) => {
-            let aa = valueFn(a).replaceAll(/[/]/g, '');
-            let bb = valueFn(b).replaceAll(/[/]/g, '');
+            const aa = valueFn(a).replaceAll(/[/]/g, '');
+            const bb = valueFn(b).replaceAll(/[/]/g, '');
             return aa.localeCompare(bb);
         });
-        let winpropsPane = this.builder.get_object('winpropsPane');
+        const winpropsPane = this.builder.get_object('winpropsPane');
         winpropsPane.addWinprops(winprops);
         winpropsPane.connect('changed', () => {
             // update gsettings with changes
-            let rows = winpropsPane.rows
+            const rows = winpropsPane.rows
                 .filter(r => r.checkHasWmClassOrTitle())
                 .map(r => JSON.stringify(r.winprop));
 
@@ -588,31 +590,31 @@ class SettingsWidget {
     }
 
     range(n) {
-        let r = [];
+        const r = [];
         for (let i = 0; i < n; i++)
             r.push(i);
         return r;
     }
 
     swapArrayElements(array, i, j) {
-        let iVal = array[i];
+        const iVal = array[i];
         array[i] = array[j];
         array[j] = iVal;
         return array;
     }
 
     createWorkspacePage(settings, index) {
-        let list = new Gtk.Box({
+        const list = new Gtk.Box({
             orientation: Gtk.Orientation.VERTICAL,
             focusable: false,
         });
-        let nameEntry = new Gtk.Entry();
-        let colorButton = new Gtk.ColorButton();
+        const nameEntry = new Gtk.Entry();
+        const colorButton = new Gtk.ColorButton();
 
         // Background
 
-        let backgroundBox = new Gtk.Box({ spacing: 16 });
-        let background = this.createFileChooserButton(
+        const backgroundBox = new Gtk.Box({ spacing: 16 });
+        const background = this.createFileChooserButton(
             settings,
             'background',
             'image-x-generic',
@@ -626,7 +628,7 @@ class SettingsWidget {
                 transient_for: this.window.get_root(),
             }
         );
-        let clearBackground = new Gtk.Button({
+        const clearBackground = new Gtk.Button({
             icon_name: 'edit-clear-symbolic',
             tooltip_text: 'Clear workspace background',
             sensitive: settings.get_string('background') !== '',
@@ -634,11 +636,11 @@ class SettingsWidget {
         backgroundBox.append(background);
         backgroundBox.append(clearBackground);
 
-        let hideTopBarSwitch = new Gtk.Switch({ active: !settings.get_boolean('show-top-bar') });
-        let hidePositionBarSwitch = new Gtk.Switch({ active: !settings.get_boolean('show-position-bar') });
+        const hideTopBarSwitch = new Gtk.Switch({ active: !settings.get_boolean('show-top-bar') });
+        const hidePositionBarSwitch = new Gtk.Switch({ active: !settings.get_boolean('show-position-bar') });
 
-        let directoryBox = new Gtk.Box({ spacing: 16 });
-        let directoryChooser = this.createFileChooserButton(
+        const directoryBox = new Gtk.Box({ spacing: 16 });
+        const directoryChooser = this.createFileChooserButton(
             settings,
             'directory',
             'folder',
@@ -651,7 +653,7 @@ class SettingsWidget {
                 transient_for: this.window.get_root(),
             }
         );
-        let clearDirectory = new Gtk.Button({
+        const clearDirectory = new Gtk.Button({
             icon_name: 'edit-clear-symbolic',
             tooltip_text: 'Clear workspace directory',
             sensitive: settings.get_string('directory') !== '',
@@ -666,9 +668,9 @@ class SettingsWidget {
         list.append(this.createRow('Hide Window Position Bar', hidePositionBarSwitch));
         list.append(this.createRow('Directory', directoryBox));
 
-        let rgba = new Gdk.RGBA();
+        const rgba = new Gdk.RGBA();
         let color = settings.get_string('color');
-        let palette = this._settings.get_strv('workspace-colors');
+        const palette = this._settings.get_strv('workspace-colors');
         if (color === '')
             color = palette[index % palette.length];
 
@@ -677,7 +679,7 @@ class SettingsWidget {
 
         nameEntry.set_text(this.getWorkspaceName(settings, index));
 
-        let workspace_combo = this.builder.get_object('workspace_combo_text');
+        const workspace_combo = this.builder.get_object('workspace_combo_text');
 
         nameEntry.connect('changed', () => {
             if (this._updatingName) {
@@ -743,13 +745,13 @@ class SettingsWidget {
     }
 
     createRow(text, widget) {
-        let margin = 12;
-        let box = new Gtk.Box({
+        const margin = 12;
+        const box = new Gtk.Box({
             margin_start: margin, margin_end: margin,
             margin_top: margin / 2, margin_bottom: margin / 2,
             orientation: Gtk.Orientation.HORIZONTAL,
         });
-        let label = new Gtk.Label({
+        const label = new Gtk.Label({
             label: text, hexpand: true, xalign: 0,
         });
 

--- a/prefs.js
+++ b/prefs.js
@@ -357,11 +357,15 @@ class SettingsWidget {
             workspaceStack.add_named(view, i.toString());
         }
 
+        let workspaces = [];
         for (let i of wsIndices) {
             // Combo box entries in normal workspace index order
             let name = this.getWorkspaceName(wsSettingsByIndex[i], i);
             workspaceCombo.append_text(name);
+            workspaces.push(name);
         }
+
+        this.builder.get_object('winpropsPane').setWorkspaces(workspaces);
 
         this.builder.get_object('workspace_reset_button').connect('clicked', () => {
             this._updatingName = true;

--- a/tiling.js
+++ b/tiling.js
@@ -4025,6 +4025,7 @@ export function insertWindow(metaWindow, options = {}) {
             // pass winprop properties to metaWindow
             metaWindow.preferredWidth = winprop.preferredWidth;
             if (winprop.focus) {
+                console.error("#winprops", `setting ${metaWindow?.title} to focusOnOpen`);
                 metaWindow.focusOnOpen = true;
             }
 

--- a/tiling.js
+++ b/tiling.js
@@ -3997,6 +3997,8 @@ export function insertWindow(metaWindow, options = {}) {
         delete metaWindow.unmapped;
     };
 
+    const actor = metaWindow.get_compositor_private();
+
     let overwriteSpace;
     if (!existing) {
         /**
@@ -4076,7 +4078,6 @@ export function insertWindow(metaWindow, options = {}) {
         return;
     }
 
-    const actor = metaWindow.get_compositor_private();
     const space = spaces.spaceOfWindow(metaWindow);
 
     if (overwriteSpace !== undefined) {

--- a/tiling.js
+++ b/tiling.js
@@ -4081,8 +4081,12 @@ export function insertWindow(metaWindow, options = {}) {
 
     if (overwriteSpace !== undefined) {
         const newspace = spaces.spaceOfIndex(overwriteSpace);
-        if (newspace) {
-            console.debug("#winprops", `Inserting window into space ${newspace.name}`);
+        if (!newspace) {
+            console.warn("#winprops", `overwriteSpace with index ${overwriteSpace} does not exist. \
+Opening "${metaWindow?.title}" on current space.`);
+        }
+        else {
+            console.debug("#winprops", `inserting window into space ${newspace.name}`);
             metaWindow.change_workspace(newspace.workspace);
             metaWindow.foreach_transient(t => {
                 space.addFloating(t);

--- a/tiling.js
+++ b/tiling.js
@@ -3977,6 +3977,7 @@ export function insertWindow(metaWindow, options = {}) {
     const existing = options?.existing ?? false;
     const dropping = options?.dropping ?? false;
     const dropCallback = options?.dropCallback ?? function() {};
+    const spaceOverwritten = options?.spaceOverwritten ?? false;
 
     // Add newly created windows to the space being previewed
     if (!existing &&
@@ -4013,7 +4014,7 @@ export function insertWindow(metaWindow, options = {}) {
         let addToScratch = false;
 
         let winprop = Settings.find_winprop(metaWindow);
-        if (winprop) {
+        if (!spaceOverwritten && winprop) {
             if (winprop.oneshot) {
                 Settings.winprops.splice(Settings.winprops.indexOf(winprop), 1);
             }
@@ -4076,7 +4077,7 @@ export function insertWindow(metaWindow, options = {}) {
     const actor = metaWindow.get_compositor_private();
     const space = spaces.spaceOfWindow(metaWindow);
 
-    if (overwriteSpace) {
+    if (!spaceOverwritten && overwriteSpace) {
         const newspace = spaces.spaceOfIndex(overwriteSpace);
         if (newspace) {
             console.log("#winprops", `Inserting window into space ${newspace.name}`);
@@ -4085,7 +4086,7 @@ export function insertWindow(metaWindow, options = {}) {
                 space.addFloating(t);
             });
             connectSizeChanged(true);
-            insertWindow(metaWindow, { existing: true, dropping: false });
+            insertWindow(metaWindow, { spaceOverwritten: true });
             return;
         }
     }
@@ -4199,7 +4200,8 @@ export function insertWindow(metaWindow, options = {}) {
         console.log("#winprops", "focusing space of inserted window");
         spaces.spaceOfWindow(metaWindow)?.activateWithFocus(metaWindow, false, true);
     }
-    else if (metaWindow === display.focus_window) {
+
+    if (metaWindow === display.focus_window) {
         focus_handler(metaWindow);
     } else if (space === spaces.activeSpace) {
         Main.activateWindow(metaWindow);

--- a/tiling.js
+++ b/tiling.js
@@ -3977,7 +3977,6 @@ export function insertWindow(metaWindow, options = {}) {
     const existing = options?.existing ?? false;
     const dropping = options?.dropping ?? false;
     const dropCallback = options?.dropCallback ?? function() {};
-    const spaceOverwritten = options?.spaceOverwritten ?? false;
 
     // Add newly created windows to the space being previewed
     if (!existing &&
@@ -4014,7 +4013,7 @@ export function insertWindow(metaWindow, options = {}) {
         let addToScratch = false;
 
         let winprop = Settings.find_winprop(metaWindow);
-        if (!spaceOverwritten && winprop) {
+        if (winprop) {
             if (winprop.oneshot) {
                 Settings.winprops.splice(Settings.winprops.indexOf(winprop), 1);
             }
@@ -4077,7 +4076,7 @@ export function insertWindow(metaWindow, options = {}) {
     const actor = metaWindow.get_compositor_private();
     const space = spaces.spaceOfWindow(metaWindow);
 
-    if (!spaceOverwritten && overwriteSpace) {
+    if (overwriteSpace) {
         const newspace = spaces.spaceOfIndex(overwriteSpace);
         if (newspace) {
             console.log("#winprops", `Inserting window into space ${newspace.name}`);
@@ -4086,7 +4085,7 @@ export function insertWindow(metaWindow, options = {}) {
                 space.addFloating(t);
             });
             connectSizeChanged(true);
-            insertWindow(metaWindow, { spaceOverwritten: true });
+            insertWindow(metaWindow, { existing: true });
             return;
         }
     }

--- a/tiling.js
+++ b/tiling.js
@@ -2694,6 +2694,15 @@ export const Spaces = class Spaces extends Map {
         this.forEach(s => s.setSpaceTopbarElementsVisible(true, { force: true }));
     }
 
+    switchSpace(fromSpace, toSpace, animate = false) {
+        const fromId = fromSpace?.index;
+        const toId = toSpace?.index;
+        if (!fromSpace || !toSpace) {
+            return;
+        }
+        spaces.switchWorkspace(null, fromId, toId, animate);
+    }
+
     switchWorkspace(wm, fromIndex, toIndex, animate = false) {
         /**
          * disable swipetrackers on workspace switch to avoid gesture confusion
@@ -3988,7 +3997,7 @@ export function insertWindow(metaWindow, options = {}) {
         delete metaWindow.unmapped;
     };
 
-    let overwriteSpace = undefined;
+    let overwriteSpace;
     let focusOnOpen = true;
 
     if (!existing) {
@@ -4091,13 +4100,6 @@ export function insertWindow(metaWindow, options = {}) {
         metaWindow.foreach_transient(t => {
             space.addFloating(t);
         });
-
-        if (focusOnOpen) {
-            console.log("#winprops", "focussing space of inserted window");
-            // TODO doesn't seem to work
-            spaces.animateToSpace(spaceOfWindow, space, true);
-            // space.activateWithFocus(metaWindow, false, false);
-        }
     }
     const active = space.selectedWindow;
 
@@ -4204,6 +4206,11 @@ export function insertWindow(metaWindow, options = {}) {
 
     space.layout();
     animateWindow(metaWindow);
+    if (focusOnOpen) {
+        console.log("#winprops", "focusing space of inserted window");
+        spaces.switchSpace(space, spaces.spaceOfWindow(metaWindow), true);
+    }
+
     if (metaWindow === display.focus_window) {
         focus_handler(metaWindow);
     } else if (space === spaces.activeSpace) {

--- a/tiling.js
+++ b/tiling.js
@@ -4025,7 +4025,7 @@ export function insertWindow(metaWindow, options = {}) {
             // pass winprop properties to metaWindow
             metaWindow.preferredWidth = winprop.preferredWidth;
             if (winprop.focus) {
-                console.error("#winprops", `setting ${metaWindow?.title} to focusOnOpen`);
+                console.debug("#winprops", `setting ${metaWindow?.title} to focusOnOpen`);
                 metaWindow.focusOnOpen = true;
             }
 
@@ -4080,10 +4080,9 @@ export function insertWindow(metaWindow, options = {}) {
     const space = spaces.spaceOfWindow(metaWindow);
 
     if (overwriteSpace !== undefined) {
-        console.log("#winprops", `overwrite space to index ${overwriteSpace} for ${metaWindow?.title}`);
         const newspace = spaces.spaceOfIndex(overwriteSpace);
         if (newspace) {
-            console.log("#winprops", `Inserting window into space ${newspace.name}`);
+            console.debug("#winprops", `Inserting window into space ${newspace.name}`);
             metaWindow.change_workspace(newspace.workspace);
             metaWindow.foreach_transient(t => {
                 space.addFloating(t);
@@ -4200,7 +4199,7 @@ export function insertWindow(metaWindow, options = {}) {
     animateWindow(metaWindow);
     if (metaWindow.focusOnOpen) {
         delete metaWindow.focusOnOpen;
-        console.log("#winprops", "focusing space of inserted window");
+        console.debug("#winprops", "focusing space of inserted window");
         spaces.spaceOfWindow(metaWindow)?.activateWithFocus(metaWindow, false, true);
     }
 

--- a/tiling.js
+++ b/tiling.js
@@ -4030,9 +4030,11 @@ export function insertWindow(metaWindow, options = {}) {
             }
 
             overwriteSpace = winprop.spaceIndex;
-            if (typeof overwriteSpace !== "number") {
-                console.error("#winprops", `${overwriteSpace} is not a valid index. Ignoring.`);
-                overwriteSpace = undefined;
+            if (overwriteSpace !== undefined) {
+                if (typeof overwriteSpace !== "number") {
+                    console.error("#winprops", `${overwriteSpace} is not a valid index. Ignoring.`);
+                    overwriteSpace = undefined;
+                }
             }
         }
 
@@ -4077,7 +4079,8 @@ export function insertWindow(metaWindow, options = {}) {
     const actor = metaWindow.get_compositor_private();
     const space = spaces.spaceOfWindow(metaWindow);
 
-    if (overwriteSpace) {
+    if (overwriteSpace !== undefined) {
+        console.log("#winprops", `overwrite space to index ${overwriteSpace} for ${metaWindow?.title}`);
         const newspace = spaces.spaceOfIndex(overwriteSpace);
         if (newspace) {
             console.log("#winprops", `Inserting window into space ${newspace.name}`);

--- a/tiling.js
+++ b/tiling.js
@@ -3989,6 +3989,8 @@ export function insertWindow(metaWindow, options = {}) {
     };
 
     let overwriteSpace = undefined;
+    let focusOnOpen = true;
+
     if (!existing) {
         /**
          * Note: Can't trust global.display.focus_window to determine currently focused window.
@@ -4022,6 +4024,10 @@ export function insertWindow(metaWindow, options = {}) {
             if (typeof overwriteSpace !== "number") {
                 console.error("#winprops", `${overwriteSpace} is not a valid index. Ignoring.`);
                 overwriteSpace = undefined;
+            }
+
+            if (winprop.focus === false) {
+                focusOnOpen = false;
             }
         }
 
@@ -4075,16 +4081,23 @@ export function insertWindow(metaWindow, options = {}) {
         }
     }
     if (spaceOfWindow !== space) {
-        console.log("#winprops", `Inserting window into space ${space.name}`);
+        console.log("#winprops", `Inserting window into space ${space.name} (current space ${spaceOfWindow.name})`);
         spaceOfWindow.removeWindow(metaWindow);
         metaWindow.foreach_transient(t => {
             spaceOfWindow.removeWindow(t);
         });
+        // TODO do we need metaWindow.move_to_monitor(...)
         metaWindow.change_workspace(space.workspace);
         metaWindow.foreach_transient(t => {
             space.addFloating(t);
         });
-        // activate?
+
+        if (focusOnOpen) {
+            console.log("#winprops", "focussing space of inserted window");
+            // TODO doesn't seem to work
+            spaces.animateToSpace(spaceOfWindow, space, true);
+            // space.activateWithFocus(metaWindow, false, false);
+        }
     }
     const active = space.selectedWindow;
 

--- a/tiling.js
+++ b/tiling.js
@@ -4026,10 +4026,6 @@ export function insertWindow(metaWindow, options = {}) {
 
             // pass winprop properties to metaWindow
             metaWindow.preferredWidth = winprop.preferredWidth;
-            if (winprop.focus) {
-                console.debug("#winprops", `setting ${metaWindow?.title} to focusOnOpen`);
-                metaWindow.focusOnOpen = true;
-            }
 
             overwriteSpace = winprop.spaceIndex;
             if (overwriteSpace !== undefined) {
@@ -4037,6 +4033,13 @@ export function insertWindow(metaWindow, options = {}) {
                     console.error("#winprops", `${overwriteSpace} is not a valid index. Ignoring.`);
                     overwriteSpace = undefined;
                 }
+                // save temporary as metaWindow property
+                metaWindow.overwriteSpace = overwriteSpace;
+            }
+
+            if (winprop.focus) {
+                console.debug("#winprops", `setting ${metaWindow?.title} to focusOnOpen`);
+                metaWindow.focusOnOpen = true;
             }
         }
 
@@ -4202,10 +4205,16 @@ Opening "${metaWindow?.title}" on current space.`);
 
     space.layout();
     animateWindow(metaWindow);
-    if (metaWindow.focusOnOpen) {
-        delete metaWindow.focusOnOpen;
-        console.debug("#winprops", "focusing space of inserted window");
-        spaces.spaceOfWindow(metaWindow)?.activateWithFocus(metaWindow, false, true);
+    if (metaWindow.overwriteSpace !== undefined) {
+        delete metaWindow.overwriteSpace;
+        if (!metaWindow.focusOnOpen) {
+            return;
+        }
+        else {
+            delete metaWindow.focusOnOpen;
+            console.debug("#winprops", "focusing space of inserted window");
+            spaces.spaceOfWindow(metaWindow)?.activateWithFocus(metaWindow, false, true);
+        }
     }
 
     if (metaWindow === display.focus_window) {

--- a/utils.js
+++ b/utils.js
@@ -363,7 +363,7 @@ export function printActorTree(node, fmt = mkFmt(), options = {}, state = null) 
         }
     }
     if (!collapse) {
-        console.log(Lib.indent(state.level, fmt(node, state.actorPrefix)));
+        console.debug(Lib.indent(state.level, fmt(node, state.actorPrefix)));
         state.actorPrefix = "";
         state.level += 1;
     }

--- a/winpropsPane.js
+++ b/winpropsPane.js
@@ -210,7 +210,7 @@ export const WinpropsRow = GObject.registerClass({
             this._space.append_text(`${i}: ${name}`);
         }
         // index 0 is CURRENT, so add 1
-        this._space.set_active((this.winprop.spaceIndex ?? -1) + 1)
+        this._space.set_active((this.winprop.spaceIndex ?? -1) + 1);
         this._space.connect('changed', () => {
             let value = this._space.get_active() - 1;
             if (value < 0) {
@@ -298,15 +298,16 @@ export const WinpropsRow = GObject.registerClass({
     }
 
     _setAccelLabel() {
-        let isScratch = this.winprop.scratch_layer ?? false;
-        let isPreferredWidth = this.winprop.preferredWidth || false;
-
-        if (isScratch) {
+        if (this.winprop.scratch_layer ?? false) {
             return 'scratch layer';
         }
-        else if (isPreferredWidth) {
+        else if (this.winprop.preferredWidth ?? false) {
             return 'preferred width';
-        } else {
+        }
+        else if (this.winprop.spaceIndex !== undefined) {
+            return 'workspace';
+        }
+        else {
             return 'no setting';
         }
     }

--- a/winpropsPane.js
+++ b/winpropsPane.js
@@ -101,6 +101,7 @@ export const WinpropsRow = GObject.registerClass({
         'title',
         'scratchLayer',
         'preferredWidth',
+        'space',
         'deleteButton',
     ],
     Properties: {
@@ -187,6 +188,20 @@ export const WinpropsRow = GObject.registerClass({
                 // having no preferredWidth is valid
                 this._setError(this._preferredWidth, false);
                 delete this.winprop.preferredWidth;
+                this.emit('changed');
+            }
+        });
+
+        // TODO make dropdown of workspace names
+        this._space.set_text(this.winprop.spaceIndex?.toString() ?? '');
+        this._space.connect('changed', () => {
+            let text = this._space.get_text();
+            let value = parseInt(text);
+            if (isNaN(value)) {
+                this._setError(this._space);
+            } else {
+                this._setError(this._space, false);
+                this.winprop.spaceIndex = value;
                 this.emit('changed');
             }
         });

--- a/winpropsPane.js
+++ b/winpropsPane.js
@@ -107,6 +107,7 @@ export const WinpropsRow = GObject.registerClass({
         'scratchLayer',
         'preferredWidth',
         'space',
+        'focus',
         'deleteButton',
     ],
     Properties: {
@@ -216,6 +217,13 @@ export const WinpropsRow = GObject.registerClass({
                 value = undefined;
             }
             this.winprop.spaceIndex = value;
+            this.emit('changed');
+        });
+
+        this._focus.set_active(this.winprop.focus ?? true);
+        this._focus.connect('state-set', () => {
+            let isActive = this._focus.get_active();
+            this.winprop.focus = isActive;
             this.emit('changed');
         });
 


### PR DESCRIPTION
Fixes #949

This adds a new winprop that allows selecting the space a new window should be inserted.

![Screenshot From 2024-09-24 12-00-30](https://github.com/user-attachments/assets/c3471885-f8e6-4b54-b4af-52002eb02ff8)

I added a dropdown to select the workspace. Not sure if that may cause problems with dynamic workspaces etc. Maybe the simple textbox was better. If so, we can simply revert the last commit.

Note: Sometimes it feels a bit confusing because you don't see anything happening if a window opens on another workspace. E.g. on firefox if you drag a tab out of the window to create a new window it is simply gone. But I think that is kind of expected for this. Maybe adding another option to automatically switch to the workspace and focus the window would be good.