### PR TITLE
Switch windows with Super+Mousewheel (Example)

### DIFF
--- a/patches.js
+++ b/patches.js
@@ -224,11 +224,11 @@ export function setupOverrides() {
 
             if (direction === Clutter.ScrollDirection.UP) {
                 const tabPopup = Navigator.getActionDispatcher(Clutter.GrabState.KEYBOARD);
-                tabPopup.show(false, 'switch-global-left', Clutter.ModifierType.MOD4_MASK);
+                tabPopup.show(false, 'switch-global-right', Clutter.ModifierType.MOD4_MASK);
                 return Clutter.EVENT_STOP;
             } else if (direction === Clutter.ScrollDirection.DOWN) {
                 const tabPopup = Navigator.getActionDispatcher(Clutter.GrabState.KEYBOARD);
-                tabPopup.show(false, 'switch-global-right', Clutter.ModifierType.MOD4_MASK);
+                tabPopup.show(false, 'switch-global-left', Clutter.ModifierType.MOD4_MASK);
                 return Clutter.EVENT_STOP;
             }
                 
@@ -444,6 +444,14 @@ export function setupOverrides() {
 
         this._icon.set_size(size * scaleFactor, size * scaleFactor);
     });
+
+    registerOverridePrototype(AltTab.AppSwitcherPopup, '_scrollHandler', function(direction) {
+        if (direction === Clutter.ScrollDirection.UP) {
+            props['_scrollHandler'].saved(Clutter.ScrollDirection.DOWN);
+        } else if (direction === Clutter.ScrollDirection.DOWN) {
+            props['_scrollHandler'].saved(Clutter.ScrollDirection.UP);
+        }
+    })
 
     registerOverridePrototype(Screenshot.ScreenshotUI, 'open', async function(mode) {
         const saved = getSavedPrototype(Screenshot.ScreenshotUI, 'open');

--- a/patches.js
+++ b/patches.js
@@ -16,7 +16,7 @@ import * as WindowManager from 'resource:///org/gnome/shell/ui/windowManager.js'
 import * as WindowPreview from 'resource:///org/gnome/shell/ui/windowPreview.js';
 import * as Screenshot from 'resource:///org/gnome/shell/ui/screenshot.js';
 
-import { Utils, Tiling, Scratch, Settings, OverviewLayout } from './imports.js';
+import { Utils, Tiling, Scratch, Settings, OverviewLayout, Navigator } from './imports.js';
 
 /**
   Some of Gnome Shell's default behavior is really sub-optimal when using
@@ -213,6 +213,27 @@ export function setupOverrides() {
 
     if (WindowManager.TouchpadWorkspaceSwitchAction) // disable 4-finger swipe
         registerOverridePrototype(WindowManager.TouchpadWorkspaceSwitchAction, '_checkActivated', () => false);
+
+
+    registerOverridePrototype(WindowManager.WindowManager, 'handleWorkspaceScroll',
+        function (event) {
+            if (event.type() !== Clutter.EventType.SCROLL)
+                return Clutter.EVENT_PROPAGATE;
+
+            const direction = event.get_scroll_direction();
+
+            if (direction === Clutter.ScrollDirection.UP) {
+                const tabPopup = Navigator.getActionDispatcher(Clutter.GrabState.KEYBOARD);
+                tabPopup.show(false, 'switch-global-left', Clutter.ModifierType.MOD4_MASK);
+                return Clutter.EVENT_STOP;
+            } else if (direction === Clutter.ScrollDirection.DOWN) {
+                const tabPopup = Navigator.getActionDispatcher(Clutter.GrabState.KEYBOARD);
+                tabPopup.show(false, 'switch-global-right', Clutter.ModifierType.MOD4_MASK);
+                return Clutter.EVENT_STOP;
+            }
+                
+            return Clutter.EVENT_PROPAGATE;
+        });
 
     // disable swipe gesture trackers
     swipeTrackers.forEach(t => {

--- a/tiling.js
+++ b/tiling.js
@@ -1971,11 +1971,11 @@ border-radius: ${borderWidth}px;
                 switch (dir) {
                 case Clutter.ScrollDirection.LEFT:
                 case Clutter.ScrollDirection.UP:
-                    this.switchLeft(false);
+                    this.switchRight(false);
                     break;
                 case Clutter.ScrollDirection.RIGHT:
                 case Clutter.ScrollDirection.DOWN:
-                    this.switchRight(false);
+                    this.switchLeft(false);
                     break;
                 }
             });

--- a/topbar.js
+++ b/topbar.js
@@ -181,10 +181,10 @@ export function topBarScrollAction(event) {
     let direction = event.get_scroll_direction();
     switch (direction) {
     case Clutter.ScrollDirection.DOWN:
-        Tiling.spaces?.activeSpace.switchRight(false);
+        Tiling.spaces?.activeSpace.switchLeft(false);
         break;
     case Clutter.ScrollDirection.UP:
-        Tiling.spaces?.activeSpace.switchLeft(false);
+        Tiling.spaces?.activeSpace.switchRight(false);
         break;
     }
     const selected = Tiling.spaces?.activeSpace?.selectedWindow;


### PR DESCRIPTION
As described here https://github.com/paperwm/PaperWM/issues/206#issuecomment-3719761093 this is an example how to get Super+Mousewheel to work for window switching. 

These are my personal patches which also invert all scroll directions (topbar, alttab, ...), so probably no good candidate for merging until toggles for the features are added.