### PR TITLE
Fix tiling break on chromium tab move

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -541,7 +541,7 @@ export class Space extends Array {
 
         const k = column.indexOf(grabWindow);
         if (k < 0) {
-            throw new Error(`Anchor doesn't exist in column ${grabWindow.title}`);
+            throw new Error(`Anchor doesn't exist in column ${grabWindow ? grabWindow.title : "unknown"}`);
         }
 
         const gap = Settings.prefs.window_gap;
@@ -741,7 +741,7 @@ export class Space extends Array {
 
             let resultingWidth, relayout;
             let allocator = allocators && allocators[i];
-            if (inGrab && column.includes(inGrab.window) && !allocator) {
+            if (inGrab && selectedInColumn && column.includes(inGrab.window) && !allocator) {
                 [resultingWidth, relayout] =
                     this.layoutGrabColumn(column, x, y0, targetWidth, availableHeight, time,
                         selectedInColumn);

--- a/vm.nix
+++ b/vm.nix
@@ -5,6 +5,7 @@
   environment.systemPackages = with pkgs;
   [ paperwm
     (lib.getBin libinput)
+    chromium
   ];
 
   ### Set graphical session to auto-login GNOME
@@ -32,6 +33,15 @@
       }
     ];
   };
+
+  #imports = [ <nixpkgs/nixos/modules/virtualisation/qemu-vm.nix> ];
+  #virtualisation.qemu.options = [
+  #  "-device qxl"
+  #];
+  services.xserver.videoDrivers = [ "qxl" ];
+  virtualisation.qemu.options = [ "-vga qxl" ];
+  virtualisation.memorySize = 8192;
+  virtualisation.cores = 8;
 
   ### Remove unnecessary dependencies
   #NOTE: This drops many GTK4 apps, re-enable if needed for testing.


### PR DESCRIPTION
When a chromium tab is moved, the code is grabbing a window (inGrab is true), but the window is new (selectedInColumn is null). Use the code path for new windows instead.

This prevents the following backtrace:

    JS ERROR: TypeError: grabWindow is null
    layoutGrabColumn@file:///home/user/.local/share/gnome-shell/extensions/paperwm@paperwm.github.com/tiling.js:544:63
    layout@file:///home/user/.local/share/gnome-shell/extensions/paperwm@paperwm.github.com/tiling.js:746:26
    insertWindow@file:///home/user/.local/share/gnome-shell/extensions/paperwm@paperwm.github.com/tiling.js:4147:11
    window_created/<@file:///home/user/.local/share/gnome-shell/extensions/paperwm@paperwm.github.com/tiling.js:3340:25
    connectOneShot/id<@file:///home/user/.local/share/gnome-shell/extensions/paperwm@paperwm.github.com/utils.js:522:20
    @resource:///org/gnome/shell/ui/init.js:21:20

Closes #1016