### PR TITLE
GNOME 48 support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -19,11 +19,26 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741127929,
-        "narHash": "sha256-FGeFUa2kVyHos4HvwinUr4g0c7U/DCwNwFO6rmOaJtc=",
+        "lastModified": 1742683096,
+        "narHash": "sha256-NAJeQATypzZRofLwGRqDMVVII8GhbWjvLECCVj8v7QY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "68bd51e2efe09a19a61adc90f0e13507ba4ca884",
+        "rev": "1b86a608d746f7e88cdc4416d74b49b5a95d7689",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-gnome": {
+      "locked": {
+        "lastModified": 1742772691,
+        "narHash": "sha256-zp5dBRmFJ47Wqwo3jphPRfgBVL7gx+DJw0Ni9J/gFFc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ebe5e16c4ae36aa4230f1108ca4e35157fae6697",
         "type": "github"
       },
       "original": {
@@ -36,7 +51,8 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-gnome": "nixpkgs-gnome"
       }
     },
     "systems": {

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -19,15 +19,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1736331163,
-        "narHash": "sha256-3mcSChVm6bWdYaTbUSHBpErhkVmfgJ39emO1TW+erjM=",
+        "lastModified": 1741127929,
+        "narHash": "sha256-FGeFUa2kVyHos4HvwinUr4g0c7U/DCwNwFO6rmOaJtc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e09d079fe4b202c1b7c1153b229f35ee83e81275",
+        "rev": "68bd51e2efe09a19a61adc90f0e13507ba4ca884",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "gnome",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -36,11 +36,19 @@
 
                 # Pull GNOME-specific packages from GNOME staging
                 (s: super: {
-                  gnome         = pkgs-gnome.gnome;
                   gnome-desktop = pkgs-gnome.gnome-desktop;
-                  gnome-shell   = pkgs-gnome.gnome-shell;
-                  gnome-session = pkgs-gnome.gnome-session;
+                  gnome-shell   = pkgs-gnome.gnome-shell.override {
+                    evolution-data-server-gtk4 = super.evolution-data-server-gtk4.override {
+                      inherit (super) webkitgtk_4_1 webkitgtk_6_0;
+                    };
+                  };
+                  gnome-session = pkgs-gnome.gnome-session.override {
+                    inherit (s) gnome-shell;
+                  };
                   gnome-control-center = pkgs-gnome.gnome-control-center;
+                  gnome-initial-setup = pkgs-gnome.gnome-initial-setup.override {
+                    inherit (super) webkitgtk_6_0;
+                  };
                   gnome-settings-daemon = pkgs-gnome.gnome-settings-daemon;
                   mutter        = pkgs-gnome.mutter;
                   gdm           = pkgs-gnome.gdm;

--- a/flake.nix
+++ b/flake.nix
@@ -1,29 +1,52 @@
 { description = "Tiled, scrollable window management for GNOME Shell";
 
-  inputs."nixpkgs".url = github:NixOS/nixpkgs/gnome;
+  inputs."nixpkgs".url = github:NixOS/nixpkgs;
+  inputs."nixpkgs-gnome".url = github:NixOS/nixpkgs/gnome;
 
-  outputs = { self, nixpkgs, flake-utils, ... }:
+  outputs = { self, nixpkgs, nixpkgs-gnome, flake-utils, ... }:
   flake-utils.lib.eachDefaultSystem
     (system:
-    let pkgs = import nixpkgs { inherit system; };
+    let hostPkgs = import nixpkgs { inherit system; };
     in
-    { packages.default = pkgs.callPackage ./default.nix {};
-      packages.vm = let hostConfig = self.nixosConfigurations.testbox.config;
-                        localConfig = hostConfig // {
-                          virtualisation = hostConfig.virtualisation // {
-                            host.pkgs = pkgs;   # Use host system's Qemu
-                          };
+    { packages.default = hostPkgs.callPackage ./default.nix {};
+
+      # This allows us to build Qemu for the host system thus avoiding
+      # double emulation.
+      packages.vm = let hostConfig = self.nixosConfigurations.testbox;
+                        localConfig = hostConfig.extendModules {
+                          modules = [
+                            ({ modulesPath, ... }: {
+                              imports = [ "${modulesPath}/virtualisation/qemu-vm.nix" ];
+                              virtualisation.host.pkgs = hostPkgs;
+                            })
+                          ];
                         };
-                     in localConfig.system.build.vm;
+                     in localConfig.config.system.build.vm;
     }) // {
       nixosConfigurations."testbox" =
         let system = "x86_64-linux";
+            pkgs-gnome = import nixpkgs-gnome { inherit system; };
         in nixpkgs.lib.nixosSystem {
           inherit system;
           modules = [
             ./vm.nix
             { nixpkgs.overlays = [
+                # Introduce PaperWM into our extensions
                 (s: super: { paperwm = self.packages.${system}.default; })
+
+                # Pull GNOME-specific packages from GNOME staging
+                (s: super: {
+                  gnome         = pkgs-gnome.gnome;
+                  gnome-desktop = pkgs-gnome.gnome-desktop;
+                  gnome-shell   = pkgs-gnome.gnome-shell;
+                  gnome-session = pkgs-gnome.gnome-session;
+                  gnome-control-center = pkgs-gnome.gnome-control-center;
+                  gnome-settings-daemon = pkgs-gnome.gnome-settings-daemon;
+                  mutter        = pkgs-gnome.mutter;
+                  gdm           = pkgs-gnome.gdm;
+                  xdg-desktop-portal-gnome = pkgs-gnome.xdg-desktop-portal-gnome;
+                  xdg-desktop-portal-gtk = pkgs-gnome.xdg-desktop-portal-gtk;
+                })
               ];
             }
           ];

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 { description = "Tiled, scrollable window management for GNOME Shell";
 
-  inputs."nixpkgs".url = github:NixOS/nixpkgs;
+  inputs."nixpkgs".url = github:NixOS/nixpkgs/gnome;
 
   outputs = { self, nixpkgs, flake-utils, ... }:
   flake-utils.lib.eachDefaultSystem

--- a/grab.js
+++ b/grab.js
@@ -66,7 +66,10 @@ export class MoveGrab {
 
         grabbed = true;
         global.display.end_grab_op?.(global.get_current_time());
-        global.display.set_cursor(Meta.Cursor.MOVE_OR_RESIZE_WINDOW);
+        if (Utils.version[0] >= 48)
+            global.display.set_cursor(Meta.Cursor.GRABBING);
+        else
+            global.display.set_cursor(Meta.Cursor.MOVE_OR_RESIZE_WINDOW);
         this.dispatcher = new Navigator.getActionDispatcher(Clutter.GrabState.POINTER);
         this.actor = this.dispatcher.actor;
 
@@ -131,7 +134,10 @@ export class MoveGrab {
         console.debug("#grab", "begin DnD");
         Navigator.getNavigator().minimaps.forEach(m => typeof m === 'number'
             ? Utils.timeout_remove(m) : m.hide());
-        global.display.set_cursor(Meta.Cursor.MOVE_OR_RESIZE_WINDOW);
+        if (Utils.version[0] >= 48)
+            global.display.set_cursor(Meta.Cursor.GRABBING);
+        else
+            global.display.set_cursor(Meta.Cursor.MOVE_OR_RESIZE_WINDOW);
         let metaWindow = this.window;
         let clone = metaWindow.clone;
         let space = this.initialSpace;

--- a/keybindings.js
+++ b/keybindings.js
@@ -365,7 +365,11 @@ export function byId(mutterId) {
 }
 
 export function asKeyHandler(actionHandler) {
-    return (display, mw, binding) => actionHandler(mw, Tiling.spaces.selectedSpace, { display, binding });
+    if (Utils.version[0] >= 48) {
+        return (display, mw, evt, binding) => actionHandler(mw, Tiling.spaces.selectedSpace, { display, binding });
+    } else {
+        return (display, mw, binding) => actionHandler(mw, Tiling.spaces.selectedSpace, { display, binding });
+    }
 }
 
 export function impliedOptions(options) {

--- a/metadata.json
+++ b/metadata.json
@@ -4,6 +4,6 @@
   "description": "Tiling window manager with a twist",
   "url": "https://github.com/paperwm/PaperWM",
   "settings-schema": "org.gnome.shell.extensions.paperwm",
-  "shell-version": [ "45", "46", "47" ],
-  "version-name": "47.1.0"
+  "shell-version": [ "45", "46", "47", "48" ],
+  "version-name": "48.0.0"
 }

--- a/topbar.js
+++ b/topbar.js
@@ -72,9 +72,10 @@ export function enable (extension) {
     Main.panel.addToStatusArea('FocusButton', focusButton, 2, 'left');
     Main.panel.addToStatusArea('OpenPositionButton', openPositionButton, 3, 'left');
 
+    /* This causes a crash on GNOME 48
     Tiling.spaces.forEach(s => {
         s.workspaceLabel.clutter_text.set_font_description(menu.label.clutter_text.font_description);
-    });
+    });*/
 
     fixWorkspaceIndicator();
     fixFocusModeIcon();

--- a/vm.nix
+++ b/vm.nix
@@ -25,6 +25,7 @@
       { settings =
         { "org/gnome/shell" =
           { enabled-extensions = [ "paperwm@paperwm.github.com" ];
+            disable-user-extensions = false;
           };
         };
         #NOTE: You can add more dconf settings to test with here!

--- a/vm.nix
+++ b/vm.nix
@@ -27,9 +27,14 @@
           { enabled-extensions = [ "paperwm@paperwm.github.com" ];
           };
         };
+        #NOTE: You can add more dconf settings to test with here!
       }
     ];
   };
+
+  ### Remove unnecessary dependencies
+  #NOTE: This drops many GTK4 apps, re-enable if needed for testing.
+  services.gnome.core-utilities.enable = false;
 
   ### Set default user
   users.users."user" =

--- a/vm.nix
+++ b/vm.nix
@@ -4,6 +4,7 @@
   ### Make PaperWM available in system environment
   environment.systemPackages = with pkgs;
   [ paperwm
+    (lib.getBin libinput)
   ];
 
   ### Set graphical session to auto-login GNOME


### PR DESCRIPTION
This fixes #1002 by restoring PaperWM functionality on the latest GNOME 48.

Contributions are welcome!
