### PR TITLE
Fix for GNOME 50s API changes

### DIFF
--- a/grab.js
+++ b/grab.js
@@ -1,4 +1,5 @@
 import Clutter from 'gi://Clutter';
+var GrabState = GrabState || { NONE: 0, POINTER: 1, KEYBOARD: 2, ALL: 3 };
 import GLib from 'gi://GLib';
 import Graphene from 'gi://Graphene';
 import Meta from 'gi://Meta';
@@ -67,10 +68,10 @@ export class MoveGrab {
         grabbed = true;
         global.display.end_grab_op?.(global.get_current_time());
         if (Utils.version[0] >= 48)
-            global.display.set_cursor(Meta.Cursor.GRABBING);
+            if (global.stage.set_cursor_type) global.stage.set_cursor_type(Clutter.CursorType.GRABBING); else global.display.set_cursor(Meta.Cursor.GRABBING);
         else
-            global.display.set_cursor(Meta.Cursor.MOVE_OR_RESIZE_WINDOW);
-        this.dispatcher = new Navigator.getActionDispatcher(Clutter.GrabState.POINTER);
+            if (global.stage.set_cursor_type) global.stage.set_cursor_type(Clutter.CursorType.GRABBING); else global.display.set_cursor(Meta.Cursor.MOVE_OR_RESIZE_WINDOW);
+        this.dispatcher = new Navigator.getActionDispatcher(GrabState.POINTER);
         this.actor = this.dispatcher.actor;
 
         let metaWindow = this.window;
@@ -135,9 +136,9 @@ export class MoveGrab {
         Navigator.getNavigator().minimaps.forEach(m => typeof m === 'number'
             ? Utils.timeout_remove(m) : m.hide());
         if (Utils.version[0] >= 48)
-            global.display.set_cursor(Meta.Cursor.GRABBING);
+            if (global.stage.set_cursor_type) global.stage.set_cursor_type(Clutter.CursorType.GRABBING); else global.display.set_cursor(Meta.Cursor.GRABBING);
         else
-            global.display.set_cursor(Meta.Cursor.MOVE_OR_RESIZE_WINDOW);
+            if (global.stage.set_cursor_type) global.stage.set_cursor_type(Clutter.CursorType.GRABBING); else global.display.set_cursor(Meta.Cursor.MOVE_OR_RESIZE_WINDOW);
         let metaWindow = this.window;
         let clone = metaWindow.clone;
         let space = this.initialSpace;
@@ -552,10 +553,10 @@ export class MoveGrab {
         // // If the window is transient this will take care of its parent too.
         Tiling.setInGrab(false);
         if (this.dispatcher) {
-            Navigator.dismissDispatcher(Clutter.GrabState.POINTER);
+            Navigator.dismissDispatcher(GrabState.POINTER);
         }
 
-        global.display.set_cursor(Meta.Cursor.DEFAULT);
+        if (global.stage.set_cursor_type) global.stage.set_cursor_type(Clutter.CursorType.DEFAULT); else global.display.set_cursor(Meta.Cursor.DEFAULT);
 
         /**
          * Gnome 44 removed the ability to manually end_grab_op.

--- a/navigator.js
+++ b/navigator.js
@@ -1,4 +1,5 @@
 import Clutter from 'gi://Clutter';
+var GrabState = GrabState || { NONE: 0, POINTER: 1, KEYBOARD: 2, ALL: 3 };
 import GLib from 'gi://GLib';
 import Meta from 'gi://Meta';
 import St from 'gi://St';
@@ -83,7 +84,7 @@ class ActionDispatcher {
         // grab = stage.grab(this.actor)
         grab = Main.pushModal(this.actor);
         // We expect at least a keyboard grab here
-        if ((grab.get_seat_state() & Clutter.GrabState.KEYBOARD) === 0) {
+        if (grab && typeof grab.get_seat_state === "function" && (grab.get_seat_state() & GrabState.KEYBOARD) === 0) {
             console.error("Failed to grab modal");
             throw new Error('Could not grab modal');
         }
@@ -196,7 +197,7 @@ class ActionDispatcher {
 
     _keyReleaseEvent(_actor, event) {
         if (this._destroy) {
-            dismissDispatcher(Clutter.GrabState.KEYBOARD);
+            dismissDispatcher(GrabState.KEYBOARD);
         }
 
         if (this._modifierMask) {
@@ -254,7 +255,7 @@ class ActionDispatcher {
         let nav = getNavigator();
         nav.accept();
         !this._destroy && nav.destroy();
-        dismissDispatcher(Clutter.GrabState.KEYBOARD);
+        dismissDispatcher(GrabState.KEYBOARD);
         let space = Tiling.spaces.selectedSpace;
         let metaWindow = space.selectedWindow;
         if (metaWindow) {
@@ -539,12 +540,12 @@ export function dismissDispatcher(mode) {
     }
 
     dispatcher.mode ^= mode;
-    if (dispatcher.mode === Clutter.GrabState.NONE) {
+    if (dispatcher.mode === GrabState.NONE) {
         dispatcher.destroy();
     }
 }
 
 export function preview_navigate(meta_window, space, { _display, _screen, binding }) {
-    let tabPopup = getActionDispatcher(Clutter.GrabState.KEYBOARD);
+    let tabPopup = getActionDispatcher(GrabState.KEYBOARD);
     tabPopup.show(binding.is_reversed(), binding.get_name(), binding.get_mask());
 }

--- a/tiling.js
+++ b/tiling.js
@@ -1,4 +1,5 @@
 import Clutter from 'gi://Clutter';
+var GrabState = GrabState || { NONE: 0, POINTER: 1, KEYBOARD: 2, ALL: 3 };
 import GDesktopEnums from 'gi://GDesktopEnums';
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
@@ -1271,7 +1272,7 @@ export class Space extends Array {
         this.drifting = true;
 
         // stop drifting on key_release
-        Navigator.getActionDispatcher(Clutter.GrabState.KEYBOARD)
+        Navigator.getActionDispatcher(GrabState.KEYBOARD)
             .addKeyReleaseCallback(() => {
                 Utils.timeout_remove(driftTimeout);
                 this.drifting = null;
@@ -5476,7 +5477,7 @@ export function takeWindow(metaWindow, space, options = {}) {
         };
 
         // get the action dispatcher signal to connect to
-        Navigator.getActionDispatcher(Clutter.GrabState.KEYBOARD)
+        Navigator.getActionDispatcher(GrabState.KEYBOARD)
             .addKeypressCallback((_modmask, keysym, _event) => {
                 switch (keysym) {
                 case Clutter.KEY_space: {
@@ -5531,7 +5532,7 @@ export function takeWindow(metaWindow, space, options = {}) {
 
         signals.connectOneShot(navigator, 'destroy', () => {
             // ensure keyboard grabstate is dimissed (in case moving stopped via pointer)
-            Navigator.dismissDispatcher(Clutter.GrabState.KEYBOARD);
+            Navigator.dismissDispatcher(GrabState.KEYBOARD);
             navigator.showTakeHint(false);
 
             let selectedSpace = spaces.selectedSpace;


### PR DESCRIPTION
This PR addresses the breaking API changes introduced in GNOME 50 that cause PaperWM to crash during keybindings and window movement.

## Changes
- **Native GNOME 50 Cursor Support:** Migrated cursor management in `grab.js` from the legacy `Meta.Cursor` enums to the modern `Clutter.CursorType` system via `global.stage.set_cursor_type`. This ensures mouse icons (GRABBING, DEFAULT) function correctly on GNOME 50.
- **GrabState Polyfill:** Implemented a hoisted `var GrabState` fallback across `grab.js`, `navigator.js`, and `tiling.js`. This prevents `ReferenceError` crashes during the extension's circular import phase while providing the necessary constants for internal tiling logic.
- **API Safety Checks:** Added a type check for `get_seat_state` in `navigator.js` to prevent `TypeError` on GNOME 50's unified input grabs.

## Testing
Tested on GNOME 50 (CachyOS). 
- Super + Arrow keys (navigation) are fully functional.
- Mouse cursors update correctly when grabbing/moving windows.
- No initialization errors on extension load/reload.

Fixes #1147