### PR TITLE
stackoverlay: switch ClickOverlay to using destroy for cleaning up StackOverlay

### DIFF
--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -326,6 +326,7 @@ export class StackOverlay {
                         if (this._pointerIsAtEdge()) {
                             this._activateTarget();
                         }
+                        this.activatePreviewTimeout = null;
                     });
             }
 

--- a/stackoverlay.js
+++ b/stackoverlay.js
@@ -152,16 +152,10 @@ export class ClickOverlay {
     }
 
     destroy() {
-        for (let overlay of [this.left, this.right]) {
-            let actor = overlay.overlay;
-            overlay.signals.destroy();
-            overlay.signals = null;
-            if (overlay.clone) {
-                overlay.clone.destroy();
-                overlay.clone = null;
-            }
-            actor.destroy();
-        }
+        this.left.destroy();
+        this.left = null;
+        this.right.destroy();
+        this.right = null;
     }
 }
 


### PR DESCRIPTION
`ClickOverlay` was using its own version of destroy for `StackOverlay`, which misses a few resources allocated by the latter.

Switch to `StackOverlay.destroy` to simplify the code and avoid resource leaks. 