### PR TITLE
Fix crash when drag detaching Chrome tabs

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -744,7 +744,7 @@ export class Space extends Array {
             if (inGrab && column.includes(inGrab.window) && !allocator) {
                 [resultingWidth, relayout] =
                     this.layoutGrabColumn(column, x, y0, targetWidth, availableHeight, time,
-                        selectedInColumn);
+                        inGrab.window);
             } else {
                 allocator = allocator || allocateDefault;
                 let targetHeights = allocator(column, availableHeight, selectedInColumn);

--- a/tiling.js
+++ b/tiling.js
@@ -741,7 +741,7 @@ export class Space extends Array {
 
             let resultingWidth, relayout;
             let allocator = allocators && allocators[i];
-            if (inGrab && column.includes(inGrab.window) && !allocator) {
+            if (inGrab && inGrab.dnd && column.includes(inGrab.window) && !allocator) {
                 [resultingWidth, relayout] =
                     this.layoutGrabColumn(column, x, y0, targetWidth, availableHeight, time,
                         inGrab.window);

--- a/tiling.js
+++ b/tiling.js
@@ -541,7 +541,7 @@ export class Space extends Array {
 
         const k = column.indexOf(grabWindow);
         if (k < 0) {
-            throw new Error(`Anchor doesn't exist in column ${grabWindow.title}`);
+            throw new Error(`Anchor doesn't exist in column ${grabWindow?.title}`);
         }
 
         const gap = Settings.prefs.window_gap;


### PR DESCRIPTION
Fixes #1069

When detaching tabs from Chrome by dragging them out of the current window, PaperWM calls `layoutGrabColumn` with a null `selectedWindow`, causing the layout recalculation to crash.

This PR changes it to pass `inGrab.window` directly for the `grabWindow` parameter, which seems to match the if predicate better too.

I also fixed an incidental crash when formatting the error in `layoutGrabColumn` when null gets passed in.

Finally, when testing this out, I noticed that `layoutGrabColumn` positions the detached window with a somewhat arbitrary seeming y position (seems to be based on where it was created on detach):

https://github.com/user-attachments/assets/78d8893f-cd63-406e-8633-f61d44afd552

Adding `inGrab.dnd` to the predicate uses the normal layout function and prevents this behavior:

https://github.com/user-attachments/assets/6bfa0c30-4c0d-4ce5-a255-27b59ea0067c

I don't yet fully understand the cases where `layoutGrabColumn` is important, but it seems like the gap preservation only matters when we're in the fully engaged "DnD grab" where the window is pulled out of the layout and being moved to a new tiled position.

There's still a little funkiness I've seen occasionally in testing, but this change prevents the stateful layout corruption described in the original issue.