### PR TITLE
Fail gracefully instead of crashing if grab fails with the error "Could not grab modal"

### DIFF
--- a/navigator.js
+++ b/navigator.js
@@ -82,10 +82,21 @@ class ActionDispatcher {
 
         // grab = stage.grab(this.actor)
         grab = Main.pushModal(this.actor);
+		// Assume that grab succeeds and store that state in the object
+		this.success = true;
         // We expect at least a keyboard grab here
         if ((grab.get_seat_state() & Clutter.GrabState.KEYBOARD) === 0) {
             console.error("Failed to grab modal");
-            throw new Error('Could not grab modal');
+			// Release current grab and let the user try again
+			try {
+				this.success = false;
+				if (grab) {
+					Main.popModal(grab);
+					grab = null;
+				}
+			} catch (e) {
+				console.error("Failed to release grab");
+			}
         }
 
         this.signals.connect(this.actor, 'key-press-event', this._keyPressEvent.bind(this));
@@ -117,6 +128,9 @@ class ActionDispatcher {
     }
 
     show(_backward, binding, mask) {
+		// If required grab was not successful, then do not show anything
+		if (!this.success) return;
+
         this._modifierMask = primaryModifier(mask);
         this.navigator = getNavigator();
         Topbar.fixTopBar();
@@ -519,11 +533,11 @@ export function getActionDispatcher(mode) {
         return dispatcher;
     }
     dispatcher = new ActionDispatcher();
-    return getActionDispatcher(mode);
+	return getActionDispatcher(mode);
 }
 
 /**
- * Fishes current dispatcher (if any).
+ * Finishes current dispatcher (if any).
  */
 export function finishDispatching() {
     dispatcher?._finish(global.get_current_time());
@@ -546,5 +560,14 @@ export function dismissDispatcher(mode) {
 
 export function preview_navigate(meta_window, space, { _display, _screen, binding }) {
     let tabPopup = getActionDispatcher(Clutter.GrabState.KEYBOARD);
-    tabPopup.show(binding.is_reversed(), binding.get_name(), binding.get_mask());
+
+	// Getting a dispatcher does not always succeed. Sometimes, it can fail because we are unable to
+	// grab the keyboard.
+	// In the case of a failure, fail gracefully by destroying the pop-up.
+	if (!tabPopup.success) {
+		tabPopup.destroy();
+		return;
+	}
+
+	tabPopup.show(binding.is_reversed(), binding.get_name(), binding.get_mask());
 }


### PR DESCRIPTION
I have been using PaperWM on a daily basis for the past few months and it is great. One of the problems that I kept running into repeatedly was https://github.com/paperwm/PaperWM/issues/991. This issue was reported on Gnome 47. I ran into this problem on Gnome 42.9.

I attempted a naive fix which simply tries to clean-up all the state instead of crashing. This works well; I have been using a version of this fix, applied on top of the gnome-44 branch, for the past month and I have not suffered any `Could not grab modal` crashes. I have backported this change to the `gnome-44` branch as well: https://github.com/paperwm/PaperWM/pull/1032.

It would be great if I could get some guidance about whether this fix looks logical, and whether there might be a way to reproduce this code path somehow. We need to somehow get into `preview_navigate` (which happens when one uses a keyboard shortcut to switch windows, I believe?) but get there in a state where the keyboard is already grabbed by something else, thus causing PaperWM to fail to grab the keyboard. 

Meanwhile, I will continue to use PaperWM daily on two machines (albeit with old Gnome versions: 3.38 and 42.9) I will attempt to get PaperWM up and running on a more recent version and check to see if I run into this crash on the default branch; if I do, then, I will also see whether this fix solves the crash.

I would really like to fix this issue within PaperWM (upstream) because I have not run into any other bug at all and this is a great project!