### PR TITLE
(Backport to Gnome 44) Fix createBackground, updateBackground crash when `monitor` doesn't exist

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -1201,6 +1201,10 @@ border-radius: ${borderWidth}px;
     }
 
     updateBackground() {
+        if (!this.monitor) {
+            return;
+        }
+
         let path = this.settings.get_string('background') || Settings.prefs.default_background;
         let useDefault = gsettings.get_boolean('use-default-background');
         if (!path && useDefault) {
@@ -1455,12 +1459,16 @@ border-radius: ${borderWidth}px;
     }
 
     createBackground() {
+        const monitor = this.monitor;
+        if (!monitor) {
+            return;
+        }
+
         if (this.background) {
             this.signals.disconnect(this.background);
             this.background.destroy();
         }
 
-        let monitor = this.monitor;
 
         this.background = new Meta.BackgroundActor(
             Object.assign({
@@ -1525,6 +1533,11 @@ border-radius: ${borderWidth}px;
 
     setMonitor(monitor, animate = false, options = {}) {
         const commit = options?.commit ?? true;
+
+        // check monitor exists
+        if (!monitor) {
+            return;
+        }
 
         // Remake the background when we move monitors. The size/scale will be
         // incorrect when using fractional scaling.


### PR DESCRIPTION
Partial cherry-pick of  c2c187d (#894). Fixes cases like (#356).

This PR gracefully addresses the case where a `monitor` doesn't exist during PaperWM enabling.