### PR TITLE
Destroy background to prevent fd leak

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -2234,6 +2234,8 @@ border-radius: ${borderWidth}px;
         this._pendingBackground = null;
         this._bgTransitionOldBackground?.destroy();
         this._bgTransitionOldBackground = null;
+        this.metaBackground?.destroy();
+        this.metaBackground = null;
         this.background.destroy();
         this.background = null;
         this.cloneContainer.destroy();


### PR DESCRIPTION
This fixes #1176 by properly closing the `MetaBackground` and its associated handle on the wallpaper file.
