### PR TITLE
Fix #1139 by assuming Wayland by default

### DIFF
--- a/gestures.js
+++ b/gestures.js
@@ -24,7 +24,7 @@ let touchpadSettings;
 export function enable(extension) {
     signals = new Utils.Signals();
     // Touchpad swipes only works in Wayland
-    if (!Meta.is_wayland_compositor())
+    if (!Utils.is_wayland_compositor())
         return;
 
     touchpadSettings = new Gio.Settings({

--- a/patches.js
+++ b/patches.js
@@ -35,7 +35,7 @@ export function enable(extension) {
     // save the last display server used
     gsettings.set_string(
         'last-used-display-server',
-        Meta.is_wayland_compositor() ? "Wayland" : "Xorg"
+        Utils.is_wayland_compositor() ? "Wayland" : "Xorg"
     );
 
     mutterSettings = new Gio.Settings({ schema_id: 'org.gnome.mutter' });

--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -449,7 +449,7 @@ export class StackOverlay {
                 return bail(); // Should normally have a neighbour. Bail!
 
             let width = neighbour.clone.targetX + space.targetX - minResizeEdge;
-            if (space.isPlaceable(metaWindow) || Meta.is_wayland_compositor())
+            if (space.isPlaceable(metaWindow) || Utils.is_wayland_compositor())
                 width = Math.min(width, 1);
             overlay.x = this.monitor.x;
             overlay.width = Math.max(width, 1);
@@ -464,7 +464,7 @@ export class StackOverlay {
             let frame = neighbour.get_frame_rect();
             frame.x = neighbour.clone.targetX + space.targetX;
             let width = this.monitor.width - (frame.x + frame.width) - minResizeEdge;
-            if (space.isPlaceable(metaWindow) || Meta.is_wayland_compositor())
+            if (space.isPlaceable(metaWindow) || Utils.is_wayland_compositor())
                 width = 1;
             width = Math.max(width, 1);
             overlay.x = this.monitor.x + this.monitor.width - width;

--- a/tiling.js
+++ b/tiling.js
@@ -1420,7 +1420,7 @@ export class Space extends Array {
 
         this.fixOverlays();
 
-        if (!Meta.is_wayland_compositor()) {
+        if (!Utils.is_wayland_compositor()) {
             // See startAnimate
             Main.layoutManager.untrackChrome(this.background);
         }
@@ -1463,7 +1463,7 @@ export class Space extends Array {
     }
 
     startAnimate() {
-        if (!this._isAnimating && !Meta.is_wayland_compositor()) {
+        if (!this._isAnimating && !Utils.is_wayland_compositor()) {
             // Tracking the background fixes issue #80
             // It also let us activate window clones clicked during animation
             // Untracked in moveDone
@@ -3162,7 +3162,7 @@ export const Spaces = class Spaces extends Map {
             // Fixes a weird bug where mouse input stops
             // working after mousing to another monitor on
             // X11.
-            if (!Meta.is_wayland_compositor()) {
+            if (!Utils.is_wayland_compositor()) {
                 to.startAnimate();
             }
 

--- a/utils.js
+++ b/utils.js
@@ -105,6 +105,13 @@ export function setBackgroundImage(actor, resource_path) {
     actor.content_repeat = Clutter.ContentRepeat.BOTH;
 }
 
+export function is_wayland_compositor() {
+    if (typeof Meta.is_wayland_compositor === 'function')
+        return Meta.is_wayland_compositor()
+    else
+        return true // GNOME 50+ is always a Wayland compositor
+}
+
 /**
  * Backwards compatible function.  Attempts to use Cogl.Color with a fallback
  * to Clutter.Color.


### PR DESCRIPTION
Fixes #1139 by abstracting `is_wayland_compositor()`. On GNOME 50+, Shell will only ever run on Wayland, so function missing should mean we're running on Wayland.