### PR TITLE
Global switch windows - move to **visually** closest window

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -1219,6 +1219,10 @@ export class Space extends Array {
                 return;
             }
 
+            // Ensure if we change workspaces and then monitors,
+            // that the new workspace stays active on the starting monitor.
+            space.activateWithFocus(space.selectedWindow, false, true);
+
             let newMonitor = Main.layoutManager.monitors[i];
             space = spaces.monitors.get(newMonitor);
             if (dir === Meta.DisplayDirection.LEFT) {

--- a/tiling.js
+++ b/tiling.js
@@ -1190,6 +1190,14 @@ export class Space extends Array {
     switchGlobalUp() { this.switchGlobal(Meta.MotionDirection.UP); }
     switchGlobalDown() { this.switchGlobal(Meta.MotionDirection.DOWN); }
     switchGlobal(direction) {
+        const motionToDisplayDirection = {
+            [Meta.MotionDirection.LEFT]: Meta.DisplayDirection.LEFT,
+            [Meta.MotionDirection.RIGHT]: Meta.DisplayDirection.RIGHT,
+            [Meta.MotionDirection.UP]: Meta.DisplayDirection.UP,
+            [Meta.MotionDirection.DOWN]: Meta.DisplayDirection.DOWN,
+        };
+        const dir = motionToDisplayDirection[direction]
+
         let space = this;
         let index = space.selectedIndex();
         if (index === -1) {
@@ -1206,8 +1214,6 @@ export class Space extends Array {
         }
         if (index < 0 || index >= space.length) {
             let monitor = focusMonitor();
-            let dir = index < 0
-                ? Meta.DisplayDirection.LEFT : Meta.DisplayDirection.RIGHT;
             let i = display.get_monitor_neighbor_index(monitor.index, dir);
             if (i === -1) {
                 return;
@@ -1238,8 +1244,6 @@ export class Space extends Array {
         }
         if (row < 0 || row >= column.length) {
             let monitor = focusMonitor();
-            let dir = row < 0
-                ? Meta.DisplayDirection.UP : Meta.DisplayDirection.DOWN;
             let i = display.get_monitor_neighbor_index(monitor.index, dir);
             if (i === -1) {
                 return;

--- a/tiling.js
+++ b/tiling.js
@@ -1208,8 +1208,9 @@ export class Space extends Array {
             let dir = index < 0
                 ? Meta.DisplayDirection.LEFT : Meta.DisplayDirection.RIGHT;
             let i = display.get_monitor_neighbor_index(monitor.index, dir);
-            if (i === -1)
+            if (i === -1) {
                 return;
+            }
 
             let newMonitor = Main.layoutManager.monitors[i];
             space = spaces.monitors.get(newMonitor);
@@ -1241,8 +1242,9 @@ export class Space extends Array {
             let dir = row < 0
                 ? Meta.DisplayDirection.UP : Meta.DisplayDirection.DOWN;
             let i = display.get_monitor_neighbor_index(monitor.index, dir);
-            if (i === -1)
+            if (i === -1) {
                 return;
+            }
 
             let newMonitor = Main.layoutManager.monitors[i];
             space = spaces.monitors.get(newMonitor);

--- a/tiling.js
+++ b/tiling.js
@@ -828,17 +828,18 @@ export class Space extends Array {
 
     // Space.prototype.isVisible = function
     isVisible(metaWindow, margin = 0) {
-        let clone = metaWindow.clone;
-        let x = clone.x + this.cloneContainer.x;
-        let workArea = this.workArea();
-        let min = workArea.x;
+        const clone = metaWindow.clone;
+        const left = clone.x + this.cloneContainer.x;
+        const right = left + clone.width;
 
-        if (x - margin + clone.width < min ||
-            x + margin > min + workArea.width) {
-            return false;
-        } else {
-            return true;
-        }
+        const workArea = this.workArea();
+        const areaLeft = workArea.x;
+        const areaRight = areaLeft + workArea.width;
+
+        const isOffscreenLeft = right < areaLeft + margin;
+        const isOffscreenRight = left > areaRight - margin;
+
+        return !isOffscreenLeft && !isOffscreenRight;
     }
 
     isFullyVisible(metaWindow) {
@@ -1219,16 +1220,14 @@ export class Space extends Array {
             } else {
                 index = 0;
             }
-            if (space[index].length <= row)
-                row = space[index].length - 1;
+            row = Math.min(row, space[index].length - 1)
             space.activate(false, false);
             Navigator.finishNavigation();
             Navigator.getNavigator().showMinimap(space);
         }
 
         let column = space[index];
-        if (column.length <= row)
-            row = column.length - 1;
+        row = Math.min(row, column.length - 1)
 
         switch (direction) {
         case Meta.MotionDirection.UP:
@@ -1248,8 +1247,7 @@ export class Space extends Array {
 
             let newMonitor = Main.layoutManager.monitors[i];
             space = spaces.monitors.get(newMonitor);
-            if (space.length <= index)
-                index = space.length - 1;
+            index = Math.min(index, space.length - 1)
             if (dir === Meta.DisplayDirection.UP) {
                 row = space[index].length - 1;
             } else {

--- a/tiling.js
+++ b/tiling.js
@@ -1213,8 +1213,8 @@ export class Space extends Array {
             index--;
         }
         if (index < 0 || index >= space.length) {
-            let monitor = focusMonitor();
-            let i = display.get_monitor_neighbor_index(monitor.index, dir);
+            const monitor = focusMonitor();
+            const i = display.get_monitor_neighbor_index(monitor.index, dir);
             if (i === -1) {
                 return;
             }
@@ -1223,17 +1223,24 @@ export class Space extends Array {
             // that the new workspace stays active on the starting monitor.
             space.activateWithFocus(space.selectedWindow, false, true);
 
-            let newMonitor = Main.layoutManager.monitors[i];
-            space = spaces.monitors.get(newMonitor);
-            if (dir === Meta.DisplayDirection.LEFT) {
-                index = space.length - 1;
-            } else {
-                index = 0;
+            const newMonitor = Main.layoutManager.monitors[i];
+            const newSpace = spaces.monitors.get(newMonitor);
+            const visibleColumns = newSpace.filter((column) => newSpace.isVisible(column[0]));
+            if (visibleColumns.length === 0) {
+                return;
             }
-            row = Math.min(row, space[index].length - 1)
-            space.activate(false, false);
+
+            const newColumn = dir === Meta.DisplayDirection.LEFT
+                ? visibleColumns[visibleColumns.length - 1]
+                : visibleColumns[0];
+            const newRow = Math.min(row, newColumn.length - 1);
+            const newWindow = newColumn[newRow];
+
+            newSpace.activate(false, false);
             Navigator.finishNavigation();
-            Navigator.getNavigator().showMinimap(space);
+            Navigator.getNavigator().showMinimap(newSpace);
+            ensureViewport(newWindow, newSpace);
+            return
         }
 
         let column = space[index];
@@ -1264,6 +1271,7 @@ export class Space extends Array {
             space.activate(false, false);
             Navigator.finishNavigation();
             Navigator.getNavigator().showMinimap(space);
+            return
         }
 
         let metaWindow = space.getWindow(index, row);


### PR DESCRIPTION
## Overview

I use paperWM with multiple monitors, but have always struggled with the hotkeys for movement. I've memorized them out of necessity, but…

<details><summary>…let's be honest, they make no sense.</summary>
<p>

- `<Super>` with `Left` and `Right` arrows, or `comma`/`period`, are the hotkeys for switching windows. Ok.
- Add either `Shift` or `Ctrl` to comma/period to drag the window instead. Great.
- For arrows, `Ctrl` works the same way, but shift suddenly moves the focus between monitors. ???
- Okay so to move the current window to a different monitor, now I use `<Super><Ctrl><Shift>Left`. That's a lot of keys but I guess once I understand that `<Shift>Left` is moving monitors then adding control grabs the window.
- `<Ctrl><Alt>Left` moves the entire workspace. Why does a less common, larger action, require fewer modifiers than moving just one window? Why doesn't it use `<Meta>` like all other PaperWM "Window manager" hotkeys?

I can go on, but I think my point is made.

</p>
</details>

Recently I saw the new actions added in https://github.com/paperwm/PaperWM/pull/775, and it was a serious :bulb: :exploding_head: revelation for me. _Obviously_ this is how PaperWM is _supposed_ to work. If you are switching left and you reach the end of one monitor, the same hotkey just _keeps going left_.

Well, kinda. There were a few things missing, which I have added in three separate PRs:

1. #1076 « :pushpin: YOU ARE HERE
2. #1081
3. #1082

## This PR

Intuitively, I expected that "keep going left" would focus the window that I already see active when looking at the monitor to the left. If I'm only using the keyboard it works great, but if I have the windows like this:

Two workspaces; each letter is a window; uppercase means focused.
```
[A b c d] [e f g h]
```
And each window is 50% size, so they're currently visible on two monitors like this:
```
[A b] [e f]
```
If I use my mouse to select E
```
[a b] [E f]
```
And then use the keyboard shortcut to move left, I get whiplash as the left monitor whisks everything away to focus D.
```
[c D] [e f]
```
This PR changes it to just activate the closest _visible_ window on the monitor.
```
[a B] [e f]
```

@dawsers Can you play around with this and tell me what you think of it?