### PR TITLE
Make position indicator scale with window width

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -1761,15 +1761,21 @@ border-radius: ${borderWidth}px;
             this.windowPositionBar.show();
         }
 
-        let width = this.monitor.width;
-        this.windowPositionBarBackdrop.width = width;
-        let segments = width / cols;
-        this.windowPositionBar.width = segments;
+        const spaceWidth = totalWidth(this);
+        const windex = this.indexOf(this.selectedWindow);
+        const widthBeforeSelection = totalWidth(this.slice(0, windex));
+        const monitorWidth = this.monitor.width;
+
+        const translateToMonitor = (width) => {
+            const percent = width / spaceWidth;
+            return percent * monitorWidth;
+        }
+
+        this.windowPositionBarBackdrop.width = monitorWidth;
+        this.windowPositionBar.width = translateToMonitor(this.selectedWindow.clone.width);
         this.windowPositionBar.height = Topbar.panelBox.height;
 
-        // index of currently selected window
-        let windex = this.indexOf(this.selectedWindow);
-        this.windowPositionBar.x = windex * segments;
+        this.windowPositionBar.x = translateToMonitor(widthBeforeSelection);
     }
 
     /**
@@ -5548,6 +5554,10 @@ export function sortWindows(space, windows) {
     return space.cloneContainer.get_children()
         .filter(c => clones.includes(c))
         .map(c => c.meta_window);
+}
+
+function totalWidth(columns) {
+    return columns.reduce((acc, col) => acc + col[0].clone.width, 0);
 }
 
 export function rotated(list, dir = 1) {

--- a/tiling.js
+++ b/tiling.js
@@ -1772,10 +1772,13 @@ border-radius: ${borderWidth}px;
         }
 
         this.windowPositionBarBackdrop.width = monitorWidth;
-        this.windowPositionBar.width = translateToMonitor(this.selectedWindow.clone.width);
         this.windowPositionBar.height = Topbar.panelBox.height;
 
-        this.windowPositionBar.x = translateToMonitor(widthBeforeSelection);
+        Easer.addEase(this.windowPositionBar, {
+            x: translateToMonitor(widthBeforeSelection),
+            width: translateToMonitor(this.selectedWindow.clone.width),
+            time: Settings.prefs.animation_time,
+        });
     }
 
     /**


### PR DESCRIPTION
As the title says. Makes the length and position proportional to the size of the windows on that monitor, not just the number.

This is the behavior I originally wanted in #471, I just didn't know enough to implement it at the time.

Per the commit message: the animation is kinda wonky, and I will remove it before merge unless someone else comes around to fix it.