### PR TITLE
Add test VM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ paperwm@paperwm.github.com.zip
 node_modules/
 package.json
 package-lock.json
+
+# generated disk image for test VM
+nixos.qcow2

--- a/README.md
+++ b/README.md
@@ -37,16 +37,32 @@ from the repository. The installer will create a link to the repo in
 >
 > After logging back in, you can then enable PaperWM via the `Extensions` application, or by running the following command from the command-line:
 >
-> ```bash
-> /usr/bin/gnome-extensions enable paperwm@paperwm.github.com
-> ```
+> `/usr/bin/gnome-extensions enable paperwm@paperwm.github.com`
+>
 
 > if you have run into issues, delete any older `paperwm@...` symlinks from `~/.local/share/gnome-shell/extensions` and re-run the `install.sh` script.
 
 #### Uninstall PaperWM (if installed via source)
+
 To uninstall simply run `./uninstall.sh`.
 
 Running the extension will automatically install a user config file as described in [User configuration & development](#user-configuration--development).
+
+
+### Try without installing
+
+This repo provides a lightweight VM based on [NixOS](https://nixos.org) to try PaperWM and aid with development. You can launch it if [Nix](https://nixos.org/nix) is installed on your system using this command:
+
+```sh
+nix run .\#vm
+```
+
+Alternatively, the VM can also be launched with GPU acceleration, by installing [NixGL](https://github.com/nix-community/nixgl) first:
+
+```sh
+nixGLIntel nix run .\#vm -- -device virtio-gpu-gl -display gtk,gl=on
+# or nixGLNvidia depending on your host GPU
+```
 
 ## Contributing
 Users are encouraged to submit [issues](https://github.com/paperwm/PaperWM/issues/new/choose) and [Pull Requests](https://github.com/paperwm/PaperWM/pulls)!

--- a/flake.lock
+++ b/flake.lock
@@ -19,11 +19,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1719492850,
-        "narHash": "sha256-koLuAz11nFcQ8DADmt15XEqEV8c1WcJ2S0JpSRTUxKo=",
+        "lastModified": 1736331163,
+        "narHash": "sha256-3mcSChVm6bWdYaTbUSHBpErhkVmfgJ39emO1TW+erjM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "69bee9866a4e2708b3153fdb61c1425e7857d6b8",
+        "rev": "e09d079fe4b202c1b7c1153b229f35ee83e81275",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -8,5 +8,18 @@
     let pkgs = import nixpkgs { inherit system; };
     in
     { packages.default = pkgs.callPackage ./default.nix {};
+      packages.vm = self.nixosConfigurations.testbox.config.system.build.vm;
+
+      nixosConfigurations."testbox" =
+        nixpkgs.lib.nixosSystem {
+          inherit system;
+          modules = [
+            ./vm.nix
+            { nixpkgs.overlays = [
+                (self: super: { paperwm = self.packages.${system}.default; })
+              ];
+            }
+          ];
+        };
     });
 }

--- a/vm.nix
+++ b/vm.nix
@@ -1,0 +1,47 @@
+{ pkgs, config, lib, ... }:
+
+{
+  ### Make PaperWM available in system environment
+  environment.systemPackages = with pkgs;
+  [ paperwm
+  ];
+
+  ### Set graphical session to auto-login GNOME
+  services.xserver =
+  { enable = true;
+    displayManager.autoLogin =
+    { enable = true;
+      user = "user";
+    };
+    desktopManager.gnome.enable = true;
+  };
+
+  ### Set dconf to enable PaperWM out of the box
+  programs.dconf =
+  { enable = true;
+    profiles."user".databases = [
+      { settings =
+        { "org/gnome/shell" =
+          { enabled-extensions = [ "paperwm@paperwm.github.com" ];
+          };
+        };
+      }
+    ];
+  };
+
+  ### Set default user
+  users.users."user" =
+  { isNormalUser = true;
+    createHome = true;
+    home = "/home";
+    description = "PaperWM test user";
+    extraGroups = [ "wheel" ];
+    password = "paperwm";
+  };
+
+  ### No-password sudo
+  security.sudo =
+  { enable = true;
+    extraConfig = "%wheel ALL=(ALL) NOPASSWD: ALL";
+  };
+}

--- a/vm.nix
+++ b/vm.nix
@@ -13,6 +13,7 @@
     { enable = true;
       user = "user";
     };
+    displayManager.gdm.enable = true;
     desktopManager.gnome.enable = true;
   };
 


### PR DESCRIPTION
So as I prepare to take up the role of maintainer for PaperWM, I got an idea: since #885 already gives us a Nix package for PaperWM, why not lean in completely and leverage Nix to create an ephemeral virtual machine, with just GNOME and PaperWM on it?

This gives me a way to quickly test changes to PaperWM, such as pull requests, without touching my existing configuration.

Ideally, this config can also be adapted to test combinations of PaperWM settings (see `programs.dconf =` in `vm.nix`), maybe automate testing too!


To test the VM in this branch, `nix run .#vm` should work.