### PR TITLE
Add shellcheck support and some fixes to make shell scripts "cleaner"

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,26 @@
+---
+name: Shellcheck
+
+on:
+  push:
+    branches: [release]
+  pull_request:
+    branches: [release]
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    name: Check shell scripts
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt update && sudo apt install -y shellcheck
+      - name: shellcheck
+        run: |
+          git grep -l '^#\( *shellcheck \|!\(/bin/\|/usr/bin/env \)\(sh\|bash\|dash\|ksh\)\)' | xargs shellcheck

--- a/gather-system-info.sh
+++ b/gather-system-info.sh
@@ -11,7 +11,7 @@
 REPO="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 main() {
-    cd "${REPO}"
+    cd "${REPO}" || exit
 
     echo "Please include this information in your bug report on GitHub!"
 

--- a/gather-system-info.sh
+++ b/gather-system-info.sh
@@ -25,6 +25,7 @@ main() {
 show_distribution() {
     echo -n "Distribution: "
     if [ -f /etc/os-release ]; then
+        # shellcheck disable=SC1091
         source /etc/os-release && echo "${NAME}"
     fi
 }

--- a/shell.sh
+++ b/shell.sh
@@ -20,9 +20,9 @@ args=()
 
 DISPLAY=$NEW_DISPLAY
 eval $(dbus-launch --exit-with-session --sh-syntax)
-echo $DBUS_SESSION_BUS_ADDRESS
+echo "$DBUS_SESSION_BUS_ADDRESS"
 
-echo -n $DBUS_SESSION_BUS_ADDRESS \
+echo -n "$DBUS_SESSION_BUS_ADDRESS" \
     | DISPLAY=$old_display xclip -i -selection clipboard
 
 DISPLAY=$old_display
@@ -43,5 +43,5 @@ esac
 dconf reset -f /  # Reset settings
 dconf write /org/gnome/shell/enabled-extensions "['paperwm@paperwm.github.com']"
 
-gnome-shell $args
+gnome-shell "$args"
 

--- a/shell.sh
+++ b/shell.sh
@@ -19,7 +19,7 @@ export XDG_CONFIG_HOME=$HOME/paperwm/.config
 args=()
 
 DISPLAY=$NEW_DISPLAY
-eval $(dbus-launch --exit-with-session --sh-syntax)
+eval "$(dbus-launch --exit-with-session --sh-syntax)"
 echo "$DBUS_SESSION_BUS_ADDRESS"
 
 echo -n "$DBUS_SESSION_BUS_ADDRESS" \
@@ -35,7 +35,7 @@ case $1 in
         echo "Running X11 Gnome Shell"
         Xephyr $NEW_DISPLAY &
         DISPLAY=$NEW_DISPLAY
-        args=--x11
+        args=(--x11)
         ;;
 esac
 
@@ -43,5 +43,5 @@ esac
 dconf reset -f /  # Reset settings
 dconf write /org/gnome/shell/enabled-extensions "['paperwm@paperwm.github.com']"
 
-gnome-shell "$args"
+gnome-shell "${args[@]}"
 


### PR DESCRIPTION
More info is at https://www.shellcheck.net about shellcheck

Note that the last commit was done mostly by `claude code` but upon my review should be kosher.

In view of potential desire for moving some logic from Makefile (see #1073 ) into external scripts, might especially be nice to ensure that shell scripts code is more robust