### PR TITLE
Global move -- allow switching to empty monitors

### DIFF
--- a/keybindings.js
+++ b/keybindings.js
@@ -222,10 +222,38 @@ export function setupActions(settings) {
     registerMinimapAction("switch-eleventh", (mw, space) => Tiling.activateNthWindow(10, space));
     registerMinimapAction("switch-last", Tiling.activateLastWindow);
 
-    registerMinimapAction("switch-global-right", (mw, space) => space.switchGlobalRight());
-    registerMinimapAction("switch-global-left", (mw, space) => space.switchGlobalLeft());
-    registerMinimapAction("switch-global-up", (mw, space) => space.switchGlobalUp());
-    registerMinimapAction("switch-global-down", (mw, space) => space.switchGlobalDown());
+    registerAction("switch-global-right", (_mw, space) => {
+        space.switchGlobalRight()
+    }, {
+        settings: keybindSettings,
+        opensNavigator: true,
+        opensMinimap: true,
+        mutterFlags: Meta.KeyBindingFlags.NONE,
+    });
+    registerAction("switch-global-left", (_mw, space) => {
+        space.switchGlobalLeft()
+    }, {
+        settings: keybindSettings,
+        opensNavigator: true,
+        opensMinimap: true,
+        mutterFlags: Meta.KeyBindingFlags.NONE,
+    });
+    registerAction("switch-global-up", (_mw, space) => {
+        space.switchGlobalUp()
+    }, {
+        settings: keybindSettings,
+        opensNavigator: true,
+        opensMinimap: true,
+        mutterFlags: Meta.KeyBindingFlags.NONE,
+    });
+    registerAction("switch-global-down", (_mw, space) => {
+        space.switchGlobalDown()
+    }, {
+        settings: keybindSettings,
+        opensNavigator: true,
+        opensMinimap: true,
+        mutterFlags: Meta.KeyBindingFlags.NONE,
+    });
 
     registerMinimapAction("move-left",
         (_mw, space) => space.swap(Meta.MotionDirection.LEFT));

--- a/tiling.js
+++ b/tiling.js
@@ -1197,22 +1197,9 @@ export class Space extends Array {
             [Meta.MotionDirection.DOWN]: Meta.DisplayDirection.DOWN,
         };
         const dir = motionToDisplayDirection[direction]
-
         let space = this;
-        let index = space.selectedIndex();
-        if (index === -1) {
-            return;
-        }
-        let row = space[index].indexOf(space.selectedWindow);
 
-        switch (direction) {
-        case Meta.MotionDirection.RIGHT:
-            index++;
-            break;
-        case Meta.MotionDirection.LEFT:
-            index--;
-        }
-        if (index < 0 || index >= space.length) {
+        const switchMonitor = () => {
             const monitor = focusMonitor();
             const i = display.get_monitor_neighbor_index(monitor.index, dir);
             if (i === -1) {
@@ -1221,7 +1208,9 @@ export class Space extends Array {
 
             // Ensure if we change workspaces and then monitors,
             // that the new workspace stays active on the starting monitor.
-            space.activateWithFocus(space.selectedWindow, false, true);
+            if (space.selectedWindow) {
+                space.activateWithFocus(space.selectedWindow, false, true);
+            }
 
             const newMonitor = Main.layoutManager.monitors[i];
             const newSpace = spaces.monitors.get(newMonitor);
@@ -1247,7 +1236,25 @@ export class Space extends Array {
             const newWindow = sortWindows(newSpace, newColumn)[newColumn.length - 1];
 
             ensureViewport(newWindow, newSpace);
-            return
+        };
+
+        let index = space.selectedIndex();
+        if (index === -1) {
+            switchMonitor();
+            return;
+        }
+        let row = space[index].indexOf(space.selectedWindow);
+
+        switch (direction) {
+        case Meta.MotionDirection.RIGHT:
+            index++;
+            break;
+        case Meta.MotionDirection.LEFT:
+            index--;
+        }
+        if (index < 0 || index >= space.length) {
+            switchMonitor();
+            return;
         }
 
         let column = space[index];

--- a/tiling.js
+++ b/tiling.js
@@ -1225,20 +1225,27 @@ export class Space extends Array {
 
             const newMonitor = Main.layoutManager.monitors[i];
             const newSpace = spaces.monitors.get(newMonitor);
+
+            newSpace.activate(false, false);
+            Navigator.finishNavigation();
+
+            // New monitor is empty, just move the mouse there
+            if (newSpace.length === 0) {
+                Utils.warpPointerToMonitor(newMonitor);
+                return;
+            }
+
+            Navigator.getNavigator().showMinimap(newSpace);
+
             const visibleColumns = newSpace.filter((column) => newSpace.isVisible(column[0]));
             if (visibleColumns.length === 0) {
                 return;
             }
 
-            const newColumn = dir === Meta.DisplayDirection.LEFT
-                ? visibleColumns[visibleColumns.length - 1]
-                : visibleColumns[0];
-            const newRow = Math.min(row, newColumn.length - 1);
-            const newWindow = newColumn[newRow];
+            const newIndex = dir === Meta.DisplayDirection.LEFT ? visibleColumns.length - 1 : 0;
+            const newColumn = visibleColumns[newIndex];
+            const newWindow = sortWindows(newSpace, newColumn)[newColumn.length - 1];
 
-            newSpace.activate(false, false);
-            Navigator.finishNavigation();
-            Navigator.getNavigator().showMinimap(newSpace);
             ensureViewport(newWindow, newSpace);
             return
         }


### PR DESCRIPTION
This is part of a series of PRs. See the first one for more context.

1. #1076
2. #1081 « :pushpin: YOU ARE HERE
3. #1082

Updates the "select window or monitor to the <direction>" to move to/from empty monitors as well as monitors with windows.