### PR TITLE
Reduce minimum fixed workspaces to the number of monitors

### DIFF
--- a/patches.js
+++ b/patches.js
@@ -583,7 +583,7 @@ export function _checkWorkspaces() {
     let workspaceManager = global.workspace_manager;
     let i;
     let emptyWorkspaces = [];
-    let minimum = Main.layoutManager.monitors.length + 1;
+    let minimum = Main.layoutManager.monitors.length;
 
     if (!Meta.prefs_get_dynamic_workspaces()) {
         // if less spaces than minimum, create!
@@ -640,8 +640,7 @@ export function _checkWorkspaces() {
     }
 
     /**
-     * Set minimum workspaces to be max of num_monitors+1.
-     * This ensures that we have at least one workspace at the end.
+     * Set minimum workspaces to be max of num_monitors.
      */
     // Make sure we have a minimum number of spaces
     for (i = 0; i < minimum; i++) {

--- a/patches.js
+++ b/patches.js
@@ -583,7 +583,9 @@ export function _checkWorkspaces() {
     let workspaceManager = global.workspace_manager;
     let i;
     let emptyWorkspaces = [];
-    let minimum = Main.layoutManager.monitors.length;
+    let minimum = Meta.prefs_get_dynamic_workspaces()
+        ? Main.layoutManager.monitors.length + 1
+        : Main.layoutManager.monitors.length;
 
     if (!Meta.prefs_get_dynamic_workspaces()) {
         // if less spaces than minimum, create!
@@ -639,10 +641,8 @@ export function _checkWorkspaces() {
         emptyWorkspaces[workspaceIndex] = false;
     }
 
-    /**
-     * Set minimum workspaces to be max of num_monitors.
-     */
-    // Make sure we have a minimum number of spaces
+    // If dynamic workspaces are enabled, keep an extra spare workspace.
+    // Otherwise, require only one workspace per monitor.
     for (i = 0; i < minimum; i++) {
         if (i >= emptyWorkspaces.length) {
             workspaceManager.append_new_workspace(false, global.get_current_time());


### PR DESCRIPTION
Fixes #1087.

Removes the requirement for an empty workspace at the end when using a fixed number of workspaces. Each monitor gets exactly one workspace minimum instead of having an extra unused one. Tested on my machine and is working fine.