### PR TITLE
(Backport to Gnome 44) Fail gracefully instead of crashing if grab fails with the error "Could not grab modal"

### DIFF
--- a/navigator.js
+++ b/navigator.js
@@ -87,10 +87,21 @@ class ActionDispatcher {
 
         // grab = stage.grab(this.actor)
         grab = Main.pushModal(this.actor);
+		// Assume that grab succeeds and store that state in the object
+		this.success = true;
         // We expect at least a keyboard grab here
         if ((grab.get_seat_state() & Clutter.GrabState.KEYBOARD) === 0) {
             console.error("Failed to grab modal");
-            throw new Error('Could not grab modal');
+			// Release current grab and let the user try again
+			try {
+				this.success = false;
+				if (grab) {
+					Main.popModal(grab);
+					grab = null;
+				}
+			} catch (e) {
+				console.error("Failed to release grab");
+			}
         }
 
         this.signals.connect(this.actor, 'key-press-event', this._keyPressEvent.bind(this));
@@ -101,6 +112,9 @@ class ActionDispatcher {
     }
 
     show(backward, binding, mask) {
+		// If required grab was not successful, then do not show anything
+		if (!this.success) return;
+
         this._modifierMask = getModLock(mask);
         this.navigator = getNavigator();
         TopBar.fixTopBar();
@@ -446,11 +460,11 @@ function getActionDispatcher(mode) {
         return dispatcher;
     }
     dispatcher = new ActionDispatcher();
-    return getActionDispatcher(mode);
+	return getActionDispatcher(mode);
 }
 
 /**
- * Fishes current dispatcher (if any).
+ * Finishes current dispatcher (if any).
  */
 function finishDispatching() {
     dispatcher?._finish(global.get_current_time());
@@ -473,5 +487,14 @@ function dismissDispatcher(mode) {
 
 function preview_navigate(meta_window, space, { display, screen, binding }) {
     let tabPopup = getActionDispatcher(Clutter.GrabState.KEYBOARD);
-    tabPopup.show(binding.is_reversed(), binding.get_name(), binding.get_mask());
+
+	// Getting a dispatcher does not always succeed. Sometimes, it can fail because we are unable to
+	// grab the keyboard.
+	// In the case of a failure, fail gracefully by destroying the pop-up.
+	if (!tabPopup.success) {
+		tabPopup.destroy();
+		return;
+	}
+
+	tabPopup.show(binding.is_reversed(), binding.get_name(), binding.get_mask());
 }


### PR DESCRIPTION
Related to #991. This is backport of the PR to the PaperWM extension version targeting Gnome 44. The PR to the `develop` branch is https://github.com/paperwm/PaperWM/pull/1031. Please see that PR for more details.
