### PR TITLE
Specify that SHELL is bash, since bashisms (`[[ COND ]]`) are used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ else
 GNOME_EXT_DISABLE := gnome-shell-extension-tool --disable
 endif
 
+SHELL=/bin/bash
+
 ## Update compiled files
 all: $(RELEASE_FILES)
 

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ uninstall:
 	@if [[ `readlink -f $(TARGET)` != `readlink -f $$PWD` ]]; \
 	then                                                   \
 		echo "'$(TARGET)' does not link to '$$PWD', refusing to remove."; \
-		exit 1                                             \
+		exit 1;                                             \
 	fi
 	@if [ -L $(TARGET) ];                                     \
 	then                                                   \
@@ -79,7 +79,7 @@ uninstall:
 	else                                                   \
 		read -p "Remove $(TARGET)? (y/N): " -n 1 -r           \
 		echo                                               \
-		[[ $$REPLY =~ ^[Yy]$ ]] && rm -rf $(TARGET)           \
+		[[ $$REPLY =~ ^[Yy]$ ]] && rm -rf $(TARGET);       \
 	fi
 
 


### PR DESCRIPTION
Without the fix, on the system with POSIX compliant /bin/sh (dash etc) you could get

    ❯ make install
    /bin/sh: 1: [[: not found
    MKDIR	/home/yoh/.local/share/gnome-shell/extensions
    LINK	paperwm@paperwm.github.com

    INSTALL SUCCESSFUL:

    If this is the first time installing PaperWM, then please logout/login
    and enable the PaperWM extension, either with the GNOME Extensions application,
    or manually by executing the following command from a terminal:

    gnome-extensions enable paperwm@paperwm.github.com

after a fix 

```
❯ make install

INSTALL FAILED:

A previous (non-symlinked) installation of PaperWM already exists at:
'/home/yoh/.local/share/gnome-shell/extensions/paperwm@paperwm.github.com'.

Please remove the installed version from that path and re-run this install script.

make: *** [Makefile:40: install] Error 1
```

and I think I will follow up with an additional fix now for using `-e` so those fail overall whenever first error happens instead of keeping plowing through! ...

<details>
<summary>actually such patch didn't work as it kept plowing through after the error</summary> 

```shell
diff --git a/Makefile b/Makefile
index e51dde7..441e78e 100644
--- a/Makefile
+++ b/Makefile
@@ -30,14 +30,14 @@ else
 GNOME_EXT_DISABLE := gnome-shell-extension-tool --disable
 endif
 
-SHELL=/bin/bash
+SHELL=/bin/bash -e
 
 ## Update compiled files
 all: $(RELEASE_FILES)
 
 ## Install PaperWM on this system
 install: schemas/gschemas.compiled
-	@if [[ ! -L "$(TARGET)" && -d "$(TARGET)" ]]; \
+	@if [[[ ! -L "$(TARGET)" && -d "$(TARGET)" ]]; \
 	then                                    \
 		echo;                               \
 		echo "INSTALL FAILED:";             \
```

```
❯ make install
/bin/bash: line 1: [[[: command not found
MKDIR	/home/yoh/.local/share/gnome-shell/extensions
LINK	paperwm@paperwm.github.com

INSTALL SUCCESSFUL:

If this is the first time installing PaperWM, then please logout/login
and enable the PaperWM extension, either with the GNOME Extensions application,
or manually by executing the following command from a terminal:

gnome-extensions enable paperwm@paperwm.github.com

changes on filesystem:                                                                                                                                                                                                            
 Makefile | 4 ++--
```

</details>

so might be better to just make them proper outside bash scripts and invoke here ... will not do in this PR