### PR TITLE
Fix touch screen drag freezing input

### DIFF
--- a/grab.js
+++ b/grab.js
@@ -586,7 +586,7 @@ export class MoveGrab {
         Utils.later_add(Meta.LaterType.IDLE, () => {
             if (!global.display.end_grab_op && this.wasTiled) {
                 let time = Clutter.get_current_event_time();
-                
+
                 // For Mouse users: Fakes a mouse click to break Mutter's pointer grab
                 let [x, y] = global.get_pointer();
                 getVirtualPointer().notify_absolute_motion(time, x, y);

--- a/grab.js
+++ b/grab.js
@@ -38,22 +38,11 @@ export function disable() {
 }
 
 /**
- * Returns a virtual pointer (i.e. mouse) device that can be used to
- * "clickout" of a drag operation when `grab_end_op` is unavailable
+ * Returns a virtual keyboard that can be used to
+ * "escape" of a drag operation when `grab_end_op` is unavailable
  * (i.e. as of Gnome 44 where `grab_end_op` was removed).
  * @returns Clutter.VirtualInputDevice
 */
-let virtualPointer;
-export function getVirtualPointer() {
-    if (!virtualPointer) {
-        virtualPointer = Clutter.get_default_backend()
-            .get_default_seat()
-            .create_virtual_device(Clutter.InputDeviceType.POINTER_DEVICE);
-    }
-
-    return virtualPointer;
-}
-
 let virtualKeyboard;
 export function getVirtualKeyboard() {
     if (!virtualKeyboard) {
@@ -586,14 +575,8 @@ export class MoveGrab {
         Utils.later_add(Meta.LaterType.IDLE, () => {
             if (!global.display.end_grab_op && this.wasTiled) {
                 let time = Clutter.get_current_event_time();
-
-                // For Mouse users: Fakes a mouse click to break Mutter's pointer grab
-                let [x, y] = global.get_pointer();
-                getVirtualPointer().notify_absolute_motion(time, x, y);
-                getVirtualPointer().notify_button(time, Clutter.BUTTON_PRIMARY, Clutter.ButtonState.PRESSED);
-                getVirtualPointer().notify_button(time, Clutter.BUTTON_PRIMARY, Clutter.ButtonState.RELEASED);
-
-                // For Touch users: Fakes an 'Escape' keypress to break Mutter's Wayland touch grab
+                
+                // Fakes an 'Escape' keypress to break Mutter's Wayland grab (works for both Touch and Pointer)
                 getVirtualKeyboard().notify_keyval(time, Clutter.KEY_Escape, Clutter.KeyState.PRESSED);
                 getVirtualKeyboard().notify_keyval(time, Clutter.KEY_Escape, Clutter.KeyState.RELEASED);
             }

--- a/grab.js
+++ b/grab.js
@@ -40,6 +40,16 @@ export function getVirtualPointer() {
     return virtualPointer;
 }
 
+let virtualKeyboard;
+export function getVirtualKeyboard() {
+    if (!virtualKeyboard) {
+        virtualKeyboard = Clutter.get_default_backend()
+            .get_default_seat()
+            .create_virtual_device(Clutter.InputDeviceType.KEYBOARD_DEVICE);
+    }
+    return virtualKeyboard;
+}
+
 export class MoveGrab {
     constructor(metaWindow, type, space) {
         this.window = metaWindow;
@@ -567,16 +577,17 @@ export class MoveGrab {
          */
         Utils.later_add(Meta.LaterType.IDLE, () => {
             if (!global.display.end_grab_op && this.wasTiled) {
-                // move to current cursor position
+                let time = Clutter.get_current_event_time();
+                
+                // For Mouse users: Fakes a mouse click to break Mutter's pointer grab
                 let [x, y] = global.get_pointer();
-                getVirtualPointer().notify_absolute_motion(
-                    Clutter.get_current_event_time(),
-                    x, y);
+                getVirtualPointer().notify_absolute_motion(time, x, y);
+                getVirtualPointer().notify_button(time, Clutter.BUTTON_PRIMARY, Clutter.ButtonState.PRESSED);
+                getVirtualPointer().notify_button(time, Clutter.BUTTON_PRIMARY, Clutter.ButtonState.RELEASED);
 
-                getVirtualPointer().notify_button(Clutter.get_current_event_time(),
-                    Clutter.BUTTON_PRIMARY, Clutter.ButtonState.PRESSED);
-                getVirtualPointer().notify_button(Clutter.get_current_event_time(),
-                    Clutter.BUTTON_PRIMARY, Clutter.ButtonState.RELEASED);
+                // For Touch users: Fakes an 'Escape' keypress to break Mutter's Wayland touch grab
+                getVirtualKeyboard().notify_keyval(time, Clutter.KEY_Escape, Clutter.KeyState.PRESSED);
+                getVirtualKeyboard().notify_keyval(time, Clutter.KEY_Escape, Clutter.KeyState.RELEASED);
             }
         });
     }


### PR DESCRIPTION
Fixes #1127. 

**Cause:**
The code was successfully intercepting `TOUCH_END` and running `this.end()`. Workaround of faking a virtual mouse click to drop the grab only works for mouse/pointer grabs. Mutter ignores the fake mouse click if the grab was started by a touch sequence, leaving the grab stuck open.

**Fix:**
Since hitting `Esc` acts as a global kill-switch for Mutter grabs, this PR adds a `virtualKeyboard` device. Alongside the fake mouse click, it now fires a virtual `Escape` keypress during cleanup. This successfully breaks the touch grab. 

Tested on CachyOS / GNOME 50 and it works perfectly!