### PR TITLE
gestures: don't disable swipe trackers mid-gesture (GNOME 49/50 overview hang)

### DIFF
--- a/gestures.js
+++ b/gestures.js
@@ -16,8 +16,15 @@ const DIRECTIONS = {
 
 let vy, time, vState, navigator, direction, signals;
 let handoffToOverview = false;
+// true between BEGIN and END/CANCEL of a PaperWM-managed swipe. Used to defer
+// any tracker disabling that would otherwise interrupt a live overview gesture.
+let inGesture = false;
 // 1 is natural scrolling, -1 is unnatural
 let natural = 1;
+
+export function isInGesture() {
+    return inGesture;
+}
 export let gliding = false; // exported
 
 let touchpadSettings;
@@ -42,9 +49,19 @@ export function enable(extension) {
      * ensure swipe trackers are reset.
      */
     signals.connect(Main.overview, 'hidden', () => {
-        if (gestureEnabled()) {
-            swipeTrackersEnable(false);
+        if (!gestureEnabled()) {
+            return;
         }
+        // Defer to idle so any in-flight overview swipe animation settles
+        // (tracker -> State.NONE) before we disable. On GNOME 50 disabling a
+        // SCROLLING tracker calls _interrupt() -> synthetic 'end' -> illegal
+        // overview state transition -> stuck/hang.
+        GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
+            if (!inGesture && gestureEnabled()) {
+                swipeTrackersEnable(false);
+            }
+            return GLib.SOURCE_REMOVE;
+        });
     });
 
     /**
@@ -88,6 +105,7 @@ export function enable(extension) {
             natural = touchpadSettings.get_boolean("natural-scroll") ? 1 : -1;
             direction = undefined;
             handoffToOverview = false;
+            inGesture = true;
             navigator = Navigator.getNavigator();
             navigator.connect('destroy', () => {
                 vState = -1;
@@ -147,6 +165,7 @@ export function enable(extension) {
             return Clutter.EVENT_PROPAGATE;
         case Clutter.TouchpadGesturePhase.CANCEL:
         case Clutter.TouchpadGesturePhase.END:
+            inGesture = false;
             // If this finger count should be handled by GNOME, never consume
             // completion here (prevents overview from getting stuck in 4-finger mode).
             if (shouldPropagate(fingers)) {

--- a/patches.js
+++ b/patches.js
@@ -16,7 +16,7 @@ import * as WindowManager from 'resource:///org/gnome/shell/ui/windowManager.js'
 import * as WindowPreview from 'resource:///org/gnome/shell/ui/windowPreview.js';
 import * as Screenshot from 'resource:///org/gnome/shell/ui/screenshot.js';
 
-import { Utils, Tiling, Scratch, Settings, OverviewLayout } from './imports.js';
+import { Utils, Tiling, Scratch, Settings, OverviewLayout, Gestures } from './imports.js';
 
 /**
   Some of Gnome Shell's default behavior is really sub-optimal when using
@@ -153,6 +153,13 @@ export function setupOverrides() {
             const reset = () => {
                 // gnome windows switch animation time = 250, do that plus a little more
                 pillSwipeTimer = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 300, () => {
+                    // Don't disable mid-gesture: on GNOME 50 disabling a
+                    // SCROLLING tracker fires _interrupt() -> synthetic 'end'
+                    // -> illegal overview transition -> hang.
+                    if (Gestures.isInGesture?.()) {
+                        pillSwipeTimer = null;
+                        return false;
+                    }
                     swipeTrackers.forEach(t => {
                         t.enabled = false;
                     });


### PR DESCRIPTION
## Summary

Fixes the overview hang / shell freeze that happens when a 3-finger up-to-overview gesture immediately follows another 3-finger gesture on GNOME 49/50.

Fixes #1165

## Root cause

GNOME 49 rewrote `SwipeTracker`. Its `enabled` setter now interrupts an in-progress gesture instead of just flipping a flag:

```js
set enabled(enabled) {
    ...
    if (!enabled && this._state === State.SCROLLING)
        this._interrupt();   // emits a synthetic 'end' with cancelProgress
    ...
}
```

So calling `swipeTrackersEnable(false)` **while the overview tracker is mid-gesture** emits a synthetic `end`, which pushes the overview into an illegal state transition:

```
JS ERROR: Error: Invalid overview shown transition from HIDDEN to HIDING
```

The overview animation then never completes and the shell wedges (pressing Super afterwards freezes it).

PaperWM disables trackers from a few spots that can run while an overview hand-off gesture is live. The `Main.overview 'hidden'` handler fires during the hand-off on every up-swipe; the `pillSwipeTimer` (300 ms) can land inside the next gesture.

## Fix

Never disable a tracker while a PaperWM gesture is in progress:

- **gestures.js** — add an `inGesture` flag (set at `BEGIN`, cleared at `END`/`CANCEL`) and an `isInGesture()` accessor. Defer the `overview 'hidden'` tracker-disable to idle and skip it when `inGesture` is still set, so the in-flight overview animation settles (tracker → `State.NONE`) before anything disables it.
- **patches.js** — the `pillSwipeTimer` skips disabling trackers when `Gestures.isInGesture()` is true.

Follow-finger overview hand-off is unchanged.

## Testing

- GNOME Shell 50.2 (Wayland), PaperWM 50.0.1.
- Before: horizontal scroll → immediate up-swipe reliably hung the overview and logged `Invalid overview shown transition …`; Super then froze the shell.
- After: repeated reproductions show **zero** `Invalid overview …` errors and no hang. Verified via `journalctl --user`.
