### PR TITLE
Fix touchpad scroll gesture on GNOME 49

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,16 +34,16 @@
     },
     "nixpkgs-gnome": {
       "locked": {
-        "lastModified": 1742772691,
-        "narHash": "sha256-zp5dBRmFJ47Wqwo3jphPRfgBVL7gx+DJw0Ni9J/gFFc=",
+        "lastModified": 1762163421,
+        "narHash": "sha256-qo7ZDi04s8EU7BQh1iKFrWV8eqclRDsJx47IY019sa4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ebe5e16c4ae36aa4230f1108ca4e35157fae6697",
+        "rev": "46391794055c11ed20e22656127d4f728dc1b263",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "gnome",
+        "ref": "wip-gnome",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 { description = "Tiled, scrollable window management for GNOME Shell";
 
   inputs."nixpkgs".url = github:NixOS/nixpkgs;
-  inputs."nixpkgs-gnome".url = github:NixOS/nixpkgs/gnome;
+  inputs."nixpkgs-gnome".url = github:NixOS/nixpkgs/wip-gnome;
 
   outputs = { self, nixpkgs, nixpkgs-gnome, flake-utils, ... }:
   flake-utils.lib.eachDefaultSystem
@@ -35,26 +35,26 @@
                 (s: super: { paperwm = self.packages.${system}.default; })
 
                 # Pull GNOME-specific packages from GNOME staging
-                #(s: super: {
-                #  gnome-desktop = pkgs-gnome.gnome-desktop;
-                #  gnome-shell   = pkgs-gnome.gnome-shell.override {
-                #    evolution-data-server-gtk4 = super.evolution-data-server-gtk4.override {
-                #      inherit (super) webkitgtk_4_1 webkitgtk_6_0;
-                #    };
-                #  };
-                #  gnome-session = pkgs-gnome.gnome-session.override {
-                #    inherit (s) gnome-shell;
-                #  };
-                #  gnome-control-center = pkgs-gnome.gnome-control-center;
-                #  gnome-initial-setup = pkgs-gnome.gnome-initial-setup.override {
-                #    inherit (super) webkitgtk_6_0;
-                #  };
-                #  gnome-settings-daemon = pkgs-gnome.gnome-settings-daemon;
-                #  mutter        = pkgs-gnome.mutter;
-                #  gdm           = pkgs-gnome.gdm;
-                #  xdg-desktop-portal-gnome = pkgs-gnome.xdg-desktop-portal-gnome;
-                #  xdg-desktop-portal-gtk = pkgs-gnome.xdg-desktop-portal-gtk;
-                #})
+                (s: super: {
+                  gnome-desktop = pkgs-gnome.gnome-desktop;
+                  gnome-shell   = pkgs-gnome.gnome-shell.override {
+                    evolution-data-server-gtk4 = super.evolution-data-server-gtk4.override {
+                      inherit (super) webkitgtk_4_1 webkitgtk_6_0;
+                    };
+                  };
+                  gnome-session = pkgs-gnome.gnome-session.override {
+                    inherit (s) gnome-shell;
+                  };
+                  gnome-control-center = pkgs-gnome.gnome-control-center;
+                  gnome-initial-setup = pkgs-gnome.gnome-initial-setup.override {
+                    inherit (super) webkitgtk_6_0;
+                  };
+                  gnome-settings-daemon = pkgs-gnome.gnome-settings-daemon;
+                  mutter        = pkgs-gnome.mutter;
+                  gdm           = pkgs-gnome.gdm;
+                  xdg-desktop-portal-gnome = pkgs-gnome.xdg-desktop-portal-gnome;
+                  xdg-desktop-portal-gtk = pkgs-gnome.xdg-desktop-portal-gtk;
+                })
               ];
             }
           ];

--- a/patches.js
+++ b/patches.js
@@ -555,6 +555,7 @@ export function restoreRuntimeDisables() {
 export let swipeTrackers; // exported
 export function setupSwipeTrackers() {
     swipeTrackers = [
+        Main?.overview?._overview?._controls?._appDisplay?._swipeTracker, // gnome 49+
         Main?.overview?._swipeTracker, // gnome 40+
         Main?.overview?._overview?._controls?._workspacesDisplay?._swipeTracker, // gnome 40+
         Main?.wm?._workspaceAnimation?._swipeTracker, // gnome 40+


### PR DESCRIPTION
This fixes #1092 by adding the AppDisplay SwipeTracker to the list of trackers to incapacitate, as per @cg505's investigation. Please try and report back!
