### PR TITLE
Specify that SHELL should be bash (not some POSIX sh)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ else
 GNOME_EXT_DISABLE := gnome-shell-extension-tool --disable
 endif
 
+SHELL=bash
+
 ## Update compiled files
 all: $(RELEASE_FILES)
 


### PR DESCRIPTION
Otherwise, I was getting

    ❯ make install
    /bin/sh: 1: [[: not found
    MKDIR	/home/yoh/.local/share/gnome-shell/extensions
    LINK	paperwm@paperwm.github.com

    INSTALL SUCCESSFUL:

    If this is the first time installing PaperWM, then please logout/login
    and enable the PaperWM extension, either with the GNOME Extensions application,
    or manually by executing the following command from a terminal:

    gnome-extensions enable paperwm@paperwm.github.com

although overall

    ❯ echo $?
    0

and I guess `[[ ]]` is bashism (didn't doublecheck)