### PR TITLE
Preserve scratch and tiling state across extension reloads

### DIFF
--- a/scratch.js
+++ b/scratch.js
@@ -59,7 +59,13 @@ export function easeScratch(metaWindow, targetX, targetY, params = {}) {
     });
 }
 
-export function makeScratch(metaWindow) {
+export function makeScratch(metaWindow, { preserveTiling = false } = {}) {
+    // Internal refreshes keep temporary scratch intent; an explicit choice
+    // supersedes any deferred return to tiling.
+    if (!preserveTiling) {
+        delete metaWindow._tiled_on_minimize;
+        delete metaWindow._pendingScratchRestore;
+    }
     let fromNonScratch = !metaWindow[float];
     let fromTiling = false;
     // Relevant when called while navigating. Use the position the user actually sees.
@@ -135,6 +141,8 @@ export function makeScratch(metaWindow) {
 }
 
 export function unmakeScratch(metaWindow) {
+    delete metaWindow._tiled_on_minimize;
+    delete metaWindow._pendingScratchRestore;
     if (!metaWindow[scratchFrame])
         metaWindow[scratchFrame] = metaWindow.get_frame_rect();
     metaWindow[float] = false;

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,27 @@
+# Scratch lifecycle regression tests
+
+Run `tests/run-scratch-tests` with Node.js 20 or newer. The runner enables Node's
+experimental VM module API; no package installation is required. To test another
+source checkout, set `PAPERWM_SOURCE_DIR` to its absolute path.
+
+The suite evaluates the complete production `tiling.js` and `scratch.js`
+modules with explicit GNOME import mocks. Test-only exports expose SaveState and
+inject a mocked Spaces collection. It calls the real SaveState.prepare, flag
+cleanup, scratch enable/disable, Space.addAll, minimizeHandler, and insertWindow
+winprop branch. It does not instantiate a GNOME desktop or run the complete
+extension enable/disable chain.
+
+Coverage includes visible and minimized tiles, deliberate scratch windows,
+first-enable heuristics, scratch winprops, destroyed windows, repeated
+population, and restoration callbacks crossing lifecycle boundaries. Explicit
+scratch choices cancel pending restoration; internal refreshes retain it.
+
+`native/scratch-lifecycle.js` is a GNOME Shell automation module. Run it only in
+an isolated GNOME test session with PaperWM installed and enabled, using Shell's
+`--automation-script` option. It creates four windows, enters and exits actual
+fullscreen across an extension reload, then tests immediate restore followed by
+disable and three cycles of visible/minimized tiled and scratch windows. It
+exports assertion-backed metrics for the automation runner and destroys its
+test windows on success. This test calls the extension manager's disable/enable
+methods; it does not simulate a lock screen, physical display power cycle, or
+application-specific behavior. Do not run it in your active desktop session.

--- a/tests/native/scratch-lifecycle.js
+++ b/tests/native/scratch-lifecycle.js
@@ -1,0 +1,103 @@
+/* eslint-disable no-await-in-loop -- Lifecycle stages must execute sequentially. */
+import Meta from 'gi://Meta';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as Scripting from 'resource:///org/gnome/shell/ui/scripting.js';
+import { ExtensionState } from 'resource:///org/gnome/shell/misc/extensionUtils.js';
+
+const UUID = 'paperwm@paperwm.github.com';
+export const METRICS = {
+    fullscreen: { description: 'Fullscreen tile survives extension reload and exit from fullscreen', units: 'checks', value: 0 },
+    pendingRestore: { description: 'Restore immediately before disable remains tiled', units: 'checks', value: 0 },
+    cycles: { description: 'Verified scratch-preserving lifecycle cycles', units: 'cycles', value: 0 },
+};
+function assert(value, message) {
+    if (!value)
+        throw new Error(message);
+}
+async function settle() {
+    await Scripting.waitLeisure();
+    await Scripting.sleep(400);
+}
+export async function run() {
+    await settle();
+    const extension = Main.extensionManager.lookup(UUID);
+    assert(extension?.state === ExtensionState.ACTIVE, 'PaperWM not active');
+    const { Scratch, Tiling } = await import(`file://${extension.path}/imports.js`);
+    for (let i = 0; i < 4; i++)
+        await Scripting.createTestWindow({ width: 300 + i * 20, height: 250 });
+    await Scripting.waitTestWindows();
+    await settle();
+    const windows = global.display.get_tab_list(Meta.TabList.NORMAL_ALL, null);
+    assert(windows.length === 4, `Expected 4 windows, got ${windows.length}`);
+    const [tiled, minimizedTiled, scratch, minimizedScratch] = windows;
+    Scratch.makeScratch(scratch);
+    Scratch.makeScratch(minimizedScratch);
+    await settle();
+    tiled.make_fullscreen();
+    await settle();
+    assert(tiled.fullscreen && tiled.is_above(), 'Precondition: fullscreen tile must be above');
+    await Main.extensionManager._callExtensionDisable(UUID);
+    await settle();
+    await Main.extensionManager._callExtensionEnable(UUID);
+    await settle();
+    assert(extension.state === ExtensionState.ACTIVE, 'PaperWM failed to re-enable with fullscreen tile');
+    assert(tiled.fullscreen, 'Reload unexpectedly exited fullscreen');
+    assert(Tiling.spaces.spaceOfWindow(tiled).indexOf(tiled) >= 0 &&
+        !Scratch.isScratchWindow(tiled), 'Fullscreen tile became scratch across reload');
+    tiled.unmake_fullscreen();
+    await settle();
+    assert(Tiling.spaces.spaceOfWindow(tiled).indexOf(tiled) >= 0 &&
+        !Scratch.isScratchWindow(tiled) && !tiled.is_on_all_workspaces(),
+    'Exiting fullscreen failed to preserve tiling');
+    METRICS.fullscreen.value++;
+    console.log('SCRATCH_NATIVE fullscreen passed');
+    // Do not settle between unminimize and disable: its deferred restoration
+    // must survive a lifecycle boundary before the compositor idle callback.
+    minimizedTiled.minimize();
+    await settle();
+    minimizedTiled.unminimize();
+    await Main.extensionManager._callExtensionDisable(UUID);
+    await settle();
+    await Main.extensionManager._callExtensionEnable(UUID);
+    await settle();
+    assert(extension.state === ExtensionState.ACTIVE, 'PaperWM failed to re-enable after pending restore');
+    assert(Tiling.spaces.spaceOfWindow(minimizedTiled).indexOf(minimizedTiled) >= 0 &&
+        !Scratch.isScratchWindow(minimizedTiled), 'Pending restore became explicit scratch across reload');
+    assert(!minimizedTiled.is_above() && !minimizedTiled.is_on_all_workspaces(),
+        'Pending restore retained scratch above/sticky state');
+    console.log('SCRATCH_NATIVE pending-restore passed');
+    METRICS.pendingRestore.value++;
+    for (let cycle = 0; cycle < 3; cycle++) {
+        minimizedTiled.minimize();
+        minimizedScratch.minimize();
+        await settle();
+        assert(minimizedTiled._tiled_on_minimize === true, 'Precondition: tiled restoration marker absent');
+        await Main.extensionManager._callExtensionDisable(UUID);
+        await settle();
+        await Main.extensionManager._callExtensionEnable(UUID);
+        await settle();
+        assert(extension.state === ExtensionState.ACTIVE, 'PaperWM failed to re-enable');
+        assert(minimizedTiled.minimized, 'Reload unexpectedly unminimized a tiled window');
+        assert(minimizedScratch.minimized, 'Reload unexpectedly unminimized explicit scratch');
+        minimizedTiled.unminimize();
+        minimizedScratch.unminimize();
+        await settle();
+        const actualTiled = w => Tiling.spaces.spaceOfWindow(w).indexOf(w) >= 0;
+        const states = windows.map(w => ({
+            scratch: Boolean(Scratch.isScratchWindow(w)),
+            tiled: actualTiled(w), sticky: w.is_on_all_workspaces(), above: w.is_above(), minimized: w.minimized,
+        }));
+        console.log(`SCRATCH_NATIVE cycle=${cycle + 1} ${JSON.stringify(states)}`);
+        assert(actualTiled(tiled) && !Scratch.isScratchWindow(tiled), 'Visible tiled window lost tiling');
+        assert(actualTiled(minimizedTiled) && !Scratch.isScratchWindow(minimizedTiled),
+            'Minimized tiled window remained scratch after reload/restore');
+        assert(Scratch.isScratchWindow(scratch) && !actualTiled(scratch), 'Explicit visible scratch lost intent');
+        assert(Scratch.isScratchWindow(minimizedScratch) && !actualTiled(minimizedScratch),
+            'Explicit minimized scratch lost intent');
+        assert(!extension.errors?.length, `Extension errors: ${extension.errors}`);
+        METRICS.cycles.value++;
+    }
+    await Scripting.destroyTestWindows();
+    await settle();
+    assert(global.display.get_tab_list(Meta.TabList.NORMAL_ALL, null).length === 0, 'Window cleanup failed');
+}

--- a/tests/run-scratch-tests
+++ b/tests/run-scratch-tests
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd -- "$(dirname -- "$0")/.."
+node --experimental-vm-modules --test tests/unit/scratch-lifecycle.test.mjs

--- a/tests/unit/gnome-module-harness.mjs
+++ b/tests/unit/gnome-module-harness.mjs
@@ -1,0 +1,42 @@
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+import { pathToFileURL } from 'node:url';
+
+function syntheticModule(context, identifier, exports) {
+    const names = Object.keys(exports);
+    return new vm.SyntheticModule(names, function initialise() {
+        for (const [name, value] of Object.entries(exports))
+            this.setExport(name, value);
+    }, { context, identifier });
+}
+
+export async function loadGnomeModule(filePath, mocks, globals = {}, testExports = '') {
+    const context = vm.createContext({
+        console,
+        ...globals,
+    });
+    const source = await fs.readFile(filePath, 'utf8') + testExports;
+    const identifier = pathToFileURL(filePath).href;
+    const module = new vm.SourceTextModule(source, {
+        context,
+        identifier,
+    });
+    const dependencies = new Map();
+
+    await module.link(specifier => {
+        if (!Object.hasOwn(mocks, specifier))
+            throw new Error(`Missing mock module: ${specifier}`);
+
+        if (!dependencies.has(specifier)) {
+            dependencies.set(specifier, syntheticModule(
+                context,
+                `${identifier}#mock:${specifier}`,
+                mocks[specifier]
+            ));
+        }
+        return dependencies.get(specifier);
+    });
+
+    await module.evaluate();
+    return module.namespace;
+}

--- a/tests/unit/scratch-lifecycle.test.mjs
+++ b/tests/unit/scratch-lifecycle.test.mjs
@@ -1,0 +1,379 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadGnomeModule } from './gnome-module-harness.mjs';
+
+const sourceRoot = process.env.PAPERWM_SOURCE_DIR ?? resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+
+async function harness() {
+    let scratch;
+    let space;
+    const windows = [];
+    const later = [];
+    const Meta = { TabList: { NORMAL: 0, NORMAL_ALL: 1 }, WindowType: { NORMAL: 0 }, LaterType: { IDLE: 0 } };
+    const display = {
+        get_tab_list: () => windows.filter(w => w.alive),
+        sort_windows_by_stacking: ws => ws,
+    };
+    const Settings = { prefs: {}, find_winprop: w => w.winprop, winprops: [] };
+    const Utils = { later_add: (_type, fn) => later.push(fn), monitorOfPoint() {} };
+    const Scratch = Object.fromEntries(['isScratchWindow', 'makeScratch', 'unmakeScratch'].map(name => [name, (...args) => scratch[name](...args)]));
+    const dependencies = {
+        'resource:///org/gnome/shell/ui/main.js': {},
+        './imports.js': { Settings, Utils, Lib: {}, Gestures: {}, Navigator: {}, Grab: {}, Topbar: {}, Scratch, Stackoverlay: {}, Background: {} },
+        './utils.js': { Easer: {}, DispatcherMode: {} },
+        './stackoverlay.js': { ClickOverlay: class {} },
+        './workspace.js': { WorkspaceSettings: class {} },
+    };
+    for (const name of ['Clutter', 'GDesktopEnums', 'Gio', 'GLib', 'Graphene', 'St'])
+        dependencies[`gi://${name}`] = { default: {} };
+    dependencies['gi://Meta'] = { default: Meta };
+    const tiling = await loadGnomeModule(resolve(sourceRoot, 'tiling.js'), dependencies, {
+        global: { display, workspace_manager: {} },
+        imports: { signals: { addSignalMethods() {} } },
+        console: { debug() {}, info() {} },
+    }, `\nexport function setupTestState(testSpaces) { spaces = testSpaces; saveState ??= new SaveState(); signals = { connectOneShot() {} }; }
+export function prepareTestState() { saveState.prepare(); }
+export function previousTestSpace(workspace) { return saveState.prevSpaces.get(workspace); }
+export function finishTestPopulation(workspace) { saveState.prevSpaces.delete(workspace); }
+`);
+    scratch = await loadGnomeModule(resolve(sourceRoot, 'scratch.js'), {
+        'gi://Meta': { default: Meta },
+        'gi://Mtk': { default: { Rectangle: class { constructor(props) { Object.assign(this, props); } } } },
+        'resource:///org/gnome/shell/ui/main.js': { activateWindow() {} },
+        'resource:///org/gnome/shell/ui/popupMenu.js': {},
+        'resource:///org/gnome/shell/ui/windowMenu.js': { WindowMenu: class { _buildMenu() {} } },
+        './imports.js': {
+            Settings, Utils, Topbar: {},
+            Tiling: { spaces: { spaceOfWindow: () => space }, showWindow() {}, focusMonitor() {} },
+        },
+        './utils.js': { Easer: { addEase: (_actor, params) => params.onComplete() } },
+    }, { global: { display }, _: x => x });
+    const workspace = { list_windows: () => windows.filter(w => w.alive) };
+    function newSpace() {
+        space = [];
+        Object.assign(space, {
+            workspace, uuid: 'test', width: 1200, targetX: 0,
+            getWindows() { return this.flat(); },
+            indexOf(w) { return this.findIndex(column => column.includes(w)); },
+            addWindow(w, i, j = 0) {
+                if (this.indexOf(w) >= 0)
+                    return;
+                if (!this[i])
+                    this[i] = [];
+                this[i].splice(j, 0, w);
+            },
+            removeWindow(w) {
+                for (const column of this) {
+                    const i = column.indexOf(w);
+                    if (i >= 0)
+                        column.splice(i, 1);
+                }
+                for (let i = this.length - 1; i >= 0; i--)
+                    if (!this[i].length)
+                        this.splice(i, 1);
+            },
+        });
+        const spaces = new Map([[workspace, space]]);
+        spaces.spaceOfWindow = () => space;
+        spaces.selectedSpace = space;
+        tiling.setupTestState(spaces);
+    }
+    function window(props = {}) {
+        const actor = {
+            connect() {
+                return 1; }, disconnect() {},
+        };
+        const w = {
+            alive: true, minimized: false, above: false, sticky: false, window_type: 0,
+            clone: { get_transformed_position: () => [10, 20] },
+            get_compositor_private() { return this.alive ? actor : null; },
+            get_transient_for: () => null,
+            get_workspace: () => workspace,
+            get_frame_rect: () => ({ x: 10, y: 20, width: 300, height: 400 }),
+            get_buffer_rect: () => ({ x: 10, y: 20, width: 300, height: 400 }),
+            is_on_all_workspaces() { return this.sticky; },
+            make_above() { this.above = true; }, unmake_above() {
+                this.above = false; },
+            stick() { this.sticky = true;
+                space.removeWindow(this); },
+            unstick() { this.sticky = false;
+                if (this.alive && !this.minimized)
+                    space.addWindow(this, space.length); },
+            lower() {}, move_resize_frame() {}, move_frame() {},
+            ...props,
+        };
+        windows.push(w);
+        return w;
+    }
+    function populate() {
+        tiling.Space.prototype.addAll.call(space, tiling.previousTestSpace(workspace));
+        tiling.finishTestPopulation(workspace);
+    }
+    function disable() {
+        tiling.prepareTestState();
+        for (const w of windows)
+            tiling.removePaperWMFlags(w);
+        scratch.disable();
+    }
+    function enable() {
+        newSpace();
+        scratch.enable();
+        // Actual Spaces.init clears flags before Space.addAll on every enable.
+        for (const w of windows)
+            tiling.removePaperWMFlags(w);
+        populate();
+    }
+    function flush() {
+        while (later.length)
+            later.shift()(); }
+    function minimize(w) {
+        w.minimized = true;
+        tiling.minimizeHandler(w);
+        flush(); }
+    function restore(w) {
+        w.minimized = false;
+        tiling.minimizeHandler(w);
+        flush(); }
+    newSpace();
+    scratch.enable();
+    return {
+        window, populate, disable, enable, minimize, restore, scratch, tiling,
+        isTiled: w => space.indexOf(w) >= 0,
+        getSpace: () => space, flush,
+        flushOne: () => later.shift()(),
+    };
+}
+
+test('ordinary minimized tile returns to tiling after repeated disable/enable cycles', async () => {
+    const h = await harness();
+    const w = h.window();
+    h.populate();
+    h.minimize(w);
+    for (let i = 0; i < 3; i++) {
+        h.disable();
+        h.enable();
+        assert.equal(w._tiled_on_minimize, true);
+        assert.equal(Boolean(h.scratch.isScratchWindow(w)), true);
+        assert.equal(h.isTiled(w), false);
+    }
+    h.restore(w);
+    assert.equal(h.isTiled(w), true);
+    assert.equal(Boolean(h.scratch.isScratchWindow(w)), false);
+    assert.equal(w.sticky, false);
+    assert.equal(w.above, false);
+});
+
+for (const minimized of [false, true]) {
+    test(`explicit scratch preserves intent when minimized=${minimized}, even if above was cleared`, async () => {
+        const h = await harness();
+        const w = h.window();
+        h.populate();
+        h.scratch.makeScratch(w);
+        if (minimized)
+            h.minimize(w);
+        w.above = false;
+        h.disable();
+        h.enable();
+        assert.equal(Boolean(h.scratch.isScratchWindow(w)), true);
+        assert.equal(w._tiled_on_minimize, undefined);
+        if (minimized)
+            h.restore(w);
+        assert.equal(h.isTiled(w), false);
+        assert.equal(Boolean(h.scratch.isScratchWindow(w)), true);
+    });
+}
+
+test('temporary scratch restored while disabled returns directly to tiling', async () => {
+    const h = await harness();
+    const w = h.window();
+    h.populate();
+    h.minimize(w);
+    h.disable();
+    w.minimized = false;
+    h.enable();
+    assert.equal(h.isTiled(w), true);
+    assert.equal(Boolean(h.scratch.isScratchWindow(w)), false);
+    assert.equal(w.sticky, false);
+});
+
+test('ordinary tile minimized while disabled restores to tiling', async () => {
+    const h = await harness();
+    const w = h.window();
+    h.populate();
+    h.disable();
+    w.minimized = true;
+    h.enable();
+    assert.equal(h.isTiled(w), false);
+    h.restore(w);
+    assert.equal(h.isTiled(w), true);
+    assert.equal(Boolean(h.scratch.isScratchWindow(w)), false);
+});
+
+test('ordinary window already minimized at first enable is temporary scratch', async () => {
+    const h = await harness();
+    const w = h.window({ minimized: true });
+    h.populate();
+    h.restore(w);
+    assert.equal(h.isTiled(w), true);
+    assert.equal(Boolean(h.scratch.isScratchWindow(w)), false);
+});
+
+test('above heuristic still preserves pre-existing floating windows on first enable', async () => {
+    const h = await harness();
+    const w = h.window({ above: true, minimized: true });
+    h.populate();
+    h.restore(w);
+    assert.equal(h.isTiled(w), false);
+    assert.equal(Boolean(h.scratch.isScratchWindow(w)), true);
+});
+
+test('visible tile stays tiled when temporarily above (e.g. fullscreen)', async () => {
+    const h = await harness();
+    const w = h.window();
+    h.populate();
+    w.above = true;
+    h.disable();
+    h.enable();
+    assert.equal(h.isTiled(w), true);
+    assert.equal(Boolean(h.scratch.isScratchWindow(w)), false);
+    assert.equal(w.above, true);
+});
+
+test('closed windows are pruned without restoring scratch or retained tiling entries', async () => {
+    const h = await harness();
+    const tiled = h.window();
+    const scratched = h.window();
+    h.populate();
+    h.scratch.makeScratch(scratched);
+    h.disable();
+    tiled.alive = false;
+    scratched.alive = false;
+    h.enable();
+    assert.equal(h.getSpace().length, 0);
+    assert.equal(Boolean(h.scratch.isScratchWindow(scratched)), false);
+});
+
+test('explicit scratch chosen after a completed minimize/restore survives another cycle', async () => {
+    const h = await harness();
+    const w = h.window();
+    h.populate();
+    h.minimize(w);
+    h.restore(w);
+    h.scratch.makeScratch(w);
+    h.minimize(w);
+    h.disable();
+    h.enable();
+    h.restore(w);
+    assert.equal(Boolean(h.scratch.isScratchWindow(w)), true);
+    assert.equal(h.isTiled(w), false);
+});
+
+// Exercise the real insertWindow winprop branch, with clone sizing already hooked up.
+test('scratch_layer winprop still creates persistent explicit scratch', async () => {
+    const h = await harness();
+    const w = h.window({ winprop: { scratch_layer: true }, _resizeHandlerAdded: true, _positionHandlerAdded: true });
+    h.tiling.insertWindow(w);
+    assert.equal(Boolean(h.scratch.isScratchWindow(w)), true);
+    h.minimize(w);
+    h.disable();
+    h.enable();
+    h.restore(w);
+    assert.equal(Boolean(h.scratch.isScratchWindow(w)), true);
+    assert.equal(h.isTiled(w), false);
+});
+
+test('saved tile intent is consumed before a later workspace population sees newly chosen scratch', async () => {
+    const h = await harness();
+    const w = h.window();
+    h.populate();
+    h.disable();
+    h.enable();
+    h.scratch.makeScratch(w);
+    h.minimize(w);
+    w.above = false;
+    h.populate();
+    assert.equal(w._tiled_on_minimize, undefined);
+    h.restore(w);
+    assert.equal(Boolean(h.scratch.isScratchWindow(w)), true);
+    assert.equal(h.isTiled(w), false);
+});
+
+for (const flushWhileDisabled of [true, false]) {
+    test(`pending restore survives disable/enable (idle while disabled=${flushWhileDisabled})`, async () => {
+        const h = await harness();
+        const w = h.window();
+        h.populate();
+        h.minimize(w);
+        w.minimized = false;
+        h.tiling.minimizeHandler(w);
+        h.disable();
+        if (flushWhileDisabled)
+            h.flush();
+        h.enable();
+        h.flush();
+        assert.equal(h.isTiled(w), true);
+        assert.equal(Boolean(h.scratch.isScratchWindow(w)), false);
+        assert.equal(w.sticky, false);
+        assert.equal(w.above, false);
+    });
+}
+
+test('explicit scratch choice cancels pending restore and survives reload', async () => {
+    const h = await harness();
+    const w = h.window();
+    h.populate();
+    h.minimize(w);
+    w.minimized = false;
+    h.tiling.minimizeHandler(w);
+    h.scratch.makeScratch(w);
+    h.flush();
+    assert.equal(h.isTiled(w), false);
+    assert.equal(Boolean(h.scratch.isScratchWindow(w)), true);
+    h.disable();
+    h.enable();
+    assert.equal(h.isTiled(w), false);
+    assert.equal(Boolean(h.scratch.isScratchWindow(w)), true);
+});
+
+test('restore callback does not touch a destroyed window', async () => {
+    const h = await harness();
+    const w = h.window();
+    h.populate();
+    h.minimize(w);
+    w.minimized = false;
+    h.tiling.minimizeHandler(w);
+    w.alive = false;
+    w.get_frame_rect = w.unmake_above = w.unstick = () => assert.fail('Destroyed window was accessed');
+    h.flush();
+});
+
+test('old restore callback cannot complete a newer minimize/restore transition', async () => {
+    const h = await harness();
+    const w = h.window();
+    h.populate();
+    h.minimize(w);
+    w.minimized = false;
+    h.tiling.minimizeHandler(w);
+    w.minimized = true;
+    h.tiling.minimizeHandler(w);
+    w.minimized = false;
+    h.tiling.minimizeHandler(w);
+    h.flushOne();
+    assert.equal(h.isTiled(w), false);
+    h.flush();
+    assert.equal(h.isTiled(w), true);
+    assert.equal(Boolean(h.scratch.isScratchWindow(w)), false);
+});
+
+test('repeated population preserves temporary scratch restoration', async () => {
+    const h = await harness();
+    const w = h.window();
+    h.populate();
+    h.minimize(w);
+    h.populate();
+    h.restore(w);
+    assert.equal(h.isTiled(w), true);
+    assert.equal(Boolean(h.scratch.isScratchWindow(w)), false);
+});

--- a/tiling.js
+++ b/tiling.js
@@ -2178,7 +2178,9 @@ border-radius: ${borderWidth}px;
                     let metaWindow = column[j];
                     // Prune removed windows
                     if (metaWindow.get_compositor_private()) {
-                        this.addWindow(metaWindow, i, j);
+                        // It may have been minimized while PaperWM was disabled.
+                        if (!metaWindow.minimized)
+                            this.addWindow(metaWindow, i, j);
                     } else {
                         // eslint-disable-next-line max-statements-per-line
                         column.splice(j, 1); j--;
@@ -2196,9 +2198,28 @@ border-radius: ${borderWidth}px;
             .sort(xz_comparator(workspace.list_windows()));
 
         windows.forEach((meta_window, _i) => {
-            if (meta_window.above || meta_window.minimized) {
-                // Rough heuristic to figure out if a window should float
-                Scratch.makeScratch(meta_window);
+            if (!meta_window.get_compositor_private())
+                return;
+
+            const previous = saveState.prevWindowStates.get(meta_window);
+            saveState.prevWindowStates.delete(meta_window);
+            if (previous?.tiled) {
+                // A temporarily scratched tile may have been restored while
+                // disabled. Remove its old above/sticky state before adding it.
+                if (previous.scratch && !meta_window.minimized)
+                    Scratch.unmakeScratch(meta_window);
+            } else if (previous?.scratch || Scratch.isScratchWindow(meta_window) || meta_window.above) {
+                // Preserve explicit scratch intent even if "above" was cleared.
+                // Keep the above heuristic for windows with no saved tiling intent.
+                Scratch.makeScratch(meta_window, { preserveTiling: true });
+                return;
+            }
+            if (meta_window.minimized) {
+                // Minimization alone is temporary scratch, not a user decision
+                // to float. Keep the normal restore handler's tiling intent.
+                if (previous?.tiled || add_filter(meta_window))
+                    meta_window._tiled_on_minimize = true;
+                Scratch.makeScratch(meta_window, { preserveTiling: true });
                 return;
             }
             if (this.indexOf(meta_window) < 0 && add_filter(meta_window)) {
@@ -3737,6 +3758,7 @@ export function removePaperWMFlags(w) {
     delete w._positionHandlerAdded;
     delete w._pos_mismatch_count;
     delete w._tiled_on_minimize;
+    delete w._pendingScratchRestore;
     delete w._fullscreen_frame;
     delete w._fullscreen_lock;
     delete w._fullscreen_above;
@@ -3922,6 +3944,7 @@ class SaveState {
         this.prevMonitors = new Map();
         this.prevSpaces = new Map();
         this.prevTargetX = new Map();
+        this.prevWindowStates = new WeakMap();
     }
 
     hasPrevMonitors() {
@@ -3976,6 +3999,17 @@ class SaveState {
      */
     prepare() {
         this.update();
+
+        // Snapshot before cleanup clears _tiled_on_minimize and Scratch.disable
+        // discards its membership symbol. Weak keys do not retain closed windows.
+        this.prevWindowStates = new WeakMap();
+        display.get_tab_list(Meta.TabList.NORMAL_ALL, null).forEach(w => {
+            this.prevWindowStates.set(w, {
+                scratch: Boolean(Scratch.isScratchWindow(w)),
+                tiled: Boolean(w._tiled_on_minimize) || isTiled(w),
+            });
+        });
+
         this.prevSpaces.forEach(space => {
             let windows = space.getWindows();
             let selected = windows.indexOf(space.selectedWindow);
@@ -4687,7 +4721,7 @@ export function focus_handler(metaWindow) {
     console.debug("focus:", metaWindow?.title);
     if (Scratch.isScratchWindow(metaWindow)) {
         setAllWorkspacesInactive();
-        Scratch.makeScratch(metaWindow);
+        Scratch.makeScratch(metaWindow, { preserveTiling: true });
         Topbar.fixTopBar();
         return;
     }
@@ -4809,18 +4843,28 @@ export function focus_handler(metaWindow) {
 export function minimizeHandler(metaWindow) {
     if (metaWindow.minimized) {
         console.debug('minimized', metaWindow?.title);
+        delete metaWindow._pendingScratchRestore;
         // check if was tiled
         if (isTiled(metaWindow)) {
             metaWindow._tiled_on_minimize = true;
         }
-        Scratch.makeScratch(metaWindow);
+        Scratch.makeScratch(metaWindow, { preserveTiling: true });
     }
     else {
         console.debug('unminimized', metaWindow?.title);
         if (metaWindow._tiled_on_minimize) {
-            delete metaWindow._tiled_on_minimize;
+            // Keep tiling intent until restoration completes, so disable can
+            // snapshot it even if it runs before this compositor idle callback.
+            const restore = {};
+            metaWindow._pendingScratchRestore = restore;
             Utils.later_add(Meta.LaterType.IDLE, () => {
-                Scratch.unmakeScratch(metaWindow);
+                // Cleanup, re-minimization, or an explicit scratch choice may
+                // supersede this callback before it runs.
+                if (metaWindow._pendingScratchRestore !== restore)
+                    return;
+                delete metaWindow._pendingScratchRestore;
+                if (metaWindow.get_compositor_private() && !metaWindow.minimized)
+                    Scratch.unmakeScratch(metaWindow);
             });
         }
     }


### PR DESCRIPTION
PaperWM currently rebuilds scratch membership from `above`/`minimized` when it is re-enabled. That can move a previously tiled window into scratch after locking and unlocking, and a minimized tile can lose the marker that would return it to tiling when restored.

Preserve per-window scratch/tiling intent in `SaveState` before teardown and consume it when rebuilding each workspace. Keep pending minimize-restoration intent until its idle callback completes, and invalidate stale callbacks on cleanup, re-minimize, or an explicit scratch choice. Deliberately scratched windows retain that choice, including when minimized. Session modes and screen-lock behavior are unchanged.

Fixes #951. This follows [lost-melody's lifecycle diagnosis](https://github.com/paperwm/PaperWM/issues/951#issuecomment-2581757579) and [wisdom-in-snow's suggestion to use SaveState](https://github.com/paperwm/PaperWM/issues/951#issuecomment-2789499226).

Validation:

- `tests/run-scratch-tests`: 18 passing tests; 9 fail against unmodified upstream. The suite loads the complete production modules with explicit GNOME mocks.
- Native GNOME 46 automation: an actual fullscreen tile survives disable/enable and exit from fullscreen; immediate restoration before disable succeeds; three additional cycles preserve visible/minimized tiles and deliberate scratch windows.
- The same runtime change backported to GNOME 49 has positive desktop-user feedback after a fresh login.
- New tests pass the repository's ESLint configuration; the runtime files introduce no diagnostics beyond the seven already present in upstream.

Native automation exercises the extension lifecycle in an isolated session. It does not simulate physical display power-off or Telegram itself. Test setup and coverage are documented in `tests/README.md`.
