### PR TITLE
Changed touch detection for Workspace button

### DIFF
--- a/topbar.js
+++ b/topbar.js
@@ -789,7 +789,7 @@ export const WorkspaceMenu = GObject.registerClass(
 
             let type = event.type();
 
-            if (type === Clutter.EventType.TOUCH_END ||
+            if (type === Clutter.EventType.TOUCH_BEGIN ||
                 type === Clutter.EventType.BUTTON_RELEASE) {
                 if (Navigator.navigating) {
                     Navigator.getNavigator().finish();


### PR DESCRIPTION
This fixes #992 by triggering the button action at the _start_ of the touch event, rather than at the _end_.

@ShamrockLee please test
