### PR TITLE
Refine GNOME 50 API changes and fix Wayland input during animation

### DIFF
--- a/grab.js
+++ b/grab.js
@@ -1,5 +1,4 @@
 import Clutter from 'gi://Clutter';
-var GrabState = GrabState || { NONE: 0, POINTER: 1, KEYBOARD: 2, ALL: 3 };
 import GLib from 'gi://GLib';
 import Graphene from 'gi://Graphene';
 import Meta from 'gi://Meta';
@@ -8,7 +7,7 @@ import St from 'gi://St';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
 import { Settings, Utils, Tiling, Navigator, Scratch, Gestures } from './imports.js';
-import { Easer } from './utils.js';
+import { DispatcherMode, Easer } from './utils.js';
 
 export let grabbed = false;
 

--- a/grab.js
+++ b/grab.js
@@ -11,6 +11,21 @@ import { DispatcherMode, Easer } from './utils.js';
 
 export let grabbed = false;
 
+/**
+ * Sets the cursor type, using the GNOME 50+ actor-based API when available,
+ * falling back to the legacy Meta.Cursor API for older versions.
+ */
+function setCursor(cursorType) {
+    if (Utils.version[0] >= 50) {
+        // GNOME 50+: Meta.Cursor and display.set_cursor() are removed
+        global.stage.set_cursor_type(cursorType);
+    } else {
+        global.display.set_cursor(cursorType === Clutter.CursorType.GRABBING
+            ? (Utils.version[0] >= 48 ? Meta.Cursor.GRABBING : Meta.Cursor.MOVE_OR_RESIZE_WINDOW)
+            : Meta.Cursor.DEFAULT);
+    }
+}
+
 let dragDriftTimeout;
 export function enable() {
 
@@ -66,11 +81,8 @@ export class MoveGrab {
 
         grabbed = true;
         global.display.end_grab_op?.(global.get_current_time());
-        if (Utils.version[0] >= 48)
-            if (global.stage.set_cursor_type) global.stage.set_cursor_type(Clutter.CursorType.GRABBING); else global.display.set_cursor(Meta.Cursor.GRABBING);
-        else
-            if (global.stage.set_cursor_type) global.stage.set_cursor_type(Clutter.CursorType.GRABBING); else global.display.set_cursor(Meta.Cursor.MOVE_OR_RESIZE_WINDOW);
-        this.dispatcher = new Navigator.getActionDispatcher(GrabState.POINTER);
+        setCursor(Clutter.CursorType.GRABBING);
+        this.dispatcher = new Navigator.getActionDispatcher(DispatcherMode.POINTER);
         this.actor = this.dispatcher.actor;
 
         let metaWindow = this.window;
@@ -134,10 +146,7 @@ export class MoveGrab {
         console.debug("#grab", "begin DnD");
         Navigator.getNavigator().minimaps.forEach(m => typeof m === 'number'
             ? Utils.timeout_remove(m) : m.hide());
-        if (Utils.version[0] >= 48)
-            if (global.stage.set_cursor_type) global.stage.set_cursor_type(Clutter.CursorType.GRABBING); else global.display.set_cursor(Meta.Cursor.GRABBING);
-        else
-            if (global.stage.set_cursor_type) global.stage.set_cursor_type(Clutter.CursorType.GRABBING); else global.display.set_cursor(Meta.Cursor.MOVE_OR_RESIZE_WINDOW);
+        setCursor(Clutter.CursorType.GRABBING);
         let metaWindow = this.window;
         let clone = metaWindow.clone;
         let space = this.initialSpace;
@@ -552,10 +561,10 @@ export class MoveGrab {
         // // If the window is transient this will take care of its parent too.
         Tiling.setInGrab(false);
         if (this.dispatcher) {
-            Navigator.dismissDispatcher(GrabState.POINTER);
+            Navigator.dismissDispatcher(DispatcherMode.POINTER);
         }
 
-        if (global.stage.set_cursor_type) global.stage.set_cursor_type(Clutter.CursorType.DEFAULT); else global.display.set_cursor(Meta.Cursor.DEFAULT);
+        setCursor(Clutter.CursorType.DEFAULT);
 
         /**
          * Gnome 44 removed the ability to manually end_grab_op.

--- a/navigator.js
+++ b/navigator.js
@@ -1,8 +1,9 @@
 import Clutter from 'gi://Clutter';
-var GrabState = GrabState || { NONE: 0, POINTER: 1, KEYBOARD: 2, ALL: 3 };
 import GLib from 'gi://GLib';
 import Meta from 'gi://Meta';
 import St from 'gi://St';
+
+import { DispatcherMode } from './utils.js';
 
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
@@ -66,7 +67,7 @@ export function primaryModifier(mask) {
    Adapted from SwitcherPopup, without any visual handling.
  */
 class ActionDispatcher {
-    /** @type {import('@gi-types/clutter10').GrabState} */
+    /** @type {number} DispatcherMode bitmask */
     mode;
 
     constructor() {
@@ -197,7 +198,7 @@ class ActionDispatcher {
 
     _keyReleaseEvent(_actor, event) {
         if (this._destroy) {
-            dismissDispatcher(GrabState.KEYBOARD);
+            dismissDispatcher(DispatcherMode.KEYBOARD);
         }
 
         if (this._modifierMask) {
@@ -255,7 +256,7 @@ class ActionDispatcher {
         let nav = getNavigator();
         nav.accept();
         !this._destroy && nav.destroy();
-        dismissDispatcher(GrabState.KEYBOARD);
+        dismissDispatcher(DispatcherMode.KEYBOARD);
         let space = Tiling.spaces.selectedSpace;
         let metaWindow = space.selectedWindow;
         if (metaWindow) {
@@ -510,8 +511,7 @@ export function finishNavigation(force = true) {
 }
 
 /**
- *
- * @param {import('@gi-types/clutter10').GrabState} mode
+ * @param {number} mode - DispatcherMode bitmask
  * @returns {ActionDispatcher}
  */
 export function getActionDispatcher(mode) {
@@ -531,8 +531,7 @@ export function finishDispatching() {
 }
 
 /**
- *
- * @param {import('@gi-types/clutter10').GrabState} mode
+ * @param {number} mode - DispatcherMode bitmask
  */
 export function dismissDispatcher(mode) {
     if (!dispatcher) {
@@ -540,12 +539,12 @@ export function dismissDispatcher(mode) {
     }
 
     dispatcher.mode ^= mode;
-    if (dispatcher.mode === GrabState.NONE) {
+    if (dispatcher.mode === DispatcherMode.NONE) {
         dispatcher.destroy();
     }
 }
 
 export function preview_navigate(meta_window, space, { _display, _screen, binding }) {
-    let tabPopup = getActionDispatcher(GrabState.KEYBOARD);
+    let tabPopup = getActionDispatcher(DispatcherMode.KEYBOARD);
     tabPopup.show(binding.is_reversed(), binding.get_name(), binding.get_mask());
 }

--- a/navigator.js
+++ b/navigator.js
@@ -82,10 +82,8 @@ class ActionDispatcher {
             return;
         }
 
-        // grab = stage.grab(this.actor)
         grab = Main.pushModal(this.actor);
-        // We expect at least a keyboard grab here
-        if (grab && typeof grab.get_seat_state === "function" && (grab.get_seat_state() & GrabState.KEYBOARD) === 0) {
+        if (!grab) {
             console.error("Failed to grab modal");
             throw new Error('Could not grab modal');
         }

--- a/tiling.js
+++ b/tiling.js
@@ -1,5 +1,4 @@
 import Clutter from 'gi://Clutter';
-var GrabState = GrabState || { NONE: 0, POINTER: 1, KEYBOARD: 2, ALL: 3 };
 import GDesktopEnums from 'gi://GDesktopEnums';
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
@@ -12,7 +11,7 @@ import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import {
     Settings, Utils, Lib, Gestures, Navigator, Grab, Topbar, Scratch, Stackoverlay, Background
 } from './imports.js';
-import { Easer } from './utils.js';
+import { Easer, DispatcherMode } from './utils.js';
 import { ClickOverlay } from './stackoverlay.js';
 import { WorkspaceSettings } from './workspace.js';
 
@@ -1272,7 +1271,7 @@ export class Space extends Array {
         this.drifting = true;
 
         // stop drifting on key_release
-        Navigator.getActionDispatcher(GrabState.KEYBOARD)
+        Navigator.getActionDispatcher(DispatcherMode.KEYBOARD)
             .addKeyReleaseCallback(() => {
                 Utils.timeout_remove(driftTimeout);
                 this.drifting = null;
@@ -5477,7 +5476,7 @@ export function takeWindow(metaWindow, space, options = {}) {
         };
 
         // get the action dispatcher signal to connect to
-        Navigator.getActionDispatcher(GrabState.KEYBOARD)
+        Navigator.getActionDispatcher(DispatcherMode.KEYBOARD)
             .addKeypressCallback((_modmask, keysym, _event) => {
                 switch (keysym) {
                 case Clutter.KEY_space: {
@@ -5532,7 +5531,7 @@ export function takeWindow(metaWindow, space, options = {}) {
 
         signals.connectOneShot(navigator, 'destroy', () => {
             // ensure keyboard grabstate is dimissed (in case moving stopped via pointer)
-            Navigator.dismissDispatcher(GrabState.KEYBOARD);
+            Navigator.dismissDispatcher(DispatcherMode.KEYBOARD);
             navigator.showTakeHint(false);
 
             let selectedSpace = spaces.selectedSpace;

--- a/tiling.js
+++ b/tiling.js
@@ -1420,10 +1420,8 @@ export class Space extends Array {
 
         this.fixOverlays();
 
-        if (!Utils.is_wayland_compositor()) {
-            // See startAnimate
-            Main.layoutManager.untrackChrome(this.background);
-        }
+        // See startAnimate
+        Main.layoutManager.untrackChrome(this.background);
 
         this._isAnimating = false;
 
@@ -1463,7 +1461,7 @@ export class Space extends Array {
     }
 
     startAnimate() {
-        if (!this._isAnimating && !Utils.is_wayland_compositor()) {
+        if (!this._isAnimating) {
             // Tracking the background fixes issue #80
             // It also let us activate window clones clicked during animation
             // Untracked in moveDone
@@ -3159,12 +3157,10 @@ export const Spaces = class Spaces extends Map {
             to.border.opacity = 255;
             Utils.actor_raise(to.clip);
 
-            // Fixes a weird bug where mouse input stops
-            // working after mousing to another monitor on
-            // X11.
-            if (!Utils.is_wayland_compositor()) {
-                to.startAnimate();
-            }
+            // Ensures window clones are clickable after switching monitors.
+            // Originally X11-only but also needed on Wayland for proper
+            // input handling after space switches.
+            to.startAnimate();
 
             to.moveDone();
             if (callback) {

--- a/utils.js
+++ b/utils.js
@@ -105,11 +105,18 @@ export function setBackgroundImage(actor, resource_path) {
     actor.content_repeat = Clutter.ContentRepeat.BOTH;
 }
 
+/**
+ * Internal mode tracking for ActionDispatcher.
+ * Tracks whether the dispatcher was requested for keyboard, pointer, or both.
+ * Replaces the removed Clutter.GrabState enum (GNOME 50+).
+ */
+export const DispatcherMode = { NONE: 0, POINTER: 1, KEYBOARD: 2 };
+
 export function is_wayland_compositor() {
     if (typeof Meta.is_wayland_compositor === 'function')
         return Meta.is_wayland_compositor()
-    else
-        return true // GNOME 50+ is always a Wayland compositor
+
+    return true // GNOME 50+ is always a Wayland compositor
 }
 
 /**


### PR DESCRIPTION
Refines #1149's GNOME 50 fixes for issue #1147, cleaning up code duplication introduced by the `GrabState` polyfill, simplifies cursor handling, and fixes a window input/layout glitching bug on Wayland.

- **`GrabState` polyfill refactored into `DispatcherMode`**: Deduplicate the `var GrabState = GrabState || {...}` repeated across 3 files into a single `DispatcherMode` constant in `utils.js`, making it clear this is internal bookkeeping rather than a Clutter API.
- **`setCursor()` helper**: Deduplicate the inline if/else cursor chains in `grab.js` into a version-gated helper.
- **Drop redundant grab seat state check**: On GNOME 50+ grabs always succeed. On older versions `pushModal()` already validates this.
- **Enable `trackChrome`/`startAnimate` on Wayland**: These were X11-only gated but the underlying issues (unclickable windows, broken layout after animation/space switches) also affected Wayland.
- **Simplify `is_wayland_compositor()`**: Early return.

## Test plan

- Keybindings work on GNOME 50
- Cursor changes during window drag/move
- Windows remain clickable after workspace/monitor switches
- Windows properly fill vertically after animation