### PR TITLE
fix: add delay before activateWithFocus call

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -4218,7 +4218,9 @@ Opening "${metaWindow?.title}" on current space.`);
         else {
             delete metaWindow.focusOnOpen;
             console.debug("#winprops", "focusing space of inserted window");
-            spaces.spaceOfWindow(metaWindow)?.activateWithFocus(metaWindow, false, true);
+            Utils.later_add(Meta.LaterType.IDLE, () => {
+                spaces.spaceOfWindow(metaWindow)?.activateWithFocus(metaWindow, false, true);
+            });
         }
     }
 


### PR DESCRIPTION
**Bug**
Having Winprop that:
1. Should insert window to specific workspace.
2. Should focus window as its created.
causes Gnome Shell crash when currently active workspace is different from workspace in which window was inserted.

**Fix**
This PR fixes it, buy adding delay before trying to activate window.