### PR TITLE
fix: reposition transient/popup windows into visible area on focus and demands-attention

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -2218,6 +2218,11 @@ export const Spaces = class Spaces extends Map {
         this.signals.connect(display, 'grab-op-begin', (display, mw, type) => grabBegin(mw, type));
         this.signals.connect(display, 'grab-op-end', (display, mw, type) => grabEnd(mw, type));
 
+        this.signals.connect(display, 'window-demands-attention',
+            (display, metaWindow) => {
+                if (isTransient(metaWindow))
+                    repositionTransient(metaWindow);
+            });
 
         this.signals.connect(global.window_manager, 'switch-workspace',
             (wm, from, to, _direction) => this.switchWorkspace(wm, from, to));
@@ -3371,6 +3376,29 @@ export function isTransient(metaWindow) {
     else {
         return false;
     }
+}
+
+// Reposition a transient/popup window into its monitor's work area so it's visible.
+// Transients are real MetaWindows rejected by add_filter so the scroll machinery
+// can't reach them — we clamp their frame rect directly via move_frame.
+function repositionTransient(metaWindow) {
+    if (!metaWindow || !metaWindow.get_compositor_private())
+        return;
+
+    let frame = metaWindow.get_frame_rect();
+    let monitorIndex = metaWindow.get_monitor();
+    let workArea = Main.layoutManager.getWorkAreaForMonitor(monitorIndex);
+
+    if (!workArea)
+        return;
+
+    let x = Math.max(workArea.x,
+        Math.min(frame.x, workArea.x + workArea.width - frame.width));
+    let y = Math.max(workArea.y,
+        Math.min(frame.y, workArea.y + workArea.height - frame.height));
+
+    if (x !== frame.x || y !== frame.y)
+        metaWindow.move_frame(true, x, y);
 }
 
 /**
@@ -4603,8 +4631,9 @@ export function focus_handler(metaWindow) {
         return;
     }
 
-    // If metaWindow is a transient window, return (after deselecting tiled focus indicators)
+    // If metaWindow is a transient window, reposition into view and return
     if (isTransient(metaWindow)) {
+        repositionTransient(metaWindow);
         setAllWorkspacesInactive();
         return;
     }


### PR DESCRIPTION
## What
Transient/popup windows (dialogs, modals, notifications) are real MetaWindows rejected by `add_filter`, so they're never in the scrollable clone container and the existing `ensureViewport`/scroll machinery can't reach them. Two paths were broken:

1. **Popup gets focus**: `focus_handler` early-returned for transients without repositioning them, leaving them clamped at the monitor edge.
2. **Popup demands attention** (focus denied): no `window-demands-attention` handler existed, so background-spawned popups stayed invisible.

Fix adds a `repositionTransient` helper that clamps the window's frame rect to its monitor's work area via `move_frame`, then calls it on both paths:
- From `focus_handler` before the early return for transients
- From a new `window-demands-attention` signal handler that repositions attention-demanding popups without stealing focus

## Why
This change resolves the target issue or improvement.

## How to test
Verify that the project builds/runs correctly and the specific bug/improvement is addressed.

Fixes #1174