### PR TITLE
fix: proper background for 'prefer-light' color-scheme

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -1671,10 +1671,10 @@ border-radius: ${borderWidth}px;
         let path = this.settings.get_string('background') || Settings.prefs.default_background;
         let useDefault = gsettings.get_boolean('use-default-background');
         if (!path && useDefault) {
-            if (interfaceSettings.get_string("color-scheme") === "default") {
-                path = backgroundSettings.get_string("picture-uri");
-            } else {
+            if (interfaceSettings.get_string("color-scheme") === "prefer-dark") {
                 path = backgroundSettings.get_string("picture-uri-dark");
+            } else {
+                path = backgroundSettings.get_string("picture-uri");
             }
         }
 


### PR DESCRIPTION
Previous logic for handling which picture uri to use based on the system theme were only checking for 'default' and fallbaking to dark in all other cases. That caused a bug, where if system is in 'prefer-light', it would render wallpaper for dark theme(picture-uri-dark).

This PR fixes it.