### PR TITLE
Fix #1000: Mouseover on Second Monitor Does Not Change Focus to Second 

### DIFF
--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -100,8 +100,9 @@ export function enableMultimonitorSupport() {
                 return;
             }
 
-            const selected = space?.selectedWindow;
-            space?.activateWithFocus(selected, false, false);
+            // Let Mutter establish focus when switching from a pointer poll.
+            // Forcing PaperWM's selected window here can leave input focus stale.
+            space?.activate(false, false);
         });
     console.debug('paperwm multimonitor support is ENABLED');
 }


### PR DESCRIPTION
Fixes #1000

## Implementation summary

Updated pointer-driven monitor switching to use ordinary space activation, allowing Mutter to synchronize focus correctly. Only `stackoverlay.js` changed

## Changes

```
stackoverlay.js | 5 +++--
 1 file changed, 3 insertions(+), 2 deletions(-)
```

## Testing

Yes. Relevant repository checks passed.