### PR TITLE
Always propagate vertical gestures if disabled

### DIFF
--- a/gestures.js
+++ b/gestures.js
@@ -113,6 +113,13 @@ export function enable(extension) {
                     return Clutter.EVENT_PROPAGATE;
                 }
 
+                // if our vertical gesture is disabled, propagate always!
+                // (might be used for a vertical-workspaces addon)
+                if (gestureWorkspaceFingers() === 0) {
+                    swipeTrackersEnable();
+                    return Clutter.EVENT_PROPAGATE;
+                }
+
                 let dir_y = -dy * natural * Settings.prefs.swipe_sensitivity[1];
                 // if not Tiling.inPreview and swipe is UP => propagate event to overview
                 if (!Tiling.inPreview && dir_y > 0) {


### PR DESCRIPTION
Do not block [V-Shell (vertical-workspaces)](https://github.com/G-dH/vertical-workspaces) from handling the down swipe.

With the combo of the two extensions, we're a lot closer to a niri-like experience: 

https://github.com/user-attachments/assets/3283ccfa-4b59-4e00-81bd-24ad259a0340

It's not perfect, e.g. the newly horizontalized overview gesture can still be triggered sometimes accidentally instead of the window scrolling (reproducibly: immediately after letting go of the workspace switcher), but it's a start.